### PR TITLE
feat: e2e dispute resolution — SDK extraction + arbiter event lookup

### DIFF
--- a/examples/arbiter-cli/src/index.ts
+++ b/examples/arbiter-cli/src/index.ts
@@ -23,8 +23,8 @@ import { config as dotenvConfig } from 'dotenv';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { X402rArbiter } from '@x402r/arbiter';
-import { getNetworkConfig, RequestStatus, type PaymentInfo } from '@x402r/core';
-import { parsePaymentInfo, shortAddress, formatUSDC } from '../../shared/utils.js';
+import { getNetworkConfig, RequestStatus, parsePaymentInfo, type PaymentInfo } from '@x402r/core';
+import { shortAddress, formatUSDC } from '../../shared/utils.js';
 
 // Load environment from the example directory
 const __filename = fileURLToPath(import.meta.url);
@@ -198,25 +198,50 @@ program
     }
   });
 
+/**
+ * Resolve PaymentInfo and nonce for a command — either from --payment-json or via event lookup
+ */
+async function resolvePaymentInfo(
+  arbiter: InstanceType<typeof X402rArbiter>,
+  key: string,
+  options: { paymentJson?: string; nonce?: string }
+): Promise<{ paymentInfo: PaymentInfo; nonce: bigint }> {
+  if (options.paymentJson) {
+    return {
+      paymentInfo: parsePaymentInfo(options.paymentJson),
+      nonce: BigInt(options.nonce ?? '0'),
+    };
+  }
+
+  // Auto-lookup from events
+  console.log('  Looking up PaymentInfo from events...');
+  const result = await arbiter.getPaymentInfoFromEvents(key as `0x${string}`);
+  if (!result) {
+    console.error('\nError: Could not find PaymentInfo in event logs for this key.');
+    console.error('Provide --payment-json explicitly, or ensure the RefundRequested event is accessible.');
+    process.exit(1);
+  }
+  console.log('  Found PaymentInfo from events');
+  return result;
+}
+
 // Approve a refund request by key
 program
   .command('approve <key>')
-  .description('Approve a refund request (requires payment JSON)')
-  .requiredOption('-p, --payment-json <json>', 'Payment info JSON')
+  .description('Approve a refund request (auto-resolves PaymentInfo from events if --payment-json omitted)')
+  .option('-p, --payment-json <json>', 'Payment info JSON (optional — looked up from events if omitted)')
   .option('-n, --nonce <nonce>', 'Nonce (record index)', '0')
   .action(async (key: string, options) => {
     const { arbiter } = createArbiter();
-    const paymentInfo = parsePaymentInfo(options.paymentJson);
-    const nonce = BigInt(options.nonce);
 
-    // The key parameter is for display/audit trail only.
-    // The actual on-chain operation uses paymentInfo + nonce to identify the request.
     console.log('\nApproving refund request...');
     console.log('  Key:', key);
-    console.log('  Payer:', paymentInfo.payer);
-    console.log('  Nonce:', nonce.toString());
 
     try {
+      const { paymentInfo, nonce } = await resolvePaymentInfo(arbiter, key, options);
+      console.log('  Payer:', paymentInfo.payer);
+      console.log('  Nonce:', nonce.toString());
+
       const result = await arbiter.approveRefundRequest(paymentInfo, nonce);
       console.log('\n✅ Refund request approved!');
       console.log('  Transaction:', result.txHash);
@@ -230,22 +255,20 @@ program
 // Deny a refund request by key
 program
   .command('deny <key>')
-  .description('Deny a refund request (requires payment JSON)')
-  .requiredOption('-p, --payment-json <json>', 'Payment info JSON')
+  .description('Deny a refund request (auto-resolves PaymentInfo from events if --payment-json omitted)')
+  .option('-p, --payment-json <json>', 'Payment info JSON (optional — looked up from events if omitted)')
   .option('-n, --nonce <nonce>', 'Nonce (record index)', '0')
   .action(async (key: string, options) => {
     const { arbiter } = createArbiter();
-    const paymentInfo = parsePaymentInfo(options.paymentJson);
-    const nonce = BigInt(options.nonce);
 
-    // The key parameter is for display/audit trail only.
-    // The actual on-chain operation uses paymentInfo + nonce to identify the request.
     console.log('\nDenying refund request...');
     console.log('  Key:', key);
-    console.log('  Payer:', paymentInfo.payer);
-    console.log('  Nonce:', nonce.toString());
 
     try {
+      const { paymentInfo, nonce } = await resolvePaymentInfo(arbiter, key, options);
+      console.log('  Payer:', paymentInfo.payer);
+      console.log('  Nonce:', nonce.toString());
+
       const result = await arbiter.denyRefundRequest(paymentInfo, nonce);
       console.log('\n❌ Refund request denied!');
       console.log('  Transaction:', result.txHash);
@@ -258,20 +281,23 @@ program
 
 // Execute a refund (after approval)
 program
-  .command('execute')
-  .description('Execute a refund for an approved request')
-  .requiredOption('-p, --payment-json <json>', 'Payment info JSON')
+  .command('execute <key>')
+  .description('Execute a refund for an approved request (auto-resolves PaymentInfo from events if --payment-json omitted)')
+  .option('-p, --payment-json <json>', 'Payment info JSON (optional — looked up from events if omitted)')
   .option('-a, --amount <amount>', 'Amount to refund (defaults to maxAmount)')
-  .action(async (options) => {
+  .action(async (key: string, options) => {
     const { arbiter } = createArbiter();
-    const paymentInfo = parsePaymentInfo(options.paymentJson);
-    const amount = options.amount ? BigInt(options.amount) : undefined;
 
     console.log('\nExecuting refund...');
-    console.log('  Payer:', paymentInfo.payer);
-    console.log('  Amount:', amount ? formatUSDC(amount) : 'maxAmount');
+    console.log('  Key:', key);
 
     try {
+      const { paymentInfo } = await resolvePaymentInfo(arbiter, key, options);
+      const amount = options.amount ? BigInt(options.amount) : undefined;
+
+      console.log('  Payer:', paymentInfo.payer);
+      console.log('  Amount:', amount ? formatUSDC(amount) : 'maxAmount');
+
       const result = await arbiter.executeRefundInEscrow(paymentInfo, amount);
       console.log('\n✅ Refund executed!');
       console.log('  Transaction:', result.txHash);

--- a/examples/client-cli/src/index.ts
+++ b/examples/client-cli/src/index.ts
@@ -23,12 +23,12 @@ import {
   calculateTotalFees,
   formatFeeBreakdown,
   validateFeeBounds,
+  parsePaymentInfo,
   type PaymentInfo,
 } from '@x402r/core';
 import { pay } from './commands/pay.js';
 import { freeze, unfreeze, checkFrozen } from './commands/freeze.js';
 import { requestRefund, cancelRefund, getRefundStatus } from './commands/refund.js';
-import { parsePaymentInfo } from '../../shared/utils.js';
 
 // Load environment from the example directory
 const __filename = fileURLToPath(import.meta.url);

--- a/examples/e2e-dispute/.env.example
+++ b/examples/e2e-dispute/.env.example
@@ -1,0 +1,11 @@
+# E2E Dispute Resolution Example
+# Requires 3 separate wallets funded with Base Sepolia ETH + USDC
+
+# Client (payer) — will make a payment and initiate a dispute
+CLIENT_PRIVATE_KEY=0x...
+
+# Merchant (receiver) — will receive the payment
+MERCHANT_PRIVATE_KEY=0x...
+
+# Arbiter — will approve/execute the refund
+ARBITER_PRIVATE_KEY=0x...

--- a/examples/e2e-dispute/README.md
+++ b/examples/e2e-dispute/README.md
@@ -1,0 +1,43 @@
+# E2E Dispute Resolution Example
+
+End-to-end script demonstrating the full x402r dispute resolution flow:
+
+1. **Setup** — Deploy operator with short escrow (60s) + freeze (120s)
+2. **Arbiter Registry** — Register arbiter
+3. **Payment** — Client pays merchant via HTTP 402 flow
+4. **Dispute** — Client freezes payment and requests refund
+5. **Resolution** — Arbiter approves and executes refund
+6. **Cleanup** — Deregister arbiter, print summary
+
+## Prerequisites
+
+- Node.js 20+
+- 3 wallets funded with Base Sepolia ETH (for gas) and USDC (for payments)
+- Get testnet ETH: https://www.coinbase.com/faucets/base-ethereum-sepolia-faucet
+- Get testnet USDC: mint at `0x036CbD53842c5426634e7929541eC2318f3dCF7e`
+
+## Setup
+
+```bash
+cp .env.example .env
+# Edit .env with your 3 private keys
+```
+
+## Run
+
+```bash
+pnpm start
+```
+
+## Expected Output
+
+The script runs through all 5 phases and prints a summary with transaction hashes for each step. The client's USDC balance should be restored after the refund executes.
+
+## Key Parameters
+
+| Parameter | Value | Note |
+|-----------|-------|------|
+| Escrow period | 60 seconds | Short for testing |
+| Freeze duration | 120 seconds | Short for testing |
+| Operator fee | 1% (100 bps) | Standard marketplace fee |
+| Payment amount | 0.01 USDC (10000 units) | Minimal test amount |

--- a/examples/e2e-dispute/index.ts
+++ b/examples/e2e-dispute/index.ts
@@ -1,0 +1,497 @@
+/**
+ * E2E Dispute Resolution Example
+ *
+ * Demonstrates the full x402r dispute flow:
+ *   Setup → Arbiter Registry → Payment → Dispute → Resolution → Cleanup
+ *
+ * Requires 3 funded wallets on Base Sepolia (ETH + USDC).
+ *
+ * Usage:
+ *   CLIENT_PRIVATE_KEY=0x... MERCHANT_PRIVATE_KEY=0x... ARBITER_PRIVATE_KEY=0x... pnpm start
+ */
+
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  formatEther,
+  type PublicClient,
+  type WalletClient,
+} from 'viem';
+import { baseSepolia } from 'viem/chains';
+import { privateKeyToAccount, type PrivateKeyAccount } from 'viem/accounts';
+import { config as dotenvConfig } from 'dotenv';
+
+import {
+  deployMarketplaceOperator,
+  getNetworkConfig,
+  RequestStatus,
+  parsePaymentInfo,
+  type PaymentInfo,
+} from '@x402r/core';
+import { X402rClient } from '@x402r/client';
+import { X402rMerchant } from '@x402r/merchant';
+import { X402rArbiter } from '@x402r/arbiter';
+import { refundable } from '@x402r/helpers';
+import {
+  createPaymentPayload,
+  type PaymentRequirements,
+} from '@x402r/evm/escrow/client';
+import {
+  EscrowFacilitatorScheme,
+  createFacilitatorSigner,
+  type PaymentPayload,
+  type PaymentRequirements as FacilitatorRequirements,
+} from '@x402r/evm/escrow/facilitator';
+
+dotenvConfig();
+
+// ============ Configuration ============
+
+const RPC_URL = 'https://sepolia.base.org';
+const NETWORK_ID = 'eip155:84532';
+const CHAIN_ID = 84532;
+const USDC_DECIMALS = 6;
+const PAYMENT_AMOUNT = '10000'; // 0.01 USDC
+
+// Short durations for testing
+const ESCROW_PERIOD_SECONDS = 60n; // 60 seconds
+const FREEZE_DURATION_SECONDS = 120n; // 120 seconds
+const OPERATOR_FEE_BPS = 100n; // 1%
+
+const STATUS_NAMES = ['Pending', 'Approved', 'Denied', 'Cancelled'] as const;
+
+// ============ Helpers ============
+
+function formatUSDC(amount: bigint): string {
+  const whole = amount / BigInt(10 ** USDC_DECIMALS);
+  const fractional = amount % BigInt(10 ** USDC_DECIMALS);
+  return `${whole}.${fractional.toString().padStart(USDC_DECIMALS, '0')} USDC`;
+}
+
+function shortAddr(address: string): string {
+  return `${address.slice(0, 10)}...${address.slice(-8)}`;
+}
+
+function step(phase: string, message: string) {
+  console.log(`\n[${phase}] ${message}`);
+}
+
+function ok(message: string) {
+  console.log(`  OK: ${message}`);
+}
+
+function tx(label: string, hash: string) {
+  console.log(`  TX: ${label} → ${hash}`);
+  txHashes.push({ label, hash });
+}
+
+const txHashes: { label: string; hash: string }[] = [];
+
+// ============ Wallet Setup ============
+
+function loadKey(envVar: string): `0x${string}` {
+  const key = process.env[envVar] as `0x${string}`;
+  if (!key) {
+    console.error(`Error: ${envVar} environment variable is required`);
+    process.exit(1);
+  }
+  return key;
+}
+
+function makeClients(account: PrivateKeyAccount): {
+  publicClient: PublicClient;
+  walletClient: WalletClient;
+} {
+  const publicClient = createPublicClient({
+    chain: baseSepolia,
+    transport: http(RPC_URL),
+  });
+  const walletClient = createWalletClient({
+    account,
+    chain: baseSepolia,
+    transport: http(RPC_URL),
+  });
+  return { publicClient, walletClient };
+}
+
+// ============ Main Flow ============
+
+async function main() {
+  console.log('='.repeat(60));
+  console.log('  E2E Dispute Resolution — x402r');
+  console.log('='.repeat(60));
+
+  // Load accounts
+  const clientAccount = privateKeyToAccount(loadKey('CLIENT_PRIVATE_KEY'));
+  const merchantAccount = privateKeyToAccount(loadKey('MERCHANT_PRIVATE_KEY'));
+  const arbiterAccount = privateKeyToAccount(loadKey('ARBITER_PRIVATE_KEY'));
+
+  const clientClients = makeClients(clientAccount);
+  const merchantClients = makeClients(merchantAccount);
+  const arbiterClients = makeClients(arbiterAccount);
+
+  const networkConfig = getNetworkConfig(NETWORK_ID)!;
+
+  step('Setup', 'Wallet addresses');
+  console.log(`  Client:   ${clientAccount.address}`);
+  console.log(`  Merchant: ${merchantAccount.address}`);
+  console.log(`  Arbiter:  ${arbiterAccount.address}`);
+
+  // Check balances
+  const clientBalance = await clientClients.publicClient.getBalance({ address: clientAccount.address });
+  const merchantBalance = await merchantClients.publicClient.getBalance({ address: merchantAccount.address });
+  const arbiterBalance = await arbiterClients.publicClient.getBalance({ address: arbiterAccount.address });
+
+  step('Setup', 'ETH balances');
+  console.log(`  Client:   ${formatEther(clientBalance)} ETH`);
+  console.log(`  Merchant: ${formatEther(merchantBalance)} ETH`);
+  console.log(`  Arbiter:  ${formatEther(arbiterBalance)} ETH`);
+
+  if (clientBalance === 0n || merchantBalance === 0n || arbiterBalance === 0n) {
+    console.error('\nError: All wallets need ETH for gas. Get testnet ETH from:');
+    console.error('https://www.coinbase.com/faucets/base-ethereum-sepolia-faucet');
+    process.exit(1);
+  }
+
+  // ============ Phase 0: Deploy Operator ============
+
+  step('Deploy', 'Deploying marketplace operator with short escrow...');
+  console.log(`  Escrow period: ${ESCROW_PERIOD_SECONDS}s`);
+  console.log(`  Freeze duration: ${FREEZE_DURATION_SECONDS}s`);
+  console.log(`  Operator fee: ${Number(OPERATOR_FEE_BPS) / 100}%`);
+
+  const deployResult = await deployMarketplaceOperator(
+    merchantClients.walletClient,
+    merchantClients.publicClient,
+    NETWORK_ID,
+    {
+      feeRecipient: merchantAccount.address,
+      arbiter: arbiterAccount.address,
+      escrowPeriodSeconds: ESCROW_PERIOD_SECONDS,
+      freezeDurationSeconds: FREEZE_DURATION_SECONDS,
+      operatorFeeBps: OPERATOR_FEE_BPS,
+    }
+  );
+
+  const operatorAddress = deployResult.operatorAddress;
+  const freezeAddress = deployResult.freezeAddress;
+  const escrowPeriodAddress = deployResult.escrowPeriodAddress;
+
+  ok(`Operator deployed: ${shortAddr(operatorAddress)}`);
+  ok(`Freeze contract: ${shortAddr(freezeAddress)}`);
+  ok(`EscrowPeriod: ${shortAddr(escrowPeriodAddress)}`);
+  console.log(`  New deployments: ${deployResult.summary.newDeployments}`);
+  console.log(`  Already existed: ${deployResult.summary.existingContracts}`);
+
+  for (const hash of deployResult.txHashes) {
+    tx('deploy', hash);
+  }
+
+  // ============ Phase 1: Arbiter Registry ============
+
+  step('Registry', 'Registering arbiter...');
+
+  const arbiter = new X402rArbiter({
+    publicClient: arbiterClients.publicClient,
+    walletClient: arbiterClients.walletClient,
+    operatorAddress,
+    escrowAddress: networkConfig.authCaptureEscrow,
+    refundRequestAddress: networkConfig.refundRequest,
+    arbiterRegistryAddress: networkConfig.arbiterRegistry,
+    chainId: CHAIN_ID,
+  });
+
+  const registerResult = await arbiter.registerArbiter('https://example.com/arbiter/disputes');
+  tx('register-arbiter', registerResult.txHash);
+  await arbiterClients.publicClient.waitForTransactionReceipt({ hash: registerResult.txHash });
+
+  const isRegistered = await arbiter.isArbiterRegistered(arbiterAccount.address);
+  ok(`Arbiter registered: ${isRegistered}`);
+
+  // ============ Phase 2: Payment via HTTP 402 ============
+
+  step('Payment', 'Starting in-process merchant server...');
+
+  // Build payment requirements
+  const baseOption = {
+    scheme: 'escrow',
+    network: NETWORK_ID,
+    payTo: merchantAccount.address as `0x${string}`,
+    maxAmountRequired: PAYMENT_AMOUNT,
+    asset: networkConfig.usdc,
+  };
+
+  const requirements = refundable(baseOption, operatorAddress);
+
+  // Create facilitator for the merchant server
+  const facilitatorSigner = createFacilitatorSigner(
+    merchantClients.walletClient,
+    merchantClients.publicClient
+  );
+  const facilitator = new EscrowFacilitatorScheme(facilitatorSigner);
+
+  // Start an in-process Hono server
+  const app = new Hono();
+  let capturedPaymentInfo: PaymentInfo | null = null;
+
+  app.get('/weather', async (c) => {
+    const paymentHeader = c.req.header('X-Payment');
+
+    if (!paymentHeader) {
+      return c.json({ error: 'Payment Required', accepts: [requirements] }, 402);
+    }
+
+    let paymentPayload: PaymentPayload;
+    try {
+      paymentPayload = JSON.parse(
+        Buffer.from(paymentHeader, 'base64').toString('utf-8')
+      );
+    } catch {
+      return c.json({ error: 'Invalid Payment' }, 402);
+    }
+
+    const verifyResult = await facilitator.verify(
+      paymentPayload,
+      requirements as unknown as FacilitatorRequirements
+    );
+    if (!verifyResult.isValid) {
+      return c.json({ error: 'Verification Failed', reason: verifyResult.invalidReason }, 402);
+    }
+
+    const settleResult = await facilitator.settle(
+      paymentPayload,
+      requirements as unknown as FacilitatorRequirements
+    );
+    if (!settleResult.success) {
+      return c.json({ error: 'Settlement Failed', reason: settleResult.errorReason }, 402);
+    }
+
+    // Extract PaymentInfo from the payload for later use in dispute
+    const payload = paymentPayload.payload as {
+      paymentInfo: Record<string, unknown>;
+      authorization: { from: string };
+    };
+    capturedPaymentInfo = {
+      operator: payload.paymentInfo.operator as `0x${string}`,
+      payer: payload.authorization.from as `0x${string}`,
+      receiver: payload.paymentInfo.receiver as `0x${string}`,
+      token: payload.paymentInfo.token as `0x${string}`,
+      maxAmount: BigInt(String(payload.paymentInfo.maxAmount)),
+      preApprovalExpiry: BigInt(String(payload.paymentInfo.preApprovalExpiry)),
+      authorizationExpiry: BigInt(String(payload.paymentInfo.authorizationExpiry)),
+      refundExpiry: BigInt(String(payload.paymentInfo.refundExpiry)),
+      minFeeBps: Number(payload.paymentInfo.minFeeBps),
+      maxFeeBps: Number(payload.paymentInfo.maxFeeBps),
+      feeReceiver: payload.paymentInfo.feeReceiver as `0x${string}`,
+      salt: BigInt(String(payload.paymentInfo.salt)),
+    };
+
+    tx('authorize-payment', settleResult.transaction!);
+
+    return c.json({ data: 'Weather: Sunny, 72F', payer: settleResult.payer });
+  });
+
+  // Start server on random port
+  const server = serve({ fetch: app.fetch, port: 0 });
+  const serverAddress = server.address();
+  const port = typeof serverAddress === 'object' && serverAddress ? serverAddress.port : 0;
+  ok(`Merchant server running on port ${port}`);
+
+  // Client makes a payment
+  step('Payment', 'Client requesting weather data (will get 402)...');
+  const serverUrl = `http://localhost:${port}`;
+
+  // Step 1: Get 402 response with requirements
+  const initialResponse = await fetch(`${serverUrl}/weather`);
+  if (initialResponse.status !== 402) {
+    console.error(`  Expected 402, got ${initialResponse.status}`);
+    process.exit(1);
+  }
+  const body402 = (await initialResponse.json()) as { accepts: PaymentRequirements[] };
+  ok(`Got 402 with ${body402.accepts.length} payment option(s)`);
+
+  // Step 2: Create payment payload
+  step('Payment', 'Creating payment payload and signing ERC-3009...');
+  const paymentPayload = await createPaymentPayload(
+    body402.accepts[0] as PaymentRequirements,
+    clientClients.walletClient
+  );
+  ok('Payment payload created');
+
+  // Step 3: Send payment
+  step('Payment', 'Sending payment to merchant...');
+  const xPayment = Buffer.from(
+    JSON.stringify({ x402Version: 1, scheme: 'escrow', payload: paymentPayload })
+  ).toString('base64');
+
+  const paidResponse = await fetch(`${serverUrl}/weather`, {
+    headers: { 'X-Payment': xPayment },
+  });
+
+  if (paidResponse.status !== 200) {
+    const errorBody = await paidResponse.json();
+    console.error('  Payment failed:', errorBody);
+    process.exit(1);
+  }
+
+  const weatherData = await paidResponse.json();
+  ok(`Payment accepted! Response: ${JSON.stringify(weatherData)}`);
+
+  // Wait for the authorize tx to be mined
+  const authTx = txHashes.find((t) => t.label === 'authorize-payment');
+  if (authTx) {
+    await clientClients.publicClient.waitForTransactionReceipt({ hash: authTx.hash as `0x${string}` });
+  }
+
+  if (!capturedPaymentInfo) {
+    console.error('  Error: PaymentInfo was not captured from settlement');
+    process.exit(1);
+  }
+
+  const paymentInfo = capturedPaymentInfo;
+  ok(`PaymentInfo captured — payer: ${shortAddr(paymentInfo.payer)}`);
+
+  // ============ Phase 3: Dispute ============
+
+  step('Dispute', 'Client freezing payment...');
+
+  const client = new X402rClient({
+    publicClient: clientClients.publicClient,
+    walletClient: clientClients.walletClient,
+    operatorAddress,
+    escrowAddress: networkConfig.authCaptureEscrow,
+    refundRequestAddress: networkConfig.refundRequest,
+    chainId: CHAIN_ID,
+  });
+
+  const freezeResult = await client.freezePayment(paymentInfo, freezeAddress);
+  tx('freeze', freezeResult.txHash);
+  await clientClients.publicClient.waitForTransactionReceipt({ hash: freezeResult.txHash });
+
+  const isFrozen = await client.isFrozen(paymentInfo, freezeAddress);
+  ok(`Payment frozen: ${isFrozen}`);
+
+  // Verify merchant cannot release while frozen
+  step('Dispute', 'Verifying merchant release fails while frozen...');
+  const merchant = new X402rMerchant({
+    publicClient: merchantClients.publicClient,
+    walletClient: merchantClients.walletClient,
+    operatorAddress,
+    escrowAddress: networkConfig.authCaptureEscrow,
+    refundRequestAddress: networkConfig.refundRequest,
+    chainId: CHAIN_ID,
+  });
+
+  try {
+    await merchant.release(paymentInfo, paymentInfo.maxAmount);
+    console.error('  Error: Release should have failed while frozen!');
+    process.exit(1);
+  } catch {
+    ok('Merchant release correctly rejected (payment is frozen)');
+  }
+
+  // Client requests refund
+  step('Dispute', 'Client requesting refund...');
+  const refundResult = await client.requestRefund(paymentInfo, paymentInfo.maxAmount, 0n);
+  tx('request-refund', refundResult.txHash);
+  await clientClients.publicClient.waitForTransactionReceipt({ hash: refundResult.txHash });
+
+  const refundStatus = await client.getRefundStatus(paymentInfo, 0n);
+  ok(`Refund status: ${STATUS_NAMES[refundStatus]}`);
+
+  // ============ Phase 4: Resolution ============
+
+  step('Resolution', 'Arbiter listing pending requests...');
+
+  const { keys, total } = await arbiter.getPendingRefundRequests(
+    0n,
+    10n,
+    merchantAccount.address
+  );
+  ok(`Found ${total} refund request(s), ${keys.length} key(s) returned`);
+
+  if (keys.length === 0) {
+    console.error('  Error: No refund requests found');
+    process.exit(1);
+  }
+
+  const targetKey = keys[0];
+  console.log(`  Target key: ${targetKey}`);
+
+  // Arbiter approves
+  step('Resolution', 'Arbiter approving refund...');
+  const approveResult = await arbiter.approveRefundRequest(paymentInfo, 0n);
+  tx('approve-refund', approveResult.txHash);
+  await arbiterClients.publicClient.waitForTransactionReceipt({ hash: approveResult.txHash });
+
+  const statusAfterApprove = await arbiter.getRefundStatus(paymentInfo, 0n);
+  ok(`Refund status after approve: ${STATUS_NAMES[statusAfterApprove]}`);
+
+  // Arbiter executes refund
+  step('Resolution', 'Arbiter executing refund (refundInEscrow)...');
+
+  // Check client USDC balance before refund
+  const usdcBalanceBefore = await clientClients.publicClient.readContract({
+    address: networkConfig.usdc,
+    abi: [{ name: 'balanceOf', type: 'function', stateMutability: 'view', inputs: [{ name: 'account', type: 'address' }], outputs: [{ type: 'uint256' }] }],
+    functionName: 'balanceOf',
+    args: [clientAccount.address],
+  }) as bigint;
+
+  const executeResult = await arbiter.executeRefundInEscrow(paymentInfo);
+  tx('execute-refund', executeResult.txHash);
+  await arbiterClients.publicClient.waitForTransactionReceipt({ hash: executeResult.txHash });
+
+  // Check client USDC balance after refund
+  const usdcBalanceAfter = await clientClients.publicClient.readContract({
+    address: networkConfig.usdc,
+    abi: [{ name: 'balanceOf', type: 'function', stateMutability: 'view', inputs: [{ name: 'account', type: 'address' }], outputs: [{ type: 'uint256' }] }],
+    functionName: 'balanceOf',
+    args: [clientAccount.address],
+  }) as bigint;
+
+  const refunded = usdcBalanceAfter - usdcBalanceBefore;
+  ok(`Client USDC refunded: ${formatUSDC(refunded)}`);
+  ok(`Client USDC balance: ${formatUSDC(usdcBalanceAfter)}`);
+
+  // ============ Phase 5: Cleanup ============
+
+  step('Cleanup', 'Arbiter deregistering from registry...');
+  const deregisterResult = await arbiter.deregisterArbiter();
+  tx('deregister-arbiter', deregisterResult.txHash);
+  await arbiterClients.publicClient.waitForTransactionReceipt({ hash: deregisterResult.txHash });
+
+  const isStillRegistered = await arbiter.isArbiterRegistered(arbiterAccount.address);
+  ok(`Arbiter still registered: ${isStillRegistered}`);
+
+  // ============ Summary ============
+
+  console.log('\n' + '='.repeat(60));
+  console.log('  SUMMARY');
+  console.log('='.repeat(60));
+
+  console.log('\nDeployed Contracts:');
+  console.log(`  Operator:     ${operatorAddress}`);
+  console.log(`  Freeze:       ${freezeAddress}`);
+  console.log(`  EscrowPeriod: ${escrowPeriodAddress}`);
+
+  console.log('\nTransaction Hashes:');
+  for (const { label, hash } of txHashes) {
+    console.log(`  ${label.padEnd(20)} ${hash}`);
+    console.log(`  ${''.padEnd(20)} https://sepolia.basescan.org/tx/${hash}`);
+  }
+
+  console.log('\nResult: Dispute resolved — client refunded');
+  console.log('='.repeat(60));
+
+  // Shutdown server
+  server.close();
+}
+
+main().catch((error) => {
+  console.error('\nFatal error:', error);
+  process.exit(1);
+});

--- a/examples/e2e-dispute/package.json
+++ b/examples/e2e-dispute/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "e2e-dispute-example",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.0",
+    "@x402r/arbiter": "workspace:*",
+    "@x402r/client": "workspace:*",
+    "@x402r/core": "workspace:*",
+    "@x402r/evm": "file:../../../x402r-scheme/packages/evm",
+    "@x402r/helpers": "workspace:*",
+    "@x402r/merchant": "workspace:*",
+    "dotenv": "^16.4.0",
+    "hono": "^4.6.0",
+    "viem": "^2.21.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/merchant-cli/src/index.ts
+++ b/examples/merchant-cli/src/index.ts
@@ -24,9 +24,9 @@ import {
   calculateTotalFees,
   formatFeeBreakdown,
   validateFeeBounds,
+  parsePaymentInfo,
   type PaymentInfo,
 } from '@x402r/core';
-import { parsePaymentInfo } from '../../shared/utils.js';
 
 // Load environment from the example directory
 const __filename = fileURLToPath(import.meta.url);

--- a/examples/merchant-server/src/middleware.ts
+++ b/examples/merchant-server/src/middleware.ts
@@ -4,49 +4,10 @@
  */
 
 import type { Context, Next } from 'hono';
-import { createPublicClient, createWalletClient, http, type Address, type WalletClient, type PublicClient } from 'viem';
-import { baseSepolia } from 'viem/chains';
-import { privateKeyToAccount } from 'viem/accounts';
-import { EscrowFacilitatorScheme, type FacilitatorEvmSigner, type PaymentPayload, type PaymentRequirements } from '@x402r/evm/escrow/facilitator';
+import { EscrowFacilitatorScheme, createFacilitatorSigner, type FacilitatorEvmSigner, type PaymentPayload, type PaymentRequirements } from '@x402r/evm/escrow/facilitator';
 
 // Re-export for ease of use
-export { EscrowFacilitatorScheme };
-
-/**
- * Create a FacilitatorEvmSigner from viem clients
- */
-export function createFacilitatorSigner(
-  walletClient: WalletClient,
-  publicClient: PublicClient
-): FacilitatorEvmSigner {
-  const account = walletClient.account!;
-
-  return {
-    address: account.address,
-    async writeContract(args) {
-      const hash = await walletClient.writeContract({
-        chain: walletClient.chain,
-        account,
-        address: args.address,
-        abi: args.abi,
-        functionName: args.functionName,
-        args: args.args as unknown[],
-      });
-      return hash;
-    },
-    async verifyTypedData(args) {
-      const valid = await publicClient.verifyTypedData({
-        address: args.address,
-        domain: args.domain as Parameters<typeof publicClient.verifyTypedData>[0]['domain'],
-        types: args.types as Record<string, { name: string; type: string }[]>,
-        primaryType: args.primaryType,
-        message: args.message,
-        signature: args.signature,
-      });
-      return valid;
-    },
-  };
-}
+export { EscrowFacilitatorScheme, createFacilitatorSigner };
 
 export interface X402MiddlewareOptions {
   /** Payment requirements to return in 402 response */

--- a/packages/arbiter/src/arbiter.ts
+++ b/packages/arbiter/src/arbiter.ts
@@ -10,6 +10,7 @@ import {
   ArbiterRegistryABI,
   RequestStatus,
   NotImplementedError,
+  computePaymentInfoHash,
   hasRefundRequest as sharedHasRefundRequest,
   getRefundRequest as sharedGetRefundRequest,
   getRefundStatus as sharedGetRefundStatus,
@@ -474,6 +475,125 @@ export class X402rArbiter {
    */
   async getRefundRequestByKey(compositeKey: `0x${string}`): Promise<RefundRequestData> {
     return sharedGetRefundRequestByKey(this.getRefundCtx(), compositeKey);
+  }
+
+  /**
+   * Resolve PaymentInfo and nonce from a composite key by scanning RefundRequested events.
+   *
+   * The RefundRequest contract stores only the hash of PaymentInfo, not the full struct.
+   * However, `RefundRequested` events emit the full PaymentInfo. This method scans those
+   * events, computes hashes, and returns the matching PaymentInfo for a given composite key.
+   *
+   * @param compositeKey - The composite key from getPendingRefundRequests
+   * @param fromBlock - Block to start scanning from (default: earliest, 0n)
+   * @returns The PaymentInfo and nonce, or null if not found in event logs
+   * @throws Error if refundRequestAddress or escrowAddress is not configured
+   *
+   * @example
+   * ```typescript
+   * const result = await arbiter.getPaymentInfoFromEvents(compositeKey);
+   * if (result) {
+   *   await arbiter.approveRefundRequest(result.paymentInfo, result.nonce);
+   * }
+   * ```
+   */
+  async getPaymentInfoFromEvents(
+    compositeKey: `0x${string}`,
+    fromBlock: bigint = 0n
+  ): Promise<{ paymentInfo: PaymentInfo; nonce: bigint } | null> {
+    if (!this.refundRequestAddress) {
+      throw new Error('RefundRequest address required');
+    }
+    if (!this.escrowAddress) {
+      throw new Error('Escrow address required for hash computation');
+    }
+
+    // First, get the stored paymentInfoHash and nonce from the request data
+    const requestData = await this.getRefundRequestByKey(compositeKey);
+    const targetPaymentInfoHash = requestData.paymentInfoHash;
+    const targetNonce = requestData.nonce;
+
+    // Scan RefundRequested events to find the matching PaymentInfo
+    const logs = await this.publicClient.getLogs({
+      address: this.refundRequestAddress,
+      event: {
+        name: 'RefundRequested',
+        type: 'event',
+        inputs: [
+          {
+            name: 'paymentInfo',
+            type: 'tuple',
+            indexed: false,
+            components: [
+              { name: 'operator', type: 'address' },
+              { name: 'payer', type: 'address' },
+              { name: 'receiver', type: 'address' },
+              { name: 'token', type: 'address' },
+              { name: 'maxAmount', type: 'uint120' },
+              { name: 'preApprovalExpiry', type: 'uint48' },
+              { name: 'authorizationExpiry', type: 'uint48' },
+              { name: 'refundExpiry', type: 'uint48' },
+              { name: 'minFeeBps', type: 'uint16' },
+              { name: 'maxFeeBps', type: 'uint16' },
+              { name: 'feeReceiver', type: 'address' },
+              { name: 'salt', type: 'uint256' },
+            ],
+          },
+          { name: 'payer', type: 'address', indexed: true },
+          { name: 'receiver', type: 'address', indexed: true },
+          { name: 'amount', type: 'uint120', indexed: false },
+          { name: 'nonce', type: 'uint256', indexed: false },
+        ],
+      },
+      fromBlock,
+      toBlock: 'latest',
+    });
+
+    for (const log of logs) {
+      const args = log.args as {
+        paymentInfo?: {
+          operator: `0x${string}`;
+          payer: `0x${string}`;
+          receiver: `0x${string}`;
+          token: `0x${string}`;
+          maxAmount: bigint;
+          preApprovalExpiry: bigint;
+          authorizationExpiry: bigint;
+          refundExpiry: bigint;
+          minFeeBps: number;
+          maxFeeBps: number;
+          feeReceiver: `0x${string}`;
+          salt: bigint;
+        };
+        nonce?: bigint;
+      };
+
+      if (!args.paymentInfo) continue;
+
+      const paymentInfo: PaymentInfo = {
+        operator: args.paymentInfo.operator,
+        payer: args.paymentInfo.payer,
+        receiver: args.paymentInfo.receiver,
+        token: args.paymentInfo.token,
+        maxAmount: args.paymentInfo.maxAmount,
+        preApprovalExpiry: args.paymentInfo.preApprovalExpiry,
+        authorizationExpiry: args.paymentInfo.authorizationExpiry,
+        refundExpiry: args.paymentInfo.refundExpiry,
+        minFeeBps: args.paymentInfo.minFeeBps,
+        maxFeeBps: args.paymentInfo.maxFeeBps,
+        feeReceiver: args.paymentInfo.feeReceiver,
+        salt: args.paymentInfo.salt,
+      };
+
+      // Compute the hash using the same algorithm as the escrow contract
+      const hash = computePaymentInfoHash(paymentInfo, this.escrowAddress, this.chainId);
+
+      if (hash === targetPaymentInfoHash && args.nonce === targetNonce) {
+        return { paymentInfo, nonce: targetNonce };
+      }
+    }
+
+    return null;
   }
 
   // ============ Freeze Operations ============

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -7,6 +7,40 @@ import { keccak256, encodeAbiParameters, toHex } from 'viem';
 import type { PaymentInfo } from '../types/index.js';
 
 /**
+ * Parse a PaymentInfo JSON string into a typed PaymentInfo object.
+ *
+ * Uses BigInt() for all bigint-typed fields (maxAmount, preApprovalExpiry,
+ * authorizationExpiry, refundExpiry, salt) to avoid precision loss from Number().
+ *
+ * @param json - JSON string representation of PaymentInfo
+ * @returns Properly typed PaymentInfo with bigint fields
+ * @throws Error if JSON is invalid or missing required fields
+ *
+ * @example
+ * ```typescript
+ * const paymentInfo = parsePaymentInfo('{"operator":"0x...","payer":"0x...",...}');
+ * console.log(paymentInfo.maxAmount); // bigint
+ * ```
+ */
+export function parsePaymentInfo(json: string): PaymentInfo {
+  const parsed = JSON.parse(json);
+  return {
+    operator: parsed.operator,
+    payer: parsed.payer,
+    receiver: parsed.receiver,
+    token: parsed.token,
+    maxAmount: BigInt(parsed.maxAmount),
+    preApprovalExpiry: BigInt(parsed.preApprovalExpiry),
+    authorizationExpiry: BigInt(parsed.authorizationExpiry),
+    refundExpiry: BigInt(parsed.refundExpiry),
+    minFeeBps: Number(parsed.minFeeBps),
+    maxFeeBps: Number(parsed.maxFeeBps),
+    feeReceiver: parsed.feeReceiver,
+    salt: BigInt(parsed.salt),
+  };
+}
+
+/**
  * EIP-712 typehash for PaymentInfo struct
  *
  * Computed as: keccak256("PaymentInfo(address operator,address payer,address receiver,address token,uint120 maxAmount,uint48 preApprovalExpiry,uint48 authorizationExpiry,uint48 refundExpiry,uint16 minFeeBps,uint16 maxFeeBps,address feeReceiver,uint256 salt)")

--- a/packages/core/tests/utils.test.ts
+++ b/packages/core/tests/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   computePaymentInfoHash,
+  parsePaymentInfo,
   PAYMENT_INFO_TYPEHASH,
 } from '../src/utils/index.js';
 import type { PaymentInfo } from '../src/types/index.js';
@@ -105,5 +106,90 @@ describe('computePaymentInfoHash', () => {
 
     const hash = computePaymentInfoHash(largePaymentInfo, escrowAddress, chainId);
     expect(hash).toMatch(/^0x[a-fA-F0-9]{64}$/);
+  });
+});
+
+describe('parsePaymentInfo', () => {
+  const sampleJson = JSON.stringify({
+    operator: '0x1234567890123456789012345678901234567890',
+    payer: '0x2345678901234567890123456789012345678901',
+    receiver: '0x3456789012345678901234567890123456789012',
+    token: '0x4567890123456789012345678901234567890123',
+    maxAmount: '1000000',
+    preApprovalExpiry: '0',
+    authorizationExpiry: '1735689600',
+    refundExpiry: '1738368000',
+    minFeeBps: 0,
+    maxFeeBps: 500,
+    feeReceiver: '0x5678901234567890123456789012345678901234',
+    salt: '81985529216486895',
+  });
+
+  it('should parse valid JSON into PaymentInfo', () => {
+    const result = parsePaymentInfo(sampleJson);
+    expect(result.operator).toBe('0x1234567890123456789012345678901234567890');
+    expect(result.payer).toBe('0x2345678901234567890123456789012345678901');
+    expect(result.receiver).toBe('0x3456789012345678901234567890123456789012');
+    expect(result.token).toBe('0x4567890123456789012345678901234567890123');
+    expect(result.feeReceiver).toBe('0x5678901234567890123456789012345678901234');
+  });
+
+  it('should convert string amounts to bigint', () => {
+    const result = parsePaymentInfo(sampleJson);
+    expect(result.maxAmount).toBe(BigInt('1000000'));
+    expect(typeof result.maxAmount).toBe('bigint');
+  });
+
+  it('should convert string timestamps to bigint', () => {
+    const result = parsePaymentInfo(sampleJson);
+    expect(result.preApprovalExpiry).toBe(0n);
+    expect(result.authorizationExpiry).toBe(BigInt(1735689600));
+    expect(result.refundExpiry).toBe(BigInt(1738368000));
+    expect(typeof result.authorizationExpiry).toBe('bigint');
+  });
+
+  it('should convert salt to bigint', () => {
+    const result = parsePaymentInfo(sampleJson);
+    expect(typeof result.salt).toBe('bigint');
+    expect(result.salt).toBe(BigInt('81985529216486895'));
+  });
+
+  it('should keep fee bps as numbers', () => {
+    const result = parsePaymentInfo(sampleJson);
+    expect(result.minFeeBps).toBe(0);
+    expect(result.maxFeeBps).toBe(500);
+    expect(typeof result.minFeeBps).toBe('number');
+    expect(typeof result.maxFeeBps).toBe('number');
+  });
+
+  it('should produce a hash-compatible result', () => {
+    const result = parsePaymentInfo(sampleJson);
+    const escrowAddress = '0xb9488351E48b23D798f24e8174514F28B741Eb4f' as const;
+    const hash = computePaymentInfoHash(result, escrowAddress, 84532);
+    expect(hash).toMatch(/^0x[a-fA-F0-9]{64}$/);
+  });
+
+  it('should throw on invalid JSON', () => {
+    expect(() => parsePaymentInfo('not json')).toThrow();
+  });
+
+  it('should handle hex-encoded bigint values', () => {
+    const hexJson = JSON.stringify({
+      operator: '0x1234567890123456789012345678901234567890',
+      payer: '0x2345678901234567890123456789012345678901',
+      receiver: '0x3456789012345678901234567890123456789012',
+      token: '0x4567890123456789012345678901234567890123',
+      maxAmount: '0xF4240',
+      preApprovalExpiry: '0',
+      authorizationExpiry: '1735689600',
+      refundExpiry: '1738368000',
+      minFeeBps: 0,
+      maxFeeBps: 500,
+      feeReceiver: '0x5678901234567890123456789012345678901234',
+      salt: '0x123456789abcdef',
+    });
+    const result = parsePaymentInfo(hexJson);
+    expect(result.maxAmount).toBe(BigInt('0xF4240'));
+    expect(result.salt).toBe(BigInt('0x123456789abcdef'));
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -116,6 +116,49 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  examples/e2e-dispute:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.13.0
+        version: 1.19.9(hono@4.11.7)
+      '@x402r/arbiter':
+        specifier: workspace:*
+        version: link:../../packages/arbiter
+      '@x402r/client':
+        specifier: workspace:*
+        version: link:../../packages/client
+      '@x402r/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@x402r/evm':
+        specifier: file:../../../x402r-scheme/packages/evm
+        version: file:../x402r-scheme/packages/evm(viem@2.45.0(typescript@5.9.3))
+      '@x402r/helpers':
+        specifier: workspace:*
+        version: link:../../packages/helpers
+      '@x402r/merchant':
+        specifier: workspace:*
+        version: link:../../packages/merchant
+      dotenv:
+        specifier: ^16.4.0
+        version: 16.6.1
+      hono:
+        specifier: ^4.6.0
+        version: 4.11.7
+      viem:
+        specifier: ^2.21.0
+        version: 2.45.0(typescript@5.9.3)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.11.0
+        version: 20.19.30
+      tsx:
+        specifier: ^4.7.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   examples/merchant-cli:
     dependencies:
       '@x402r/core':


### PR DESCRIPTION
## Summary
- Extract `parsePaymentInfo()` from examples into `@x402r/core` utils with 8 new tests
- Add `getPaymentInfoFromEvents()` to `X402rArbiter` — resolves full PaymentInfo from `RefundRequested` event logs given a composite key
- Update arbiter CLI `approve`/`deny`/`execute` to auto-resolve PaymentInfo from events when `--payment-json` is omitted
- Update merchant-server example to import `createFacilitatorSigner` from `@x402r/evm` (companion PR: BackTrackCo/x402r-scheme#new)
- Create `e2e-dispute` example with full 5-phase dispute flow (deploy → pay → freeze → refund → resolve)

## Changes
- `packages/core/src/utils/index.ts` — add `parsePaymentInfo()`
- `packages/core/tests/utils.test.ts` — add 8 tests for `parsePaymentInfo`
- `packages/arbiter/src/arbiter.ts` — add `getPaymentInfoFromEvents()`
- `examples/arbiter-cli/src/index.ts` — auto-resolve PaymentInfo, `--payment-json` now optional
- `examples/client-cli/src/index.ts` — import `parsePaymentInfo` from `@x402r/core`
- `examples/merchant-cli/src/index.ts` — import `parsePaymentInfo` from `@x402r/core`
- `examples/merchant-server/src/middleware.ts` — import `createFacilitatorSigner` from `@x402r/evm`
- `examples/e2e-dispute/` — new full dispute resolution example

## Test plan
- [x] `pnpm build` — 5 packages build successfully
- [x] `pnpm test` — 324 tests pass (186 core + 56 arbiter + 46 client + 29 merchant + 7 helpers)
- [ ] Run `e2e-dispute` example with funded wallets on Base Sepolia

🤖 Generated with [Claude Code](https://claude.com/claude-code)