### PR TITLE
Patch @x402/core extra field bug and update E2E docs

### DIFF
--- a/docs/EXAMPLES_GUIDE.md
+++ b/docs/EXAMPLES_GUIDE.md
@@ -1,6 +1,6 @@
 # x402r Examples Guide
 
-End-to-end demo: Client pays for weather data → Merchant delegates to Facilitator → Facilitator settles on-chain → Merchant releases after escrow period.
+End-to-end demo: Client pays for weather data via escrow, Merchant delegates to Facilitator, Facilitator settles on-chain, Merchant releases after escrow period.
 
 ## Prerequisites
 
@@ -14,80 +14,80 @@ End-to-end demo: Client pays for weather data → Merchant delegates to Facilita
 
 ## Step 1: Deploy an Operator
 
-Skip this if using the pre-deployed example operator below.
+Skip this if using the pre-deployed short-escrow operator below.
 
 ```bash
 cd x402r-sdk
 PRIVATE_KEY=0x... pnpm example:deploy-operator
 ```
 
-Save the output addresses for the next steps.
+Save the output addresses (PaymentOperator, EscrowPeriod, Freeze) for the next steps.
 
 ## Step 2: Start the Facilitator
 
-The facilitator service handles payment verification and on-chain settlement. The merchant server delegates to it via x402's standard middleware.
+The facilitator handles payment verification and on-chain settlement. It is **operator-agnostic** — it does not need an operator address. It reads escrow config from the payment requirements at verify/settle time.
 
 ```bash
-cd x402r-sdk/examples/facilitator
-cp .env.example .env
+cd x402r-sdk/examples/facilitator/basic
+cp .env-local .env
 ```
 
 Edit `.env`:
 
 ```env
 PRIVATE_KEY=0x...your_facilitator_private_key...
-OPERATOR_ADDRESS=0xbb4f390b80E4F4895B96B95AE382B65fDC45974B
+PORT=4022
 ```
 
-Start:
+Start (from x402r-sdk root):
 
 ```bash
-pnpm dev
+pnpm example:facilitator
 ```
 
 The facilitator runs at http://localhost:4022.
 
+Verify it's working:
+
+```bash
+curl http://localhost:4022/supported
+```
+
 ## Step 3: Start the Merchant Server
 
 ```bash
-cd x402r-sdk/examples/merchant-server
-pnpm install
-cp .env.example .env
+cd x402r-sdk/examples/servers/express
+cp .env-local .env
 ```
 
 Edit `.env`:
 
 ```env
-PRIVATE_KEY=0x...your_merchant_private_key...
-OPERATOR_ADDRESS=0xbb4f390b80E4F4895B96B95AE382B65fDC45974B
+ADDRESS=0x...your_merchant_wallet_address...
+OPERATOR_ADDRESS=0x8140b98ec518843EA1Dd40C42617ACBa71752C33
 FACILITATOR_URL=http://localhost:4022
 ```
 
-Start:
+Start (from x402r-sdk root):
 
 ```bash
-# From examples/merchant-server directory:
-pnpm dev
-
-# Or from x402r-sdk root:
-pnpm example:merchant-server
+pnpm example:server:express
 ```
 
-The merchant server uses x402's standard `paymentMiddleware` and delegates verify/settle to the facilitator.
+The merchant server runs at http://localhost:4021.
 
 Test it returns 402:
 
 ```bash
-curl http://localhost:3000/weather
+curl http://localhost:4021/weather
 ```
+
+You should see a 402 response with `accepts` containing the escrow scheme payment requirements, including `operatorAddress` in `extra`.
 
 ## Step 4: Make a Payment
 
-In a new terminal:
-
 ```bash
-cd x402r-sdk/examples/client-cli
-pnpm install
+cd x402r-sdk/examples/dev-tools/client-cli
 cp .env.example .env
 ```
 
@@ -97,69 +97,59 @@ Edit `.env`:
 PRIVATE_KEY=0x...your_payer_private_key...
 ```
 
-Pay for weather data:
+Pay for weather data (from x402r-sdk root):
 
 ```bash
-# From examples/client-cli directory:
-pnpm start pay --url http://localhost:3000/weather
-
-# Or from x402r-sdk root:
-pnpm example:client-cli pay --url http://localhost:3000/weather
+pnpm example:client-cli pay --url http://localhost:4021/weather
 ```
 
-**Save the Payment Info JSON from the output** - you need it for freeze/refund.
+**Save the Payment Info JSON from the output** — you need it for freeze/refund.
 
 ## Step 5: Freeze a Payment (Optional)
 
 Freezing blocks the merchant from releasing funds:
 
 ```bash
-pnpm start freeze \
+pnpm example:client-cli freeze \
   --payment-json '{"operator":"0x...","payer":"0x...",...}' \
-  --freeze-address 0xD0f99B7667076f151FD8240b277f1765d147e48C \
-  --operator-address 0xbb4f390b80E4F4895B96B95AE382B65fDC45974B
+  --freeze-address 0x6d64A0B25A1494f347941614fc8799B486a603A6 \
+  --operator-address 0x8140b98ec518843EA1Dd40C42617ACBa71752C33
 ```
 
 Check status:
 
 ```bash
-pnpm start is-frozen \
+pnpm example:client-cli is-frozen \
   --payment-json '...' \
-  --freeze-address 0xD0f99B7667076f151FD8240b277f1765d147e48C \
-  --operator-address 0xbb4f390b80E4F4895B96B95AE382B65fDC45974B
+  --freeze-address 0x6d64A0B25A1494f347941614fc8799B486a603A6 \
+  --operator-address 0x8140b98ec518843EA1Dd40C42617ACBa71752C33
 ```
 
 ## Step 6: Request a Refund (Optional)
 
 ```bash
-pnpm start refund \
+pnpm example:client-cli refund \
   --payment-json '...' \
   --amount 10000 \
-  --operator-address 0xbb4f390b80E4F4895B96B95AE382B65fDC45974B
+  --operator-address 0x8140b98ec518843EA1Dd40C42617ACBa71752C33
 ```
 
 Check refund status:
 
 ```bash
-pnpm start refund-status \
+pnpm example:client-cli refund-status \
   --payment-json '...' \
-  --operator-address 0xbb4f390b80E4F4895B96B95AE382B65fDC45974B
+  --operator-address 0x8140b98ec518843EA1Dd40C42617ACBa71752C33
 ```
 
 ## Step 7: Arbiter Operations (Dispute Resolution)
 
 The arbiter-cli handles dispute resolution for refund requests.
 
-```bash
-# From x402r-sdk root:
-pnpm example:arbiter-cli <command>
-```
-
 ### Setup
 
 ```bash
-cd x402r-sdk/examples/arbiter-cli
-pnpm install
+cd x402r-sdk/examples/dev-tools/arbiter-cli
 cp .env.example .env
 ```
 
@@ -167,39 +157,39 @@ Edit `.env`:
 
 ```env
 PRIVATE_KEY=0x...your_arbiter_private_key...
-OPERATOR_ADDRESS=0xbb4f390b80E4F4895B96B95AE382B65fDC45974B
-FREEZE_ADDRESS=0xD0f99B7667076f151FD8240b277f1765d147e48C
+OPERATOR_ADDRESS=0x8140b98ec518843EA1Dd40C42617ACBa71752C33
+FREEZE_ADDRESS=0x6d64A0B25A1494f347941614fc8799B486a603A6
 ```
 
 ### List Pending Refund Requests
 
 ```bash
-pnpm start list
-pnpm start list --offset 0 --count 20
+pnpm example:arbiter-cli list
+pnpm example:arbiter-cli list --offset 0 --count 20
 ```
 
 ### View Request Details
 
 ```bash
-pnpm start show 0x1234...abcd
+pnpm example:arbiter-cli show 0x1234...abcd
 ```
 
 ### Approve or Deny a Refund
 
 ```bash
 # Approve
-pnpm start approve 0x1234...abcd \
+pnpm example:arbiter-cli approve 0x1234...abcd \
   --payment-json '{"operator":"0x...",...}'
 
 # Deny
-pnpm start deny 0x1234...abcd \
+pnpm example:arbiter-cli deny 0x1234...abcd \
   --payment-json '{"operator":"0x...",...}'
 ```
 
 ### Execute an Approved Refund
 
 ```bash
-pnpm start execute --payment-json '{"operator":"0x...",...}'
+pnpm example:arbiter-cli execute --payment-json '{"operator":"0x...",...}'
 ```
 
 ### Watch for New Requests
@@ -207,7 +197,7 @@ pnpm start execute --payment-json '{"operator":"0x...",...}'
 Monitor incoming refund requests in real-time:
 
 ```bash
-pnpm start watch
+pnpm example:arbiter-cli watch
 ```
 
 ## Step 8: Merchant Operations (Using Merchant CLI)
@@ -217,10 +207,16 @@ The merchant-cli provides direct access to merchant operations without running a
 ### Setup
 
 ```bash
-cd x402r-sdk/examples/merchant-cli
-pnpm install
+cd x402r-sdk/examples/dev-tools/merchant-cli
 cp .env.example .env
-# Edit .env with your merchant private key
+```
+
+Edit `.env`:
+
+```env
+PRIVATE_KEY=0x...your_merchant_private_key...
+OPERATOR_ADDRESS=0x8140b98ec518843EA1Dd40C42617ACBa71752C33
+FREEZE_ADDRESS=0x6d64A0B25A1494f347941614fc8799B486a603A6
 ```
 
 ### Release Funds
@@ -228,7 +224,7 @@ cp .env.example .env
 After the escrow period passes, release funds to the merchant:
 
 ```bash
-pnpm start release \
+pnpm example:merchant-cli release \
   --payment-json '{"operator":"0x...","payer":"0x...",...}' \
   --amount 10000
 ```
@@ -236,20 +232,20 @@ pnpm start release \
 ### Check Payment Amounts
 
 ```bash
-pnpm start payment-amounts --payment-json '...'
+pnpm example:merchant-cli payment-amounts --payment-json '...'
 ```
 
 ### Approve/Deny Refund Requests
 
 ```bash
 # List pending refunds
-pnpm start pending-refunds
+pnpm example:merchant-cli pending-refunds
 
 # Approve a refund
-pnpm start approve-refund --payment-json '...'
+pnpm example:merchant-cli approve-refund --payment-json '...'
 
 # Or deny it
-pnpm start deny-refund --payment-json '...'
+pnpm example:merchant-cli deny-refund --payment-json '...'
 ```
 
 ## Merchant CLI vs Merchant Server
@@ -263,22 +259,45 @@ pnpm start deny-refund --payment-json '...'
 
 ## Reference Addresses (Base Sepolia)
 
-### Example Operator
+### Short-Escrow Operator (for E2E testing)
+
+5min escrow, 3min freeze window, 1% fee.
 
 | Contract        | Address                                      |
 | --------------- | -------------------------------------------- |
-| PaymentOperator | `0xbb4f390b80E4F4895B96B95AE382B65fDC45974B` |
-| EscrowPeriod    | `0xFcFb7e197823D304D53F47BE1E9761e9D102589b` |
-| Freeze          | `0xD0f99B7667076f151FD8240b277f1765d147e48C` |
+| PaymentOperator | `0x8140b98ec518843EA1Dd40C42617ACBa71752C33` |
+| EscrowPeriod    | `0x0402f5b49126786c01c3e0885767bB11C0199372` |
+| Freeze          | `0x6d64A0B25A1494f347941614fc8799B486a603A6` |
 
 ### Protocol Contracts
 
+Source of truth: `packages/core/src/config/index.ts`
+
 | Contract          | Address                                      |
 | ----------------- | -------------------------------------------- |
-| AuthCaptureEscrow | `0xb9488351E48b23D798f24e8174514F28B741Eb4f` |
-| RefundRequest     | `0x6926c05193c714ED4bA3867Ee93d6816Fdc14128` |
-| ArbiterRegistry   | `0xFcE18CB2f44a85D043E5F86f200dfFc9649622DF` |
+| AuthCaptureEscrow | `0x29025c0E9D4239d438e169570818dB9FE0A80873` |
+| TokenCollector    | `0x5cA789000070DF15b4663DB64a50AeF5D49c5Ee0` |
+| RefundRequest     | `0x1C2Ab244aC8bDdDB74d43389FF34B118aF2E90F4` |
+| ProtocolFeeConfig | `0x8F96C493bAC365E41f0315cf45830069EBbDCaCe` |
+| ArbiterRegistry   | `0x762d562a5ff10EcbFD2Bc4fea663433b84226F35` |
 | USDC              | `0x036CbD53842c5426634e7929541eC2318f3dCF7e` |
+
+## Directory Structure
+
+```
+examples/
+├── deploy-operator/           # Deploy a new operator (pnpm example:deploy-operator)
+├── facilitator/
+│   └── basic/                 # Facilitator server (pnpm example:facilitator)
+├── servers/
+│   ├── express/               # Express merchant server (pnpm example:server:express)
+│   └── hono/                  # Hono merchant server (pnpm example:server:hono)
+└── dev-tools/
+    ├── client-cli/            # Payer CLI (pnpm example:client-cli)
+    ├── merchant-cli/          # Merchant CLI (pnpm example:merchant-cli)
+    ├── arbiter-cli/           # Arbiter CLI (pnpm example:arbiter-cli)
+    └── shared/                # Shared utilities
+```
 
 ## CLI Commands Reference
 
@@ -323,3 +342,15 @@ pnpm start deny-refund --payment-json '...'
 | `watch`                               | Watch for new refund requests in real-time |
 | `count`                               | Get total refund request count             |
 | `info`                                | Show arbiter wallet and config             |
+
+## Known Issues
+
+### `@x402/core` extra field passthrough bug
+
+`@x402/core@2.3.0` has a bug where `buildPaymentRequirementsFromOptions()` drops the `extra` field from payment options. This means escrow-specific config (`operatorAddress`, `escrowAddress`, etc.) set by `refundable()` never reaches the 402 response or the verification path.
+
+**Workaround:** A pnpm patch is applied in this repo (`patches/@x402__core@2.3.0.patch`) that adds `extra: option.extra` to the `resourceConfig` construction in both CJS and ESM builds.
+
+**Upstream:** Fix submitted to `coinbase/x402` — adds `extra` to the inline parameter type and passes it through to `ResourceConfig` in `buildPaymentRequirementsFromOptions()`.
+
+**Impact without patch:** `GET /weather` returns 402 but `extra` is empty — the client cannot construct a valid escrow payment because `operatorAddress` and other required fields are missing.

--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
     "vitest": "^2.1.0"
   },
   "pnpm": {
-    "overrides": {}
+    "overrides": {},
+    "patchedDependencies": {
+      "@x402/core@2.3.0": "patches/@x402__core@2.3.0.patch"
+    }
   },
   "packageManager": "pnpm@9.15.0",
   "engines": {

--- a/patches/@x402__core@2.3.0.patch
+++ b/patches/@x402__core@2.3.0.patch
@@ -1,0 +1,52 @@
+diff --git a/dist/cjs/mechanisms-CP6q1k8-.d.ts b/dist/cjs/mechanisms-CP6q1k8-.d.ts
+index 464908e51b49ced5a72f4ba1dc6ad37f8e40df7c..a5e07537311a18716932c0ea6e85fe3d59c7d8ad 100644
+--- a/dist/cjs/mechanisms-CP6q1k8-.d.ts
++++ b/dist/cjs/mechanisms-CP6q1k8-.d.ts
+@@ -366,6 +366,7 @@ declare class x402ResourceServer {
+         price: Price | ((context: TContext) => Price | Promise<Price>);
+         network: Network;
+         maxTimeoutSeconds?: number;
++        extra?: Record<string, unknown>;
+     }>, context: TContext): Promise<PaymentRequirements[]>;
+     /**
+      * Create a payment required response
+diff --git a/dist/cjs/server/index.js b/dist/cjs/server/index.js
+index 4d683bfd5bdbd0739fb4098bce9b083914b5c977..9233c199f9c34203dd12ea0de4e48dbbf4d98e9c 100644
+--- a/dist/cjs/server/index.js
++++ b/dist/cjs/server/index.js
+@@ -583,7 +583,8 @@ var x402ResourceServer = class {
+         payTo: resolvedPayTo,
+         price: resolvedPrice,
+         network: option.network,
+-        maxTimeoutSeconds: option.maxTimeoutSeconds
++        maxTimeoutSeconds: option.maxTimeoutSeconds,
++        extra: option.extra
+       };
+       const requirements = await this.buildPaymentRequirements(resourceConfig);
+       allRequirements.push(...requirements);
+diff --git a/dist/esm/mechanisms-CP6q1k8-.d.mts b/dist/esm/mechanisms-CP6q1k8-.d.mts
+index 464908e51b49ced5a72f4ba1dc6ad37f8e40df7c..a5e07537311a18716932c0ea6e85fe3d59c7d8ad 100644
+--- a/dist/esm/mechanisms-CP6q1k8-.d.mts
++++ b/dist/esm/mechanisms-CP6q1k8-.d.mts
+@@ -366,6 +366,7 @@ declare class x402ResourceServer {
+         price: Price | ((context: TContext) => Price | Promise<Price>);
+         network: Network;
+         maxTimeoutSeconds?: number;
++        extra?: Record<string, unknown>;
+     }>, context: TContext): Promise<PaymentRequirements[]>;
+     /**
+      * Create a payment required response
+diff --git a/dist/esm/server/index.mjs b/dist/esm/server/index.mjs
+index a0e82eee61d4e1ab8ce27263831decf9bcd688c3..a9c971907c82bf1c99a013cd62f3f3aa04aa5af4 100644
+--- a/dist/esm/server/index.mjs
++++ b/dist/esm/server/index.mjs
+@@ -331,7 +331,8 @@ var x402ResourceServer = class {
+         payTo: resolvedPayTo,
+         price: resolvedPrice,
+         network: option.network,
+-        maxTimeoutSeconds: option.maxTimeoutSeconds
++        maxTimeoutSeconds: option.maxTimeoutSeconds,
++        extra: option.extra
+       };
+       const requirements = await this.buildPaymentRequirements(resourceConfig);
+       allRequirements.push(...requirements);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@x402/core@2.3.0':
+    hash: wng4rpihzpsrif3iprw527ojpy
+    path: patches/@x402__core@2.3.0.patch
+
 importers:
 
   .:
@@ -95,7 +100,7 @@ importers:
         version: link:../../../packages/core
       '@x402r/evm':
         specifier: file:../../../../x402r-scheme/packages/evm
-        version: file:../x402r-scheme/packages/evm(@x402/core@2.3.0)(@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: file:../x402r-scheme/packages/evm(@x402/core@2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy))(@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -148,7 +153,7 @@ importers:
     dependencies:
       '@x402/core':
         specifier: ^2.3.0
-        version: 2.3.0
+        version: 2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy)
       '@x402/evm':
         specifier: ^2.3.0
         version: 2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
@@ -157,7 +162,7 @@ importers:
         version: link:../../../packages/core
       '@x402r/evm':
         specifier: file:../../../../x402r-scheme/packages/evm
-        version: file:../x402r-scheme/packages/evm(@x402/core@2.3.0)(@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: file:../x402r-scheme/packages/evm(@x402/core@2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy))(@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       dotenv:
         specifier: ^16.4.0
         version: 16.6.1
@@ -206,13 +211,13 @@ importers:
     dependencies:
       '@x402/core':
         specifier: ^2.3.0
-        version: 2.3.0
+        version: 2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy)
       '@x402/express':
         specifier: ^2.3.0
-        version: 2.3.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(express@4.22.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+        version: 2.3.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(express@4.22.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@x402r/evm':
         specifier: file:../../../../x402r-scheme/packages/evm
-        version: file:../x402r-scheme/packages/evm(@x402/core@2.3.0)(@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: file:../x402r-scheme/packages/evm(@x402/core@2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy))(@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@x402r/helpers':
         specifier: workspace:*
         version: link:../../../packages/helpers
@@ -270,13 +275,13 @@ importers:
         version: 1.19.9(hono@4.11.7)
       '@x402/core':
         specifier: ^2.3.0
-        version: 2.3.0
+        version: 2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy)
       '@x402/hono':
         specifier: ^2.3.0
         version: 2.3.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hono@4.11.7)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@x402r/evm':
         specifier: file:../../../../x402r-scheme/packages/evm
-        version: file:../x402r-scheme/packages/evm(@x402/core@2.3.0)(@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+        version: file:../x402r-scheme/packages/evm(@x402/core@2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy))(@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
       '@x402r/helpers':
         specifier: workspace:*
         version: link:../../../packages/helpers
@@ -5190,7 +5195,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/kit@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/accounts': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -5203,11 +5208,11 @@ snapshots:
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-parsed-types': 2.3.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/signers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/sysvars': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/transaction-confirmation': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       typescript: 5.9.3
@@ -5412,14 +5417,14 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions-channel-websocket@2.3.0(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       '@solana/functional': 2.3.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.9.3)
       '@solana/subscribable': 2.3.0(typescript@5.9.3)
       typescript: 5.9.3
-      ws: 8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      ws: 7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10)
 
   '@solana/rpc-subscriptions-channel-websocket@5.5.1(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
@@ -5451,7 +5456,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.3
 
-  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/rpc-subscriptions@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/errors': 2.3.0(typescript@5.9.3)
       '@solana/fast-stable-stringify': 2.3.0(typescript@5.9.3)
@@ -5459,7 +5464,7 @@ snapshots:
       '@solana/promises': 2.3.0(typescript@5.9.3)
       '@solana/rpc-spec-types': 2.3.0(typescript@5.9.3)
       '@solana/rpc-subscriptions-api': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions-channel-websocket': 2.3.0(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/rpc-subscriptions-spec': 2.3.0(typescript@5.9.3)
       '@solana/rpc-transformers': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -5647,7 +5652,7 @@ snapshots:
     transitivePeerDependencies:
       - fastestsmallesttextencoderdecoder
 
-  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@solana/transaction-confirmation@2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@solana/addresses': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/codecs-strings': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -5655,7 +5660,7 @@ snapshots:
       '@solana/keys': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/promises': 2.3.0(typescript@5.9.3)
       '@solana/rpc': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
-      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@solana/rpc-subscriptions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       '@solana/rpc-types': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transaction-messages': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
       '@solana/transactions': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)
@@ -6043,13 +6048,13 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
-  '@x402/core@2.3.0':
+  '@x402/core@2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy)':
     dependencies:
       zod: 3.25.76
 
   '@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@x402/core': 2.3.0
+      '@x402/core': 2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy)
       viem: 2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -6057,11 +6062,11 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402/express@2.3.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(express@4.22.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
+  '@x402/express@2.3.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(express@4.22.1)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))':
     dependencies:
       '@coinbase/cdp-sdk': 1.44.0(bufferutil@4.1.0)(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(utf-8-validate@5.0.10)
-      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@8.18.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))
-      '@x402/core': 2.3.0
+      '@solana/kit': 2.3.0(fastestsmallesttextencoderdecoder@1.0.22)(typescript@5.9.3)(ws@7.5.10(bufferutil@4.1.0)(utf-8-validate@5.0.10))
+      '@x402/core': 2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy)
       '@x402/extensions': 2.3.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
       express: 4.22.1
       viem: 2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
@@ -6079,7 +6084,7 @@ snapshots:
   '@x402/extensions@2.3.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
       '@scure/base': 1.2.6
-      '@x402/core': 2.3.0
+      '@x402/core': 2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy)
       ajv: 8.17.1
       siwe: 2.3.2(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))
       tweetnacl: 1.0.3
@@ -6093,7 +6098,7 @@ snapshots:
 
   '@x402/hono@2.3.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(hono@4.11.7)(typescript@5.9.3)(utf-8-validate@5.0.10)':
     dependencies:
-      '@x402/core': 2.3.0
+      '@x402/core': 2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy)
       '@x402/extensions': 2.3.0(bufferutil@4.1.0)(ethers@6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(typescript@5.9.3)(utf-8-validate@5.0.10)
       hono: 4.11.7
       zod: 3.25.76
@@ -6103,9 +6108,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402r/evm@file:../x402r-scheme/packages/evm(@x402/core@2.3.0)(@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
+  '@x402r/evm@file:../x402r-scheme/packages/evm(@x402/core@2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy))(@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))':
     dependencies:
-      '@x402/core': 2.3.0
+      '@x402/core': 2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy)
       '@x402/evm': 2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       viem: 2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
 


### PR DESCRIPTION
## Summary

- Apply pnpm patch to `@x402/core@2.3.0` to fix `extra` field passthrough in `buildPaymentRequirementsFromOptions()` — without this patch, escrow config (`operatorAddress`, `escrowAddress`, etc.) set by `refundable()` is silently dropped from the 402 response
- Rewrite `docs/EXAMPLES_GUIDE.md` fixing 10+ inaccuracies from recent refactors (paths, ports, commands, addresses, env templates)
- Add known issues section documenting the upstream bug and our patch workaround

### Upstream

Fix submitted to coinbase/x402 — patch can be removed once `@x402/core` releases with the fix.

### Docs fixes

| Issue | Old (wrong) | New (correct) |
|-------|------------|---------------|
| Facilitator path | `examples/facilitator` | `examples/facilitator/basic` |
| Merchant server path | `examples/merchant-server` | `examples/servers/express` |
| Client CLI path | `examples/client-cli` | `examples/dev-tools/client-cli` |
| Merchant server port | `localhost:3000` | `localhost:4021` |
| Merchant server command | `pnpm example:merchant-server` | `pnpm example:server:express` |
| Start command | `pnpm dev` | `pnpm example:facilitator` / `pnpm example:server:express` |
| Env template | `.env.example` | `.env-local` (facilitator/express) |
| Operator address | `0xbb4f39...` | `0x8140b9...` (short-escrow) |
| Protocol addresses | Old contracts | Current from `@x402r/core/config` |
| Facilitator env | Has `OPERATOR_ADDRESS` | Facilitator is operator-agnostic |

## Test plan

- [x] `pnpm install` applies patch successfully
- [x] `pnpm build` passes
- [x] All SDK tests pass
- [x] E2E: facilitator `/supported` returns escrow scheme
- [x] E2E: express `GET /weather` returns 402 with `operatorAddress` in `extra`
- [x] E2E: client CLI `pay` succeeds, weather data returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)