### PR TITLE
Add env var support to deploy-operator example

### DIFF
--- a/examples/deploy-operator/.env.example
+++ b/examples/deploy-operator/.env.example
@@ -1,0 +1,27 @@
+# Deploy Operator configuration
+# Copy this file to .env and fill in the values
+
+# Required: deployer private key with ETH for gas
+# Get testnet ETH: https://www.coinbase.com/faucets/base-ethereum-sepolia-faucet
+PRIVATE_KEY=0x...
+
+# Arbiter address for dispute resolution (default: deployer address)
+# ARBITER=0x...
+
+# Address that receives operator fees (default: deployer address)
+# FEE_RECIPIENT=0x...
+
+# Escrow period in seconds (default: 604800 = 7 days)
+# ESCROW_PERIOD=604800
+
+# Freeze duration in seconds (default: 259200 = 3 days)
+# FREEZE_DURATION=259200
+
+# Operator fee in basis points, 100 = 1% (default: 100)
+# FEE_BPS=100
+
+# Network (default: eip155:84532 = Base Sepolia)
+# NETWORK_ID=eip155:84532
+
+# RPC URL (default: https://sepolia.base.org)
+# RPC_URL=https://sepolia.base.org

--- a/examples/deploy-operator/README.md
+++ b/examples/deploy-operator/README.md
@@ -10,13 +10,25 @@ Deploy a complete marketplace payment operator with escrow, freeze, and arbiter 
 
 ## Usage
 
-```bash
-PRIVATE_KEY=0x... pnpm start
-```
+1. Copy the `.env.example` and fill in your private key:
+   ```bash
+   cp .env.example .env
+   # Edit .env with your PRIVATE_KEY
+   ```
 
-Or using tsx directly from the SDK root:
+2. Run the deployment:
+   ```bash
+   pnpm start
+   ```
+
+Or pass env vars inline from the SDK root:
 ```bash
 PRIVATE_KEY=0x... pnpm tsx examples/deploy-operator/index.ts
+```
+
+With custom configuration:
+```bash
+PRIVATE_KEY=0x... ARBITER=0xArbiterAddr ESCROW_PERIOD=86400 FEE_BPS=50 pnpm tsx examples/deploy-operator/index.ts
 ```
 
 ## What Gets Deployed
@@ -41,17 +53,18 @@ The deployment script composes conditions for refund authorization:
 
 This means disputes can be resolved by the arbiter while escrow is active, but once the escrow period passes, only the merchant retains refund authority.
 
-## Default Configuration
+## Environment Variables
 
-```typescript
-{
-  feeRecipient: <your address>,     // Receives operator fees
-  arbiter: <your address>,          // Self as arbiter (for testing)
-  escrowPeriodSeconds: 604800n,     // 7 days
-  freezeDurationSeconds: 259200n,   // 3 days max freeze
-  operatorFeeBps: 100n,             // 1% operator fee
-}
-```
+| Variable | Required | Default | Description |
+|----------|----------|---------|-------------|
+| `PRIVATE_KEY` | Yes | — | Deployer wallet private key |
+| `ARBITER` | No | deployer address | Arbiter address for dispute resolution |
+| `FEE_RECIPIENT` | No | deployer address | Address that receives operator fees |
+| `ESCROW_PERIOD` | No | `604800` (7 days) | Escrow period in seconds |
+| `FREEZE_DURATION` | No | `259200` (3 days) | Freeze duration in seconds |
+| `FEE_BPS` | No | `100` (1%) | Operator fee in basis points |
+| `NETWORK_ID` | No | `eip155:84532` | Chain identifier |
+| `RPC_URL` | No | `https://sepolia.base.org` | RPC endpoint |
 
 ## Output
 
@@ -117,17 +130,19 @@ After deployment:
 
 ## Customization
 
-To customize the operator, edit `index.ts`:
+Set env vars to customize the operator — no need to edit the script:
 
-```typescript
-const options = {
-  feeRecipient: '0x...custom_address...',
-  arbiter: '0x...arbiter_address...',
-  escrowPeriodSeconds: 86400n,      // 1 day
-  freezeDurationSeconds: 0n,         // No freeze limit
-  operatorFeeBps: 50n,               // 0.5% fee
-};
+```bash
+# 1-day escrow, no freeze limit, 0.5% fee, custom arbiter
+PRIVATE_KEY=0x... \
+  ARBITER=0xArbiterAddr \
+  ESCROW_PERIOD=86400 \
+  FREEZE_DURATION=0 \
+  FEE_BPS=50 \
+  pnpm start
 ```
+
+See `.env.example` for all available options.
 
 ## Deterministic Addresses
 

--- a/examples/deploy-operator/index.ts
+++ b/examples/deploy-operator/index.ts
@@ -10,9 +10,19 @@
  *
  * Usage:
  *   PRIVATE_KEY=0x... pnpm example:deploy-operator
+ *
+ * Environment variables:
+ *   PRIVATE_KEY      (required) Deployer wallet private key
+ *   ARBITER          Arbiter address for disputes (default: deployer)
+ *   FEE_RECIPIENT    Address that receives fees (default: deployer)
+ *   ESCROW_PERIOD    Escrow period in seconds (default: 604800 = 7 days)
+ *   FREEZE_DURATION  Freeze duration in seconds (default: 259200 = 3 days)
+ *   FEE_BPS          Operator fee in basis points (default: 100 = 1%)
+ *   NETWORK_ID       Chain identifier (default: eip155:84532)
+ *   RPC_URL          RPC endpoint (default: https://sepolia.base.org)
  */
 
-import { createWalletClient, createPublicClient, http, formatEther } from "viem";
+import { createWalletClient, createPublicClient, http, formatEther, type Address } from "viem";
 import { baseSepolia } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
 import {
@@ -20,9 +30,9 @@ import {
   previewMarketplaceOperator,
 } from "../../packages/core/dist/index.js";
 
-// Network configuration
-const NETWORK_ID = "eip155:84532"; // Base Sepolia
-const RPC_URL = "https://sepolia.base.org";
+// Network configuration (overridable via env vars)
+const NETWORK_ID = process.env.NETWORK_ID ?? "eip155:84532";
+const RPC_URL = process.env.RPC_URL ?? "https://sepolia.base.org";
 
 async function main() {
   // Get private key from environment
@@ -60,13 +70,13 @@ async function main() {
     process.exit(1);
   }
 
-  // Configuration for the marketplace operator
+  // Configuration — reads from env vars, falls back to sensible defaults
   const options = {
-    feeRecipient: account.address, // Receive operator fees
-    arbiter: account.address, // Self as arbiter for testing
-    escrowPeriodSeconds: 604800n, // 7 days
-    freezeDurationSeconds: 259200n, // 3 days max freeze
-    operatorFeeBps: 100n, // 1% operator fee
+    feeRecipient: (process.env.FEE_RECIPIENT ?? account.address) as Address,
+    arbiter: (process.env.ARBITER ?? account.address) as Address,
+    escrowPeriodSeconds: BigInt(process.env.ESCROW_PERIOD ?? "604800"), // 7 days
+    freezeDurationSeconds: BigInt(process.env.FREEZE_DURATION ?? "259200"), // 3 days
+    operatorFeeBps: BigInt(process.env.FEE_BPS ?? "100"), // 1%
   };
 
   console.log("\n--- Configuration ---");


### PR DESCRIPTION
## Summary
- Deploy-operator script now reads config from env vars (`ARBITER`, `FEE_RECIPIENT`, `ESCROW_PERIOD`, `FREEZE_DURATION`, `FEE_BPS`, `NETWORK_ID`, `RPC_URL`) with sensible defaults matching previous hardcoded values
- Added `.env.example` file documenting all available env vars
- Updated README with env var table and usage examples

## Test plan
- [x] Ran deployment with only `PRIVATE_KEY` — uses all defaults, same behavior as before
- [x] Ran deployment with custom env vars (`ESCROW_PERIOD=86400 FREEZE_DURATION=43200 FEE_BPS=50`) — correctly picks up overrides and produces different deterministic addresses
- [x] Pre-commit hooks pass (typecheck, lint, format, docs:generate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)