### PR TITLE
Add RefundRequestEvidence deployed addresses

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -297,6 +297,7 @@ export const NETWORK_CONFIG: Record<string, NetworkConfig> = {
     usdcTvlLimit: "0xb33D6502EdBbC47201cd1E53C49d703EC0a660b8",
     arbiterRegistry: "0xE78648e7af7B1BaDE717FF6E410B922F92adE80f",
     usdc: "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
+    refundRequestEvidence: "0x19a798c7F66E6401f6004b732dA604196952e843",
     factories: {
       paymentOperator: "0x32d6AC59BCe8DFB3026F10BcaDB8D00AB218f5b6",
       escrowPeriod: "0x2714EA3e839Ac50F52B2e2a5788F614cACeE5316",


### PR DESCRIPTION
## Summary
- Adds `refundRequestEvidence` optional field to `NetworkConfig` interface
- Populates deployed + verified addresses for all 10 chains

| Chain | Address |
|-------|---------|
| Base Sepolia | `0x917317BBBBe1b9b53BD0ceD4C7b7386Dbd1727ea` |
| Base Mainnet | `0x2176D0edfeC9e2B8d3FDbB37f09535BEe4BAFB34` |
| Ethereum Sepolia | `0xd709e87DF198eF3C15C5eaE81E3EbD8Fd7AC908a` |
| Ethereum Mainnet | `0x12EDefd4549c53497689067f165c0f101796Eb6D` |
| Polygon | `0xe4f1840171E31DaD221C6b25FED91bcB1A431A8C` |
| Arbitrum | `0xd709e87DF198eF3C15C5eaE81E3EbD8Fd7AC908a` |
| Celo | `0xd709e87DF198eF3C15C5eaE81E3EbD8Fd7AC908a` |
| Optimism | `0xd709e87DF198eF3C15C5eaE81E3EbD8Fd7AC908a` |
| Avalanche | `0xd709e87DF198eF3C15C5eaE81E3EbD8Fd7AC908a` |
| Monad | `0x19a798c7F66E6401f6004b732dA604196952e843` |

## Test plan
- [x] `pnpm build` — all 5 packages build successfully
- [x] `pnpm typecheck` — passes
- [x] `pnpm lint` — passes
- [x] All contracts verified on respective block explorers

🤖 Generated with [Claude Code](https://claude.com/claude-code)