### PR TITLE
Implement PaymentInfo recovery after restart (Tech Debt #14)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Production TypeScript SDK for the x402r refundable payments protocol.
 ```bash
 pnpm install
 pnpm build              # Build all packages (Turborepo)
-pnpm test               # Run all tests (413 vitest tests across 30 files, 5 packages)
+pnpm test               # Run all tests (vitest, 33 test files across 5 packages)
 pnpm test:coverage      # Run with coverage
 pnpm typecheck          # Type check all packages
 pnpm lint               # Lint code
@@ -29,7 +29,7 @@ All packages live in `packages/` and are built via Turborepo.
 
 ## Contract Address Source of Truth
 
-`packages/core/src/config/index.ts` — canonical contract addresses for Base Sepolia and Base Mainnet. All other repos should reference this file.
+`packages/core/src/config/index.ts` — canonical contract addresses for 10 networks (deployed; only Base Sepolia tested). All other repos should reference this file.
 
 ## Key Files
 
@@ -60,9 +60,13 @@ pnpm --filter @x402r/helpers test
 | Example | Script | Description |
 |---------|--------|-------------|
 | `deploy-operator` | `pnpm example:deploy-operator` | Deploy a marketplace operator |
+| `facilitator` | `pnpm example:facilitator` | Facilitator server (verify/settle) |
+| `server:express` | `pnpm example:server:express` | Express merchant server |
+| `server:hono` | `pnpm example:server:hono` | Hono merchant server |
+| `client-cli` | `pnpm example:client-cli` | Client CLI (payer operations) |
+| `merchant-cli` | `pnpm example:merchant-cli` | Merchant CLI (release, refunds) |
+| `arbiter-cli` | `pnpm example:arbiter-cli` | Arbiter CLI (dispute resolution) |
 | `e2e-test` | `PRIVATE_KEY=0x... pnpm example:e2e-test` | Full payment lifecycle on Base Sepolia |
-| `client-cli` | `pnpm example:client-cli` | Client SDK usage patterns |
-| `arbiter-cli` | `pnpm example:arbiter-cli` | Arbiter SDK usage patterns |
 
 ## E2E Test Key Learnings
 

--- a/README.md
+++ b/README.md
@@ -52,38 +52,38 @@ pnpm docs:watch
 
 ## Running Examples
 
-The SDK includes working examples for a complete payment flow:
+The SDK includes working examples for a complete payment flow. All commands run from the SDK root.
 
 ```bash
-# 1. Deploy an operator (one-time setup)
+# 1. Deploy an operator (one-time setup — or use the pre-deployed one below)
 PRIVATE_KEY=0x... pnpm example:deploy-operator
 
-# 2. Start the facilitator service
-cd examples/facilitator && cp .env.example .env  # Configure with PRIVATE_KEY + OPERATOR_ADDRESS
-pnpm dev
+# 2. Start the facilitator (new terminal)
+# Configure examples/facilitator/basic/.env first (copy from .env-local)
+pnpm example:facilitator
 
-# 3. Start the merchant server (in a new terminal)
-cd examples/merchant-server && cp .env.example .env  # Configure with PRIVATE_KEY, OPERATOR_ADDRESS, FACILITATOR_URL
-pnpm example:merchant-server
+# 3. Start the merchant server (new terminal)
+# Configure examples/servers/express/.env first (copy from .env-local)
+pnpm example:server:express
 
-# 4. Make a payment with the client CLI (in a new terminal)
-cd examples/client-cli && cp .env.example .env  # Configure first
-pnpm example:client-cli pay --url http://localhost:3000/weather
+# 4. Make a payment (new terminal)
+# Configure examples/dev-tools/client-cli/.env first (copy from .env.example)
+pnpm example:client-cli pay --url http://localhost:4021/weather
 ```
 
 The flow is: Client -> Merchant Server -> Facilitator -> Blockchain. The merchant server uses x402's standard `paymentMiddleware` and delegates verify/settle to the facilitator service.
 
-See the [Examples Guide](./docs/EXAMPLES_GUIDE.md) for the complete walkthrough including freeze and refund operations.
+See the [Examples Guide](./docs/EXAMPLES_GUIDE.md) for the complete walkthrough including freeze, refund, and arbiter operations.
 
 ### Pre-deployed Test Operator (Base Sepolia)
 
-Use this operator for testing:
+Short-escrow operator for testing (5min escrow, 3min freeze window, 1% fee):
 
 | Contract        | Address                                      |
 | --------------- | -------------------------------------------- |
-| PaymentOperator | `0xbb4f390b80E4F4895B96B95AE382B65fDC45974B` |
-| Freeze          | `0xD0f99B7667076f151FD8240b277f1765d147e48C` |
-| EscrowPeriod    | `0xFcFb7e197823D304D53F47BE1E9761e9D102589b` |
+| PaymentOperator | `0x8140b98ec518843EA1Dd40C42617ACBa71752C33` |
+| EscrowPeriod    | `0x0402f5b49126786c01c3e0885767bB11C0199372` |
+| Freeze          | `0x6d64A0B25A1494f347941614fc8799B486a603A6` |
 
 ## Documentation
 
@@ -93,15 +93,17 @@ Use this operator for testing:
 
 ## Network Support
 
-| Network      | Chain ID | Status       |
-| ------------ | -------- | ------------ |
-| Base Sepolia | 84532    | ✅ Supported |
-| Base Mainnet | 8453     | 🚧 Pending   |
+| Network | Chain ID | Status |
+| ------- | -------- | ------ |
+| Base Sepolia | 84532 | ✅ Tested |
+| Base Mainnet | 8453 | 🚧 Deployed, not yet tested |
+| Ethereum, Ethereum Sepolia, Polygon, Arbitrum, Optimism, Avalanche, Celo, Monad | various | 🚧 Deployed, not yet tested |
+
+Contracts are deployed to 10 networks. Addresses: `packages/core/src/config/index.ts`.
 
 ## Known Limitations
 
-- `client.getPaymentDetails()` throws `NotImplementedError` — cannot reverse a hash to PaymentInfo without a subgraph. Store PaymentInfo locally when creating payments.
-- All other query methods (`getPaymentState()`, `paymentExists()`, `isInEscrow()`, `getPayerPayments()`, `getReceiverPayments()`, `getPaymentAmounts()`) read directly from on-chain contracts.
+- All query methods (`getPaymentDetails()`, `getPaymentState()`, `paymentExists()`, `isInEscrow()`, `getPayerPayments()`, `getReceiverPayments()`, `getPaymentAmounts()`) read directly from on-chain contracts.
 - All write operations (refunds, releases, charges) work directly on-chain.
 
 ## License

--- a/examples/deploy-operator/README.md
+++ b/examples/deploy-operator/README.md
@@ -110,23 +110,24 @@ Freeze: 0xD0f99B7667076f151FD8240b277f1765d147e48C
 
 ## Next Steps
 
-After deployment:
+After deployment, test the full payment flow. From the SDK root:
 
-1. **Configure merchant server:**
+1. **Configure and start the merchant server:**
    ```bash
-   cd ../merchant-server
-   cp .env.example .env
-   # Add the deployed addresses to .env
+   cd examples/servers/express
+   cp .env-local .env
+   # Add OPERATOR_ADDRESS=<your deployed operator address> to .env
+   ```
+   ```bash
+   pnpm example:server:express
    ```
 
-2. **Test the payment flow:**
+2. **Make a payment:**
    ```bash
-   # Start merchant
-   cd ../merchant-server && pnpm start
-
-   # Make payment
-   cd ../client-cli && pnpm start pay --url http://localhost:3000/weather
+   pnpm example:client-cli pay --url http://localhost:4021/weather
    ```
+
+See the [Examples Guide](../../docs/EXAMPLES_GUIDE.md) for the full walkthrough.
 
 ## Customization
 

--- a/examples/dev-tools/client-cli/README.md
+++ b/examples/dev-tools/client-cli/README.md
@@ -6,7 +6,7 @@ A command-line tool for making x402r payments, freezing payments, and requesting
 
 - Node.js 20+
 - Private key with Base Sepolia ETH and USDC
-- A running merchant server (see `../merchant-server`)
+- A running merchant server (see `../../servers/express` or the [Examples Guide](../../../docs/EXAMPLES_GUIDE.md))
 
 ## Setup
 

--- a/examples/e2e-test/payment-recovery.ts
+++ b/examples/e2e-test/payment-recovery.ts
@@ -1,0 +1,440 @@
+/**
+ * E2E Test: PaymentInfo Recovery After Restart
+ *
+ * Tests the payment recovery feature (Tech Debt #14):
+ *   1. Deploy operator → Authorize payment
+ *   2. Create NEW client (simulates restart) → getPaymentDetails() via escrow events
+ *   3. Verify cache-fill → getPaymentDetails() from MemoryPaymentStore
+ *   4. Create THIRD client with empty store → verify event fallback still works
+ *   5. getPayerPayments() returns full PaymentInfo[]
+ *   6. FilePaymentStore: save → delete → re-recover from events
+ *
+ * Usage:
+ *   PRIVATE_KEY=0x... pnpm tsx examples/e2e-test/payment-recovery.ts
+ */
+
+import {
+  createPublicClient,
+  createWalletClient,
+  http,
+  formatUnits,
+  type Address,
+  type PublicClient,
+  erc20Abi,
+} from "viem";
+import { baseSepolia } from "viem/chains";
+import { mnemonicToAccount, privateKeyToAccount, generateMnemonic } from "viem/accounts";
+import { english } from "viem/accounts";
+import { mkdtempSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  deployMarketplaceOperator,
+  getNetworkConfig,
+  resolveAddresses,
+  toAbiPaymentInfo,
+  computeEscrowNonce,
+  signERC3009Authorization,
+  computePaymentInfoHash,
+  PaymentOperatorABI,
+  AuthCaptureEscrowABI,
+  MemoryPaymentStore,
+  FilePaymentStore,
+  type PaymentInfo,
+} from "../../packages/core/dist/index.js";
+import { X402rClient } from "../../packages/client/dist/index.js";
+import { X402rMerchant } from "../../packages/merchant/dist/index.js";
+
+// ============ Configuration ============
+
+const NETWORK_ID = process.env.NETWORK_ID ?? "eip155:84532";
+const RPC_URL = process.env.RPC_URL ?? "https://sepolia.base.org";
+const USDC_ADDRESS = "0x036CbD53842c5426634e7929541eC2318f3dCF7e" as Address;
+const PAYMENT_AMOUNT = 10000n; // 0.01 USDC
+const GAS_FUNDING = 10000000000000n;
+
+// ============ Helpers ============
+
+let passed = 0;
+let failed = 0;
+
+function log(msg: string) {
+  console.log(`  ${msg}`);
+}
+
+function step(name: string) {
+  console.log(`\n${"=".repeat(60)}`);
+  console.log(`STEP: ${name}`);
+  console.log("=".repeat(60));
+}
+
+function pass(name: string) {
+  console.log(`  ✓ PASS: ${name}`);
+  passed++;
+}
+
+function fail(name: string, error: string) {
+  console.log(`  ✗ FAIL: ${name}`);
+  console.log(`    error: ${error}`);
+  failed++;
+}
+
+function assert(condition: boolean, name: string, errorMsg?: string) {
+  if (condition) {
+    pass(name);
+  } else {
+    fail(name, errorMsg ?? "Assertion failed");
+  }
+}
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function waitForTx(publicClient: PublicClient, hash: `0x${string}`) {
+  const receipt = await publicClient.waitForTransactionReceipt({ hash, confirmations: 1 });
+  if (receipt.status !== "success") {
+    throw new Error(`Transaction reverted: ${hash}`);
+  }
+  await sleep(2000);
+  return receipt;
+}
+
+// ============ Main ============
+
+async function main() {
+  console.log("╔══════════════════════════════════════════════════════════╗");
+  console.log("║    x402r E2E: PaymentInfo Recovery After Restart       ║");
+  console.log("╚══════════════════════════════════════════════════════════╝");
+
+  const privateKey = process.env.PRIVATE_KEY as `0x${string}`;
+  if (!privateKey) {
+    console.error("Error: PRIVATE_KEY environment variable required");
+    process.exit(1);
+  }
+
+  // ---- Setup ----
+  step("1. Setup Accounts");
+
+  const mnemonic = generateMnemonic(english);
+  const payerAccount = privateKeyToAccount(privateKey);
+  const merchantAccount = mnemonicToAccount(mnemonic, { addressIndex: 0 });
+
+  log(`Payer:    ${payerAccount.address}`);
+  log(`Merchant: ${merchantAccount.address}`);
+
+  const publicClient = createPublicClient({
+    chain: baseSepolia,
+    transport: http(RPC_URL),
+  });
+
+  const payerWallet = createWalletClient({
+    account: payerAccount,
+    chain: baseSepolia,
+    transport: http(RPC_URL),
+  });
+
+  const merchantWallet = createWalletClient({
+    account: merchantAccount,
+    chain: baseSepolia,
+    transport: http(RPC_URL),
+  });
+
+  // Balance checks
+  const ethBalance = await publicClient.getBalance({ address: payerAccount.address });
+  const usdcBalance = await publicClient.readContract({
+    address: USDC_ADDRESS,
+    abi: erc20Abi,
+    functionName: "balanceOf",
+    args: [payerAccount.address],
+  });
+  log(`ETH: ${(Number(ethBalance) / 1e18).toFixed(6)}, USDC: ${formatUnits(usdcBalance, 6)}`);
+
+  if (ethBalance < GAS_FUNDING * 3n || usdcBalance < PAYMENT_AMOUNT) {
+    console.error("Insufficient balance");
+    process.exit(1);
+  }
+
+  const networkConfig = getNetworkConfig(NETWORK_ID);
+  const addresses = resolveAddresses(NETWORK_ID);
+
+  // ---- Deploy operator ----
+  step("2. Deploy Operator");
+
+  const deployStartBlock = await publicClient.getBlockNumber();
+
+  const deployResult = await deployMarketplaceOperator(payerWallet, publicClient, NETWORK_ID, {
+    feeRecipient: payerAccount.address,
+    arbiter: payerAccount.address,
+    escrowPeriodSeconds: 604800n,
+    freezeDurationSeconds: 259200n,
+    operatorFeeBps: 100n,
+  });
+
+  log(`Operator: ${deployResult.operatorAddress}`);
+  pass("Deploy operator");
+
+  // ---- Authorize payment ----
+  step("3. Authorize Payment");
+
+  const now = BigInt(Math.floor(Date.now() / 1000));
+
+  const paymentInfo: PaymentInfo = {
+    operator: deployResult.operatorAddress as Address,
+    payer: payerAccount.address,
+    receiver: merchantAccount.address,
+    token: USDC_ADDRESS,
+    maxAmount: PAYMENT_AMOUNT,
+    preApprovalExpiry: now + 3600n,
+    authorizationExpiry: now + 3600n,
+    refundExpiry: now + 864000n,
+    minFeeBps: 0,
+    maxFeeBps: 10000,
+    feeReceiver: deployResult.operatorAddress as Address,
+    salt: BigInt(Date.now()),
+  };
+
+  const escrowNonce = computeEscrowNonce(
+    paymentInfo,
+    networkConfig.authCaptureEscrow as Address,
+    84532,
+  );
+
+  const erc3009Signature = await signERC3009Authorization(payerWallet, USDC_ADDRESS, {
+    from: payerAccount.address,
+    to: networkConfig.tokenCollector as `0x${string}`,
+    value: PAYMENT_AMOUNT,
+    validAfter: 0n,
+    validBefore: paymentInfo.preApprovalExpiry,
+    nonce: escrowNonce,
+  });
+
+  const authorizeTx = await payerWallet.writeContract({
+    address: deployResult.operatorAddress as Address,
+    abi: PaymentOperatorABI,
+    functionName: "authorize",
+    args: [
+      toAbiPaymentInfo(paymentInfo),
+      PAYMENT_AMOUNT,
+      networkConfig.tokenCollector,
+      erc3009Signature,
+    ],
+    chain: baseSepolia,
+    account: payerAccount,
+  });
+  await waitForTx(publicClient, authorizeTx);
+
+  const escrowHash = computePaymentInfoHash(
+    paymentInfo,
+    networkConfig.authCaptureEscrow as Address,
+    84532,
+  );
+  log(`Payment hash: ${escrowHash.slice(0, 18)}...`);
+
+  // Verify funds in escrow
+  const escrowState = (await publicClient.readContract({
+    address: networkConfig.authCaptureEscrow as Address,
+    abi: AuthCaptureEscrowABI,
+    functionName: "paymentState",
+    args: [escrowHash],
+  })) as [boolean, bigint, bigint];
+
+  assert(escrowState[1] > 0n, "Funds in escrow after authorize");
+
+  // ======================================================================
+  // CORE TESTS: PaymentInfo Recovery
+  // ======================================================================
+
+  // ---- Test A: New client with NO store → recover from escrow events ----
+  step("4. Recovery via Escrow Events (no store)");
+
+  const clientNoStore = new X402rClient({
+    publicClient,
+    walletClient: payerWallet,
+    operatorAddress: deployResult.operatorAddress as Address,
+    escrowAddress: addresses.escrowAddress,
+    refundRequestAddress: addresses.refundRequestAddress,
+    chainId: addresses.chainId,
+    // No paymentStore — pure event fallback
+  });
+
+  const recoveredFromEvents = await clientNoStore.getPaymentDetails(escrowHash, deployStartBlock);
+
+  assert(
+    recoveredFromEvents.operator.toLowerCase() === paymentInfo.operator.toLowerCase(),
+    "Recovered operator matches",
+  );
+  assert(
+    recoveredFromEvents.payer.toLowerCase() === paymentInfo.payer.toLowerCase(),
+    "Recovered payer matches",
+  );
+  assert(
+    recoveredFromEvents.receiver.toLowerCase() === paymentInfo.receiver.toLowerCase(),
+    "Recovered receiver matches",
+  );
+  assert(recoveredFromEvents.maxAmount === paymentInfo.maxAmount, "Recovered maxAmount matches");
+  assert(recoveredFromEvents.salt === paymentInfo.salt, "Recovered salt matches");
+  assert(recoveredFromEvents.minFeeBps === paymentInfo.minFeeBps, "Recovered minFeeBps matches");
+  assert(recoveredFromEvents.maxFeeBps === paymentInfo.maxFeeBps, "Recovered maxFeeBps matches");
+
+  // ---- Test B: MemoryPaymentStore — cache-fill + instant lookup ----
+  step("5. MemoryPaymentStore Cache-Fill");
+
+  const memStore = new MemoryPaymentStore();
+
+  const clientWithMemStore = new X402rClient({
+    publicClient,
+    walletClient: payerWallet,
+    operatorAddress: deployResult.operatorAddress as Address,
+    escrowAddress: addresses.escrowAddress,
+    refundRequestAddress: addresses.refundRequestAddress,
+    chainId: addresses.chainId,
+    paymentStore: memStore,
+  });
+
+  // First call: should hit events, then cache-fill
+  const recovered2 = await clientWithMemStore.getPaymentDetails(escrowHash, deployStartBlock);
+  assert(recovered2.salt === paymentInfo.salt, "Event fallback → cache-fill works");
+
+  // Verify it was saved to store
+  const cached = await memStore.load(escrowHash);
+  assert(cached !== null, "PaymentInfo saved to MemoryPaymentStore after event lookup");
+  assert(cached!.salt === paymentInfo.salt, "Cached salt matches original");
+
+  // Second call: should come from store (no RPC needed)
+  // We can't easily verify it didn't hit RPC, but let's confirm it returns correctly
+  const fromCache = await clientWithMemStore.getPaymentDetails(escrowHash, deployStartBlock);
+  assert(fromCache.salt === paymentInfo.salt, "Subsequent lookup from cache returns correct data");
+
+  // ---- Test C: getPayerPayments() returns full PaymentInfo ----
+  step("6. getPayerPayments() Returns Full PaymentInfo");
+
+  const payments = await clientWithMemStore.getPayerPayments(deployStartBlock);
+  assert(payments.length > 0, "getPayerPayments returns at least 1 payment");
+  assert(payments[0].hash === escrowHash, "First payment hash matches");
+  assert(
+    payments[0].paymentInfo.salt === paymentInfo.salt,
+    "First payment PaymentInfo.salt matches",
+  );
+  assert(
+    payments[0].paymentInfo.payer.toLowerCase() === payerAccount.address.toLowerCase(),
+    "First payment payer matches wallet",
+  );
+
+  // ---- Test D: FilePaymentStore — persist, delete, re-recover ----
+  step("7. FilePaymentStore Persistence & Recovery");
+
+  const tmpDir = mkdtempSync(join(tmpdir(), "x402r-e2e-"));
+  log(`Temp dir: ${tmpDir}`);
+
+  try {
+    const fileStore = new FilePaymentStore(tmpDir);
+
+    const clientWithFileStore = new X402rClient({
+      publicClient,
+      walletClient: payerWallet,
+      operatorAddress: deployResult.operatorAddress as Address,
+      escrowAddress: addresses.escrowAddress,
+      refundRequestAddress: addresses.refundRequestAddress,
+      chainId: addresses.chainId,
+      paymentStore: fileStore,
+    });
+
+    // First call: populate file store from events
+    const fromFile1 = await clientWithFileStore.getPaymentDetails(escrowHash, deployStartBlock);
+    assert(fromFile1.salt === paymentInfo.salt, "FilePaymentStore: event fallback works");
+
+    // Verify file exists
+    const filePath = join(tmpDir, `${escrowHash}.json`);
+    assert(existsSync(filePath), "FilePaymentStore: JSON file created on disk");
+
+    // New FilePaymentStore instance (simulates restart) — should load from file
+    const fileStore2 = new FilePaymentStore(tmpDir);
+    const fromFile2 = await fileStore2.load(escrowHash);
+    assert(fromFile2 !== null, "FilePaymentStore: survives new instance (simulated restart)");
+    assert(fromFile2!.salt === paymentInfo.salt, "FilePaymentStore: persisted data matches");
+
+    // Delete the cache directory (simulates disk wipe)
+    rmSync(tmpDir, { recursive: true, force: true });
+    assert(!existsSync(filePath), "FilePaymentStore: cache directory deleted");
+
+    // New store pointing to wiped directory + new client
+    const fileStore3 = new FilePaymentStore(tmpDir);
+    const clientAfterWipe = new X402rClient({
+      publicClient,
+      walletClient: payerWallet,
+      operatorAddress: deployResult.operatorAddress as Address,
+      escrowAddress: addresses.escrowAddress,
+      refundRequestAddress: addresses.refundRequestAddress,
+      chainId: addresses.chainId,
+      paymentStore: fileStore3,
+    });
+
+    // Should recover from events again since cache was wiped
+    const fromFile3 = await clientAfterWipe.getPaymentDetails(escrowHash, deployStartBlock);
+    assert(
+      fromFile3.salt === paymentInfo.salt,
+      "FilePaymentStore: re-recovers after disk wipe via events",
+    );
+
+    // And the file should be re-created
+    assert(existsSync(filePath), "FilePaymentStore: file re-created after recovery");
+  } finally {
+    // Cleanup
+    if (existsSync(tmpDir)) {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+
+  // ---- Test E: Merchant getReceiverPayments + getPaymentDetails ----
+  step("8. Merchant: getReceiverPayments + getPaymentDetails");
+
+  const merchant = new X402rMerchant({
+    publicClient,
+    walletClient: merchantWallet,
+    operatorAddress: deployResult.operatorAddress as Address,
+    escrowAddress: addresses.escrowAddress,
+    refundRequestAddress: addresses.refundRequestAddress,
+    chainId: addresses.chainId,
+  });
+
+  // getReceiverPayments now returns full PaymentInfo
+  const receiverPayments = await merchant.getReceiverPayments(deployStartBlock);
+  assert(receiverPayments.length > 0, "Merchant: getReceiverPayments returns payments");
+  assert(
+    receiverPayments[0].paymentInfo.salt === paymentInfo.salt,
+    "Merchant: recovered PaymentInfo.salt matches",
+  );
+  assert(
+    receiverPayments[0].paymentInfo.receiver.toLowerCase() ===
+      merchantAccount.address.toLowerCase(),
+    "Merchant: receiver matches merchant wallet",
+  );
+
+  // Merchant can also call getPaymentDetails directly
+  const merchantDetails = await merchant.getPaymentDetails(escrowHash, deployStartBlock);
+  assert(
+    merchantDetails.maxAmount === paymentInfo.maxAmount,
+    "Merchant: getPaymentDetails returns correct maxAmount",
+  );
+
+  // ============ Summary ============
+  console.log(`\n${"=".repeat(60)}`);
+  console.log("RESULTS");
+  console.log("=".repeat(60));
+  console.log(`  Passed: ${passed}`);
+  console.log(`  Failed: ${failed}`);
+  console.log(`  Total:  ${passed + failed}`);
+
+  if (failed > 0) {
+    console.log("\n  ✗ SOME TESTS FAILED");
+    process.exit(1);
+  } else {
+    console.log("\n  ✓ ALL TESTS PASSED");
+  }
+}
+
+main().catch(err => {
+  console.error("\n  FATAL ERROR:", err.message);
+  process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "example:client-cli": "tsx examples/dev-tools/client-cli/src/index.ts",
     "example:merchant-cli": "tsx examples/dev-tools/merchant-cli/src/index.ts",
     "example:arbiter-cli": "tsx examples/dev-tools/arbiter-cli/src/index.ts",
-    "example:e2e-test": "tsx examples/e2e-test/index.ts"
+    "example:e2e-test": "tsx examples/e2e-test/index.ts",
+    "example:e2e-recovery": "tsx examples/e2e-test/payment-recovery.ts"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -10,7 +10,6 @@ import {
   RefundRequestABI,
   EscrowPeriodABI,
   FreezeABI,
-  NotImplementedError,
   PaymentState,
   computePaymentInfoHash,
   toAbiPaymentInfo,
@@ -27,6 +26,7 @@ import {
   getAllEvidence as sharedGetAllEvidence,
   watchEvidenceSubmissions as sharedWatchEvidenceSubmissions,
   type PaymentInfo,
+  type PaymentStore,
   type RequestStatus,
   type RefundRequestData,
   type Evidence,
@@ -54,6 +54,8 @@ export interface X402rClientConfig {
   refundRequestEvidenceAddress?: `0x${string}`;
   /** Chain ID for hash computation (default: 84532 for Base Sepolia) */
   chainId?: number;
+  /** Optional PaymentStore for caching PaymentInfo locally */
+  paymentStore?: PaymentStore;
 }
 
 /**
@@ -99,6 +101,8 @@ export class X402rClient {
   readonly refundRequestEvidenceAddress?: `0x${string}`;
   /** Chain ID */
   readonly chainId: number;
+  /** Optional PaymentStore for caching PaymentInfo locally */
+  readonly paymentStore?: PaymentStore;
 
   constructor(config: X402rClientConfig) {
     this.publicClient = config.publicClient;
@@ -108,6 +112,7 @@ export class X402rClient {
     this.refundRequestAddress = config.refundRequestAddress;
     this.refundRequestEvidenceAddress = config.refundRequestEvidenceAddress;
     this.chainId = config.chainId ?? 84532;
+    this.paymentStore = config.paymentStore;
   }
 
   /** Get the refund read context, throwing if refundRequestAddress is not configured */
@@ -253,32 +258,112 @@ export class X402rClient {
   }
 
   /**
-   * Get stored PaymentInfo for a given hash.
+   * Get the full PaymentInfo for a given hash.
    *
-   * The escrow contract only stores the hash, not the full PaymentInfo struct.
-   * This method cannot reverse a hash into PaymentInfo. Store PaymentInfo locally
-   * when creating payments, or use a subgraph when available.
+   * Resolution strategy:
+   * 1. Check local PaymentStore (instant, zero RPC)
+   * 2. Scan escrow `PaymentAuthorized` events by hash (1 getLogs call)
+   * 3. Cache-fill: save to store if found via events
    *
-   * @throws NotImplementedError - Cannot reverse hash to PaymentInfo without subgraph
+   * @param paymentInfoHash - The hash of the PaymentInfo
+   * @param fromBlock - Starting block for event scan fallback (default: earliest)
+   * @returns The full PaymentInfo struct
+   * @throws Error if PaymentInfo cannot be found in store or events
+   * @throws Error if escrowAddress is not configured
    */
-  async getPaymentDetails(_paymentInfoHash: `0x${string}`): Promise<PaymentInfo> {
-    throw new NotImplementedError(
-      "getPaymentDetails",
-      "Cannot reverse hash to PaymentInfo. " +
-        "Store PaymentInfo locally when creating payments, or use a subgraph.",
-    );
+  async getPaymentDetails(
+    paymentInfoHash: `0x${string}`,
+    fromBlock?: bigint,
+  ): Promise<PaymentInfo> {
+    // 1. Check local store first
+    if (this.paymentStore) {
+      const cached = await this.paymentStore.load(paymentInfoHash);
+      if (cached) return cached;
+    }
+
+    // 2. Fall back to scanning escrow PaymentAuthorized events
+    if (!this.escrowAddress) {
+      throw new Error(
+        "Escrow address required. Use resolveAddresses(networkId) from @x402r/core to get the escrow address for your network.",
+      );
+    }
+
+    const logs = await this.publicClient.getContractEvents({
+      address: this.escrowAddress,
+      abi: AuthCaptureEscrowABI,
+      eventName: "PaymentAuthorized",
+      args: {
+        paymentInfoHash,
+      },
+      fromBlock: fromBlock ?? "earliest",
+    });
+
+    if (logs.length === 0) {
+      throw new Error(
+        `PaymentInfo not found for hash ${paymentInfoHash}. ` +
+          "Payment may not exist or event logs may have been pruned.",
+      );
+    }
+
+    const eventArgs = logs[0].args as {
+      paymentInfo?: {
+        operator: `0x${string}`;
+        payer: `0x${string}`;
+        receiver: `0x${string}`;
+        token: `0x${string}`;
+        maxAmount: bigint;
+        preApprovalExpiry: bigint;
+        authorizationExpiry: bigint;
+        refundExpiry: bigint;
+        minFeeBps: number;
+        maxFeeBps: number;
+        feeReceiver: `0x${string}`;
+        salt: bigint;
+      };
+    };
+
+    if (!eventArgs.paymentInfo) {
+      throw new Error(`PaymentAuthorized event missing paymentInfo for hash ${paymentInfoHash}`);
+    }
+
+    const paymentInfo: PaymentInfo = {
+      operator: eventArgs.paymentInfo.operator,
+      payer: eventArgs.paymentInfo.payer,
+      receiver: eventArgs.paymentInfo.receiver,
+      token: eventArgs.paymentInfo.token,
+      maxAmount: eventArgs.paymentInfo.maxAmount,
+      preApprovalExpiry: eventArgs.paymentInfo.preApprovalExpiry,
+      authorizationExpiry: eventArgs.paymentInfo.authorizationExpiry,
+      refundExpiry: eventArgs.paymentInfo.refundExpiry,
+      minFeeBps: Number(eventArgs.paymentInfo.minFeeBps),
+      maxFeeBps: Number(eventArgs.paymentInfo.maxFeeBps),
+      feeReceiver: eventArgs.paymentInfo.feeReceiver,
+      salt: eventArgs.paymentInfo.salt,
+    };
+
+    // 3. Cache-fill: save to store for future lookups
+    if (this.paymentStore) {
+      await this.paymentStore.save(paymentInfoHash, paymentInfo);
+    }
+
+    return paymentInfo;
   }
 
   /**
-   * Get all payment hashes where the current wallet is the payer.
+   * Get all payments where the current wallet is the payer.
    *
-   * Scans `AuthorizationCreated` event logs on the operator contract.
+   * Returns full PaymentInfo structs by:
+   * 1. Scanning `AuthorizationCreated` event logs on the operator (payer-indexed)
+   * 2. Resolving each hash to full PaymentInfo via `getPaymentDetails()`
    *
    * @param fromBlock - Starting block for the scan (default: earliest)
-   * @returns Object with an array of payment info hashes
+   * @returns Array of objects containing the hash and full PaymentInfo
    * @throws Error if walletClient is not configured
+   * @throws Error if escrowAddress is not configured
    */
-  async getPayerPayments(fromBlock?: bigint): Promise<{ hashes: readonly `0x${string}`[] }> {
+  async getPayerPayments(
+    fromBlock?: bigint,
+  ): Promise<Array<{ hash: `0x${string}`; paymentInfo: PaymentInfo }>> {
     if (!this.walletClient?.account) {
       throw new Error("WalletClient required");
     }
@@ -297,7 +382,12 @@ export class X402rClient {
       .map(log => (log.args as { paymentInfoHash?: `0x${string}` }).paymentInfoHash)
       .filter((h): h is `0x${string}` => h !== undefined);
 
-    return { hashes };
+    const results: Array<{ hash: `0x${string}`; paymentInfo: PaymentInfo }> = [];
+    for (const hash of hashes) {
+      const paymentInfo = await this.getPaymentDetails(hash, fromBlock);
+      results.push({ hash, paymentInfo });
+    }
+    return results;
   }
 
   // ============ Refund Operations ============

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -8,4 +8,13 @@
 export { X402rClient, type X402rClientConfig } from "./client.js";
 
 // Re-export types from core for convenience
-export { PaymentState, RequestStatus, type PaymentInfo, type RefundRequestData } from "@x402r/core";
+export {
+  PaymentState,
+  RequestStatus,
+  type PaymentInfo,
+  type PaymentStore,
+  type RefundRequestData,
+} from "@x402r/core";
+
+// Re-export storage implementations for convenience
+export { MemoryPaymentStore, FilePaymentStore } from "@x402r/core";

--- a/packages/client/tests/client.test.ts
+++ b/packages/client/tests/client.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { X402rClient, X402rClientConfig } from "../src/client.js";
-import { NotImplementedError, PaymentState } from "@x402r/core";
+import { PaymentState, MemoryPaymentStore } from "@x402r/core";
+import type { PaymentInfo, PaymentStore } from "@x402r/core";
 import type { PublicClient, WalletClient } from "viem";
 
 // Mock viem clients
@@ -275,13 +276,107 @@ describe("X402rClient", () => {
   });
 
   describe("getPaymentDetails", () => {
-    it("should throw NotImplementedError (cannot reverse hash)", async () => {
+    const testHash = "0x1234567890123456789012345678901234567890123456789012345678901234" as const;
+
+    it("should throw if escrowAddress not configured and no store", async () => {
       const client = new X402rClient({ publicClient, operatorAddress });
-      await expect(
-        client.getPaymentDetails(
-          "0x1234567890123456789012345678901234567890123456789012345678901234",
-        ),
-      ).rejects.toThrow(NotImplementedError);
+      await expect(client.getPaymentDetails(testHash)).rejects.toThrow("Escrow address required");
+    });
+
+    it("should return PaymentInfo from local store if available", async () => {
+      const store = new MemoryPaymentStore();
+      await store.save(testHash, samplePaymentInfo);
+
+      const client = new X402rClient({ publicClient, operatorAddress, paymentStore: store });
+      const result = await client.getPaymentDetails(testHash);
+      expect(result.operator).toBe(samplePaymentInfo.operator);
+      expect(result.maxAmount).toBe(samplePaymentInfo.maxAmount);
+    });
+
+    it("should fall back to escrow events when not in store", async () => {
+      const store = new MemoryPaymentStore();
+      const mockLogs = [
+        {
+          args: {
+            paymentInfoHash: testHash,
+            paymentInfo: samplePaymentInfo,
+            amount: 1000000n,
+            tokenCollector: "0x0000000000000000000000000000000000000000",
+          },
+        },
+      ];
+      (
+        publicClient as unknown as { getContractEvents: ReturnType<typeof vi.fn> }
+      ).getContractEvents = vi.fn().mockResolvedValue(mockLogs);
+
+      const client = new X402rClient({
+        publicClient,
+        operatorAddress,
+        escrowAddress,
+        paymentStore: store,
+      });
+      const result = await client.getPaymentDetails(testHash);
+      expect(result.operator).toBe(samplePaymentInfo.operator);
+      expect(result.maxAmount).toBe(samplePaymentInfo.maxAmount);
+    });
+
+    it("should cache-fill store after event lookup", async () => {
+      const store = new MemoryPaymentStore();
+      const mockLogs = [
+        {
+          args: {
+            paymentInfoHash: testHash,
+            paymentInfo: samplePaymentInfo,
+            amount: 1000000n,
+            tokenCollector: "0x0000000000000000000000000000000000000000",
+          },
+        },
+      ];
+      (
+        publicClient as unknown as { getContractEvents: ReturnType<typeof vi.fn> }
+      ).getContractEvents = vi.fn().mockResolvedValue(mockLogs);
+
+      const client = new X402rClient({
+        publicClient,
+        operatorAddress,
+        escrowAddress,
+        paymentStore: store,
+      });
+      await client.getPaymentDetails(testHash);
+
+      // Should now be in the store
+      const cached = await store.load(testHash);
+      expect(cached).not.toBeNull();
+      expect(cached!.operator).toBe(samplePaymentInfo.operator);
+    });
+
+    it("should throw if not found in store or events", async () => {
+      (
+        publicClient as unknown as { getContractEvents: ReturnType<typeof vi.fn> }
+      ).getContractEvents = vi.fn().mockResolvedValue([]);
+
+      const client = new X402rClient({ publicClient, operatorAddress, escrowAddress });
+      await expect(client.getPaymentDetails(testHash)).rejects.toThrow("PaymentInfo not found");
+    });
+
+    it("should work without a store (event-only fallback)", async () => {
+      const mockLogs = [
+        {
+          args: {
+            paymentInfoHash: testHash,
+            paymentInfo: samplePaymentInfo,
+            amount: 1000000n,
+            tokenCollector: "0x0000000000000000000000000000000000000000",
+          },
+        },
+      ];
+      (
+        publicClient as unknown as { getContractEvents: ReturnType<typeof vi.fn> }
+      ).getContractEvents = vi.fn().mockResolvedValue(mockLogs);
+
+      const client = new X402rClient({ publicClient, operatorAddress, escrowAddress });
+      const result = await client.getPaymentDetails(testHash);
+      expect(result.operator).toBe(samplePaymentInfo.operator);
     });
   });
 
@@ -291,34 +386,83 @@ describe("X402rClient", () => {
       await expect(client.getPayerPayments()).rejects.toThrow("WalletClient required");
     });
 
-    it("should return hashes from AuthorizationCreated events", async () => {
-      const mockLogs = [
-        {
-          args: {
-            paymentInfoHash: "0xaaa0000000000000000000000000000000000000000000000000000000000001",
-          },
-        },
-        {
-          args: {
-            paymentInfoHash: "0xbbb0000000000000000000000000000000000000000000000000000000000002",
-          },
-        },
-      ];
+    it("should return full PaymentInfo from AuthorizationCreated + escrow events", async () => {
+      const hash1 = "0xaaa0000000000000000000000000000000000000000000000000000000000001" as const;
+      const hash2 = "0xbbb0000000000000000000000000000000000000000000000000000000000002" as const;
+
+      // First call: AuthorizationCreated from operator
+      // Second + Third calls: PaymentAuthorized from escrow
+      const getContractEventsMock = vi.fn();
+      getContractEventsMock.mockResolvedValueOnce([
+        { args: { paymentInfoHash: hash1 } },
+        { args: { paymentInfoHash: hash2 } },
+      ]);
+      getContractEventsMock.mockResolvedValueOnce([
+        { args: { paymentInfoHash: hash1, paymentInfo: samplePaymentInfo } },
+      ]);
+      getContractEventsMock.mockResolvedValueOnce([
+        { args: { paymentInfoHash: hash2, paymentInfo: { ...samplePaymentInfo, salt: 999n } } },
+      ]);
+
       (
         publicClient as unknown as { getContractEvents: ReturnType<typeof vi.fn> }
-      ).getContractEvents = vi.fn().mockResolvedValue(mockLogs);
-      const client = new X402rClient({ publicClient, walletClient, operatorAddress });
+      ).getContractEvents = getContractEventsMock;
+
+      const client = new X402rClient({
+        publicClient,
+        walletClient,
+        operatorAddress,
+        escrowAddress,
+      });
       const result = await client.getPayerPayments();
-      expect(result.hashes).toHaveLength(2);
+      expect(result).toHaveLength(2);
+      expect(result[0].hash).toBe(hash1);
+      expect(result[0].paymentInfo.operator).toBe(samplePaymentInfo.operator);
+      expect(result[1].hash).toBe(hash2);
+      expect(result[1].paymentInfo.salt).toBe(999n);
     });
 
     it("should return empty array when no events found", async () => {
       (
         publicClient as unknown as { getContractEvents: ReturnType<typeof vi.fn> }
       ).getContractEvents = vi.fn().mockResolvedValue([]);
-      const client = new X402rClient({ publicClient, walletClient, operatorAddress });
+      const client = new X402rClient({
+        publicClient,
+        walletClient,
+        operatorAddress,
+        escrowAddress,
+      });
       const result = await client.getPayerPayments();
-      expect(result.hashes).toHaveLength(0);
+      expect(result).toHaveLength(0);
+    });
+
+    it("should use store for cached payments instead of hitting escrow events", async () => {
+      const hash1 = "0xaaa0000000000000000000000000000000000000000000000000000000000001" as const;
+
+      const store = new MemoryPaymentStore();
+      await store.save(hash1, samplePaymentInfo);
+
+      const getContractEventsMock = vi.fn();
+      // AuthorizationCreated from operator
+      getContractEventsMock.mockResolvedValueOnce([{ args: { paymentInfoHash: hash1 } }]);
+
+      (
+        publicClient as unknown as { getContractEvents: ReturnType<typeof vi.fn> }
+      ).getContractEvents = getContractEventsMock;
+
+      const client = new X402rClient({
+        publicClient,
+        walletClient,
+        operatorAddress,
+        escrowAddress,
+        paymentStore: store,
+      });
+      const result = await client.getPayerPayments();
+      expect(result).toHaveLength(1);
+      expect(result[0].paymentInfo.operator).toBe(samplePaymentInfo.operator);
+      // Should only have called getContractEvents once (for AuthorizationCreated),
+      // not a second time for PaymentAuthorized (resolved from store)
+      expect(getContractEventsMock).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/core/src/abis/index.ts
+++ b/packages/core/src/abis/index.ts
@@ -689,6 +689,22 @@ export const AuthCaptureEscrowABI = [
       { name: "refundableAmount", type: "uint120" },
     ],
   },
+  // Events
+  {
+    name: "PaymentAuthorized",
+    type: "event",
+    inputs: [
+      { name: "paymentInfoHash", type: "bytes32", indexed: true },
+      {
+        name: "paymentInfo",
+        type: "tuple",
+        components: paymentInfoComponents,
+        indexed: false,
+      },
+      { name: "amount", type: "uint256", indexed: false },
+      { name: "tokenCollector", type: "address", indexed: false },
+    ],
+  },
 ] as const;
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,3 +42,6 @@ export * from "./validation/index.js";
 
 // Discovery utilities
 export * from "./discovery/index.js";
+
+// Payment storage
+export * from "./storage/index.js";

--- a/packages/core/src/storage/file.ts
+++ b/packages/core/src/storage/file.ts
@@ -1,0 +1,70 @@
+/**
+ * File-based PaymentStore implementation.
+ *
+ * Stores each PaymentInfo as a JSON file in a configurable directory
+ * (default: `~/.x402r/payments/{hash}.json`). Survives process restarts.
+ *
+ * @module storage/file
+ */
+
+import { existsSync, mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { PaymentInfo, PaymentStore } from "../types/index.js";
+import {
+  serializePaymentInfo,
+  deserializePaymentInfo,
+  type SerializedPaymentInfo,
+} from "./serialization.js";
+
+export class FilePaymentStore implements PaymentStore {
+  private readonly dir: string;
+
+  /**
+   * @param dir - Directory to store payment JSON files.
+   *              Defaults to `~/.x402r/payments`.
+   */
+  constructor(dir?: string) {
+    this.dir = dir ?? join(homedir(), ".x402r", "payments");
+    if (!existsSync(this.dir)) {
+      mkdirSync(this.dir, { recursive: true });
+    }
+  }
+
+  async save(hash: `0x${string}`, paymentInfo: PaymentInfo): Promise<void> {
+    const filePath = join(this.dir, `${hash}.json`);
+    const data = serializePaymentInfo(paymentInfo);
+    writeFileSync(filePath, JSON.stringify(data, null, 2));
+  }
+
+  async load(hash: `0x${string}`): Promise<PaymentInfo | null> {
+    const filePath = join(this.dir, `${hash}.json`);
+    if (!existsSync(filePath)) {
+      return null;
+    }
+    const raw: SerializedPaymentInfo = JSON.parse(readFileSync(filePath, "utf-8"));
+    return deserializePaymentInfo(raw);
+  }
+
+  async listByPayer(
+    payer: `0x${string}`,
+  ): Promise<Array<{ hash: `0x${string}`; paymentInfo: PaymentInfo }>> {
+    if (!existsSync(this.dir)) {
+      return [];
+    }
+    const lowerPayer = payer.toLowerCase();
+    const results: Array<{ hash: `0x${string}`; paymentInfo: PaymentInfo }> = [];
+
+    const files = readdirSync(this.dir).filter(f => f.endsWith(".json"));
+    for (const file of files) {
+      const filePath = join(this.dir, file);
+      const raw: SerializedPaymentInfo = JSON.parse(readFileSync(filePath, "utf-8"));
+      const paymentInfo = deserializePaymentInfo(raw);
+      if (paymentInfo.payer.toLowerCase() === lowerPayer) {
+        const hash = file.replace(".json", "") as `0x${string}`;
+        results.push({ hash, paymentInfo });
+      }
+    }
+    return results;
+  }
+}

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Payment storage implementations for persisting PaymentInfo locally.
+ * @module storage
+ */
+
+export { MemoryPaymentStore } from "./memory.js";
+export { FilePaymentStore } from "./file.js";
+export { serializePaymentInfo, deserializePaymentInfo } from "./serialization.js";

--- a/packages/core/src/storage/memory.ts
+++ b/packages/core/src/storage/memory.ts
@@ -1,0 +1,35 @@
+/**
+ * In-memory PaymentStore implementation.
+ *
+ * Stores PaymentInfo in a Map — useful for tests and ephemeral processes.
+ * Data is lost on process exit.
+ *
+ * @module storage/memory
+ */
+
+import type { PaymentInfo, PaymentStore } from "../types/index.js";
+
+export class MemoryPaymentStore implements PaymentStore {
+  private readonly store = new Map<`0x${string}`, PaymentInfo>();
+
+  async save(hash: `0x${string}`, paymentInfo: PaymentInfo): Promise<void> {
+    this.store.set(hash, paymentInfo);
+  }
+
+  async load(hash: `0x${string}`): Promise<PaymentInfo | null> {
+    return this.store.get(hash) ?? null;
+  }
+
+  async listByPayer(
+    payer: `0x${string}`,
+  ): Promise<Array<{ hash: `0x${string}`; paymentInfo: PaymentInfo }>> {
+    const lowerPayer = payer.toLowerCase();
+    const results: Array<{ hash: `0x${string}`; paymentInfo: PaymentInfo }> = [];
+    for (const [hash, paymentInfo] of this.store) {
+      if (paymentInfo.payer.toLowerCase() === lowerPayer) {
+        results.push({ hash, paymentInfo });
+      }
+    }
+    return results;
+  }
+}

--- a/packages/core/src/storage/serialization.ts
+++ b/packages/core/src/storage/serialization.ts
@@ -1,0 +1,58 @@
+/**
+ * BigInt-safe JSON serialization for PaymentInfo structs.
+ * @module storage/serialization
+ */
+
+import type { PaymentInfo } from "../types/index.js";
+
+/** JSON-safe representation of PaymentInfo (bigint fields as strings) */
+export interface SerializedPaymentInfo {
+  operator: `0x${string}`;
+  payer: `0x${string}`;
+  receiver: `0x${string}`;
+  token: `0x${string}`;
+  maxAmount: string;
+  preApprovalExpiry: string;
+  authorizationExpiry: string;
+  refundExpiry: string;
+  minFeeBps: number;
+  maxFeeBps: number;
+  feeReceiver: `0x${string}`;
+  salt: string;
+}
+
+/** Convert PaymentInfo to a JSON-serializable object (bigint → string) */
+export function serializePaymentInfo(paymentInfo: PaymentInfo): SerializedPaymentInfo {
+  return {
+    operator: paymentInfo.operator,
+    payer: paymentInfo.payer,
+    receiver: paymentInfo.receiver,
+    token: paymentInfo.token,
+    maxAmount: paymentInfo.maxAmount.toString(),
+    preApprovalExpiry: paymentInfo.preApprovalExpiry.toString(),
+    authorizationExpiry: paymentInfo.authorizationExpiry.toString(),
+    refundExpiry: paymentInfo.refundExpiry.toString(),
+    minFeeBps: paymentInfo.minFeeBps,
+    maxFeeBps: paymentInfo.maxFeeBps,
+    feeReceiver: paymentInfo.feeReceiver,
+    salt: paymentInfo.salt.toString(),
+  };
+}
+
+/** Convert a serialized object back to PaymentInfo (string → bigint) */
+export function deserializePaymentInfo(raw: SerializedPaymentInfo): PaymentInfo {
+  return {
+    operator: raw.operator,
+    payer: raw.payer,
+    receiver: raw.receiver,
+    token: raw.token,
+    maxAmount: BigInt(raw.maxAmount),
+    preApprovalExpiry: BigInt(raw.preApprovalExpiry),
+    authorizationExpiry: BigInt(raw.authorizationExpiry),
+    refundExpiry: BigInt(raw.refundExpiry),
+    minFeeBps: raw.minFeeBps,
+    maxFeeBps: raw.maxFeeBps,
+    feeReceiver: raw.feeReceiver,
+    salt: BigInt(raw.salt),
+  };
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -209,6 +209,25 @@ export interface ArbiterList {
   total: bigint;
 }
 
+// ============ Payment Store ============
+
+/**
+ * Interface for persisting PaymentInfo structs locally.
+ *
+ * Used by X402rClient and X402rMerchant to cache PaymentInfo for fast lookup
+ * and to recover full payment details after restart without RPC calls.
+ */
+export interface PaymentStore {
+  /** Persist a PaymentInfo by its hash */
+  save(hash: `0x${string}`, paymentInfo: PaymentInfo): Promise<void>;
+  /** Load a PaymentInfo by its hash, or null if not found */
+  load(hash: `0x${string}`): Promise<PaymentInfo | null>;
+  /** List all stored payments where payer matches the given address */
+  listByPayer(
+    payer: `0x${string}`,
+  ): Promise<Array<{ hash: `0x${string}`; paymentInfo: PaymentInfo }>>;
+}
+
 // ============ Event Log Types ============
 
 /**

--- a/packages/core/tests/abis.test.ts
+++ b/packages/core/tests/abis.test.ts
@@ -340,6 +340,22 @@ describe("AuthCaptureEscrowABI", () => {
     expect(paymentStateFn).toBeDefined();
     expect(paymentStateFn?.outputs).toHaveLength(3);
   });
+
+  it("should have PaymentAuthorized event with indexed hash and full struct", () => {
+    const event = AuthCaptureEscrowABI.find(
+      item => item.name === "PaymentAuthorized" && item.type === "event",
+    );
+    expect(event).toBeDefined();
+    expect(event?.inputs).toHaveLength(4);
+    // paymentInfoHash is indexed for filtering
+    const hashInput = event?.inputs?.find(i => i.name === "paymentInfoHash");
+    expect(hashInput?.indexed).toBe(true);
+    expect(hashInput?.type).toBe("bytes32");
+    // paymentInfo is the full struct (not indexed)
+    const paymentInfoInput = event?.inputs?.find(i => i.name === "paymentInfo");
+    expect(paymentInfoInput?.type).toBe("tuple");
+    expect(paymentInfoInput?.indexed).toBe(false);
+  });
 });
 
 describe("StaticAddressConditionABI", () => {

--- a/packages/core/tests/storage.test.ts
+++ b/packages/core/tests/storage.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  MemoryPaymentStore,
+  FilePaymentStore,
+  serializePaymentInfo,
+  deserializePaymentInfo,
+} from "../src/storage/index.js";
+import type { PaymentInfo } from "../src/types/index.js";
+
+const samplePaymentInfo: PaymentInfo = {
+  operator: "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  payer: "0x1111111111111111111111111111111111111111",
+  receiver: "0x2222222222222222222222222222222222222222",
+  token: "0x3333333333333333333333333333333333333333",
+  maxAmount: 1000000n,
+  preApprovalExpiry: 0n,
+  authorizationExpiry: 1735689600n,
+  refundExpiry: 1738368000n,
+  minFeeBps: 0,
+  maxFeeBps: 500,
+  feeReceiver: "0x4444444444444444444444444444444444444444",
+  salt: 0x123456n,
+};
+
+const samplePaymentInfo2: PaymentInfo = {
+  ...samplePaymentInfo,
+  payer: "0x5555555555555555555555555555555555555555",
+  salt: 0x789abcn,
+};
+
+const hash1 = "0xaaa0000000000000000000000000000000000000000000000000000000000001" as const;
+const hash2 = "0xbbb0000000000000000000000000000000000000000000000000000000000002" as const;
+
+describe("serializePaymentInfo / deserializePaymentInfo", () => {
+  it("should round-trip PaymentInfo through JSON serialization", () => {
+    const serialized = serializePaymentInfo(samplePaymentInfo);
+    const deserialized = deserializePaymentInfo(serialized);
+
+    expect(deserialized.operator).toBe(samplePaymentInfo.operator);
+    expect(deserialized.payer).toBe(samplePaymentInfo.payer);
+    expect(deserialized.receiver).toBe(samplePaymentInfo.receiver);
+    expect(deserialized.token).toBe(samplePaymentInfo.token);
+    expect(deserialized.maxAmount).toBe(samplePaymentInfo.maxAmount);
+    expect(deserialized.preApprovalExpiry).toBe(samplePaymentInfo.preApprovalExpiry);
+    expect(deserialized.authorizationExpiry).toBe(samplePaymentInfo.authorizationExpiry);
+    expect(deserialized.refundExpiry).toBe(samplePaymentInfo.refundExpiry);
+    expect(deserialized.minFeeBps).toBe(samplePaymentInfo.minFeeBps);
+    expect(deserialized.maxFeeBps).toBe(samplePaymentInfo.maxFeeBps);
+    expect(deserialized.feeReceiver).toBe(samplePaymentInfo.feeReceiver);
+    expect(deserialized.salt).toBe(samplePaymentInfo.salt);
+  });
+
+  it("should serialize bigint fields as strings", () => {
+    const serialized = serializePaymentInfo(samplePaymentInfo);
+    expect(typeof serialized.maxAmount).toBe("string");
+    expect(typeof serialized.salt).toBe("string");
+    expect(serialized.maxAmount).toBe("1000000");
+    expect(serialized.salt).toBe("1193046"); // 0x123456
+  });
+
+  it("should survive JSON.stringify/parse round-trip", () => {
+    const serialized = serializePaymentInfo(samplePaymentInfo);
+    const jsonStr = JSON.stringify(serialized);
+    const parsed = JSON.parse(jsonStr);
+    const deserialized = deserializePaymentInfo(parsed);
+    expect(deserialized.maxAmount).toBe(1000000n);
+    expect(deserialized.salt).toBe(0x123456n);
+  });
+});
+
+describe("MemoryPaymentStore", () => {
+  let store: MemoryPaymentStore;
+
+  beforeEach(() => {
+    store = new MemoryPaymentStore();
+  });
+
+  it("should return null for unknown hash", async () => {
+    const result = await store.load(hash1);
+    expect(result).toBeNull();
+  });
+
+  it("should save and load PaymentInfo", async () => {
+    await store.save(hash1, samplePaymentInfo);
+    const loaded = await store.load(hash1);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.operator).toBe(samplePaymentInfo.operator);
+    expect(loaded!.maxAmount).toBe(samplePaymentInfo.maxAmount);
+  });
+
+  it("should overwrite on duplicate save", async () => {
+    await store.save(hash1, samplePaymentInfo);
+    const updated = { ...samplePaymentInfo, maxAmount: 2000000n };
+    await store.save(hash1, updated);
+    const loaded = await store.load(hash1);
+    expect(loaded!.maxAmount).toBe(2000000n);
+  });
+
+  it("should list payments by payer", async () => {
+    await store.save(hash1, samplePaymentInfo);
+    await store.save(hash2, samplePaymentInfo2);
+
+    const payer1Payments = await store.listByPayer(samplePaymentInfo.payer);
+    expect(payer1Payments).toHaveLength(1);
+    expect(payer1Payments[0].hash).toBe(hash1);
+
+    const payer2Payments = await store.listByPayer(samplePaymentInfo2.payer);
+    expect(payer2Payments).toHaveLength(1);
+    expect(payer2Payments[0].hash).toBe(hash2);
+  });
+
+  it("should return empty array for unknown payer", async () => {
+    const result = await store.listByPayer("0x9999999999999999999999999999999999999999");
+    expect(result).toHaveLength(0);
+  });
+
+  it("should match payer case-insensitively", async () => {
+    await store.save(hash1, samplePaymentInfo);
+    const upper = samplePaymentInfo.payer.toUpperCase() as `0x${string}`;
+    const result = await store.listByPayer(upper);
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe("FilePaymentStore", () => {
+  let tmpDir: string;
+  let store: FilePaymentStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "x402r-test-"));
+    store = new FilePaymentStore(tmpDir);
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("should return null for unknown hash", async () => {
+    const result = await store.load(hash1);
+    expect(result).toBeNull();
+  });
+
+  it("should save and load PaymentInfo", async () => {
+    await store.save(hash1, samplePaymentInfo);
+    const loaded = await store.load(hash1);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.operator).toBe(samplePaymentInfo.operator);
+    expect(loaded!.maxAmount).toBe(samplePaymentInfo.maxAmount);
+    expect(loaded!.salt).toBe(samplePaymentInfo.salt);
+  });
+
+  it("should persist across store instances", async () => {
+    await store.save(hash1, samplePaymentInfo);
+
+    // Create a new store pointing to the same directory
+    const store2 = new FilePaymentStore(tmpDir);
+    const loaded = await store2.load(hash1);
+    expect(loaded).not.toBeNull();
+    expect(loaded!.maxAmount).toBe(samplePaymentInfo.maxAmount);
+  });
+
+  it("should list payments by payer", async () => {
+    await store.save(hash1, samplePaymentInfo);
+    await store.save(hash2, samplePaymentInfo2);
+
+    const payer1Payments = await store.listByPayer(samplePaymentInfo.payer);
+    expect(payer1Payments).toHaveLength(1);
+    expect(payer1Payments[0].hash).toBe(hash1);
+  });
+
+  it("should return empty array for unknown payer", async () => {
+    const result = await store.listByPayer("0x9999999999999999999999999999999999999999");
+    expect(result).toHaveLength(0);
+  });
+
+  it("should create directory if it does not exist", () => {
+    const nestedDir = join(tmpDir, "nested", "dir");
+    const nestedStore = new FilePaymentStore(nestedDir);
+    // Should not throw — directory created in constructor
+    expect(nestedStore).toBeDefined();
+  });
+});

--- a/packages/merchant/src/merchant.ts
+++ b/packages/merchant/src/merchant.ts
@@ -28,6 +28,7 @@ import {
   getAllEvidence as sharedGetAllEvidence,
   watchEvidenceSubmissions as sharedWatchEvidenceSubmissions,
   type PaymentInfo,
+  type PaymentStore,
   type OperatorConfig,
   type FeeStructure,
   type RefundRequestData,
@@ -56,6 +57,8 @@ export interface X402rMerchantConfig {
   refundRequestEvidenceAddress?: `0x${string}`;
   /** Chain ID for hash computation (default: 84532 for Base Sepolia) */
   chainId?: number;
+  /** Optional PaymentStore for caching PaymentInfo locally */
+  paymentStore?: PaymentStore;
 }
 
 /**
@@ -113,6 +116,8 @@ export class X402rMerchant {
   readonly refundRequestEvidenceAddress?: `0x${string}`;
   /** Chain ID */
   readonly chainId: number;
+  /** Optional PaymentStore for caching PaymentInfo locally */
+  readonly paymentStore?: PaymentStore;
 
   constructor(config: X402rMerchantConfig) {
     if (!config.walletClient.account) {
@@ -128,6 +133,7 @@ export class X402rMerchant {
     this.refundRequestAddress = config.refundRequestAddress;
     this.refundRequestEvidenceAddress = config.refundRequestEvidenceAddress;
     this.chainId = config.chainId ?? 84532;
+    this.paymentStore = config.paymentStore;
   }
 
   /** Get the refund read context, throwing if refundRequestAddress is not configured */
@@ -220,14 +226,19 @@ export class X402rMerchant {
   }
 
   /**
-   * Get all payment hashes where the current wallet is the receiver.
+   * Get all payments where the current wallet is the receiver.
    *
-   * Scans `AuthorizationCreated` event logs on the operator contract.
+   * Returns full PaymentInfo structs by:
+   * 1. Scanning `AuthorizationCreated` event logs on the operator (receiver-indexed)
+   * 2. Resolving each hash to full PaymentInfo via `getPaymentDetails()`
    *
    * @param fromBlock - Starting block for the scan (default: earliest)
-   * @returns Object with an array of payment info hashes
+   * @returns Array of objects containing the hash and full PaymentInfo
+   * @throws Error if escrowAddress is not configured
    */
-  async getReceiverPayments(fromBlock?: bigint): Promise<{ hashes: readonly `0x${string}`[] }> {
+  async getReceiverPayments(
+    fromBlock?: bigint,
+  ): Promise<Array<{ hash: `0x${string}`; paymentInfo: PaymentInfo }>> {
     const logs = await this.publicClient.getContractEvents({
       address: this.operatorAddress,
       abi: PaymentOperatorABI,
@@ -242,7 +253,104 @@ export class X402rMerchant {
       .map(log => (log.args as { paymentInfoHash?: `0x${string}` }).paymentInfoHash)
       .filter((h): h is `0x${string}` => h !== undefined);
 
-    return { hashes };
+    const results: Array<{ hash: `0x${string}`; paymentInfo: PaymentInfo }> = [];
+    for (const hash of hashes) {
+      const paymentInfo = await this.getPaymentDetails(hash, fromBlock);
+      results.push({ hash, paymentInfo });
+    }
+    return results;
+  }
+
+  /**
+   * Get the full PaymentInfo for a given hash.
+   *
+   * Resolution strategy:
+   * 1. Check local PaymentStore (instant, zero RPC)
+   * 2. Scan escrow `PaymentAuthorized` events by hash (1 getLogs call)
+   * 3. Cache-fill: save to store if found via events
+   *
+   * @param paymentInfoHash - The hash of the PaymentInfo
+   * @param fromBlock - Starting block for event scan fallback (default: earliest)
+   * @returns The full PaymentInfo struct
+   * @throws Error if PaymentInfo cannot be found in store or events
+   * @throws Error if escrowAddress is not configured
+   */
+  async getPaymentDetails(
+    paymentInfoHash: `0x${string}`,
+    fromBlock?: bigint,
+  ): Promise<PaymentInfo> {
+    // 1. Check local store first
+    if (this.paymentStore) {
+      const cached = await this.paymentStore.load(paymentInfoHash);
+      if (cached) return cached;
+    }
+
+    // 2. Fall back to scanning escrow PaymentAuthorized events
+    if (!this.escrowAddress) {
+      throw new Error(
+        "Escrow address required. Use resolveAddresses(networkId) from @x402r/core to get the escrow address for your network.",
+      );
+    }
+
+    const logs = await this.publicClient.getContractEvents({
+      address: this.escrowAddress,
+      abi: AuthCaptureEscrowABI,
+      eventName: "PaymentAuthorized",
+      args: {
+        paymentInfoHash,
+      },
+      fromBlock: fromBlock ?? "earliest",
+    });
+
+    if (logs.length === 0) {
+      throw new Error(
+        `PaymentInfo not found for hash ${paymentInfoHash}. ` +
+          "Payment may not exist or event logs may have been pruned.",
+      );
+    }
+
+    const eventArgs = logs[0].args as {
+      paymentInfo?: {
+        operator: `0x${string}`;
+        payer: `0x${string}`;
+        receiver: `0x${string}`;
+        token: `0x${string}`;
+        maxAmount: bigint;
+        preApprovalExpiry: bigint;
+        authorizationExpiry: bigint;
+        refundExpiry: bigint;
+        minFeeBps: number;
+        maxFeeBps: number;
+        feeReceiver: `0x${string}`;
+        salt: bigint;
+      };
+    };
+
+    if (!eventArgs.paymentInfo) {
+      throw new Error(`PaymentAuthorized event missing paymentInfo for hash ${paymentInfoHash}`);
+    }
+
+    const paymentInfo: PaymentInfo = {
+      operator: eventArgs.paymentInfo.operator,
+      payer: eventArgs.paymentInfo.payer,
+      receiver: eventArgs.paymentInfo.receiver,
+      token: eventArgs.paymentInfo.token,
+      maxAmount: eventArgs.paymentInfo.maxAmount,
+      preApprovalExpiry: eventArgs.paymentInfo.preApprovalExpiry,
+      authorizationExpiry: eventArgs.paymentInfo.authorizationExpiry,
+      refundExpiry: eventArgs.paymentInfo.refundExpiry,
+      minFeeBps: Number(eventArgs.paymentInfo.minFeeBps),
+      maxFeeBps: Number(eventArgs.paymentInfo.maxFeeBps),
+      feeReceiver: eventArgs.paymentInfo.feeReceiver,
+      salt: eventArgs.paymentInfo.salt,
+    };
+
+    // 3. Cache-fill: save to store for future lookups
+    if (this.paymentStore) {
+      await this.paymentStore.save(paymentInfoHash, paymentInfo);
+    }
+
+    return paymentInfo;
   }
 
   /**

--- a/packages/merchant/tests/operations.test.ts
+++ b/packages/merchant/tests/operations.test.ts
@@ -94,29 +94,87 @@ describe("X402rMerchant - Payment Operations", () => {
   });
 
   describe("getReceiverPayments", () => {
-    it("should return hashes from AuthorizationCreated events", async () => {
-      const mockLogs = [
-        {
-          args: {
-            paymentInfoHash: "0xaaa0000000000000000000000000000000000000000000000000000000000001",
-          },
-        },
-      ];
+    it("should return full PaymentInfo from AuthorizationCreated + escrow events", async () => {
+      const hash1 = "0xaaa0000000000000000000000000000000000000000000000000000000000001" as const;
+
+      const getContractEventsMock = vi.fn();
+      // First call: AuthorizationCreated from operator
+      getContractEventsMock.mockResolvedValueOnce([{ args: { paymentInfoHash: hash1 } }]);
+      // Second call: PaymentAuthorized from escrow
+      getContractEventsMock.mockResolvedValueOnce([
+        { args: { paymentInfoHash: hash1, paymentInfo: samplePaymentInfo } },
+      ]);
+
       (
         publicClient as unknown as { getContractEvents: ReturnType<typeof vi.fn> }
-      ).getContractEvents = vi.fn().mockResolvedValue(mockLogs);
-      const merchant = new X402rMerchant({ publicClient, walletClient, operatorAddress });
+      ).getContractEvents = getContractEventsMock;
+
+      const merchant = new X402rMerchant({
+        publicClient,
+        walletClient,
+        operatorAddress,
+        escrowAddress,
+      });
       const result = await merchant.getReceiverPayments();
-      expect(result.hashes).toHaveLength(1);
+      expect(result).toHaveLength(1);
+      expect(result[0].hash).toBe(hash1);
+      expect(result[0].paymentInfo.operator).toBe(samplePaymentInfo.operator);
     });
 
     it("should return empty array when no events found", async () => {
       (
         publicClient as unknown as { getContractEvents: ReturnType<typeof vi.fn> }
       ).getContractEvents = vi.fn().mockResolvedValue([]);
-      const merchant = new X402rMerchant({ publicClient, walletClient, operatorAddress });
+      const merchant = new X402rMerchant({
+        publicClient,
+        walletClient,
+        operatorAddress,
+        escrowAddress,
+      });
       const result = await merchant.getReceiverPayments();
-      expect(result.hashes).toHaveLength(0);
+      expect(result).toHaveLength(0);
+    });
+  });
+
+  describe("getPaymentDetails", () => {
+    const testHash = "0x1234567890123456789012345678901234567890123456789012345678901234" as const;
+
+    it("should throw if escrowAddress not configured and no store", async () => {
+      const merchant = new X402rMerchant({ publicClient, walletClient, operatorAddress });
+      await expect(merchant.getPaymentDetails(testHash)).rejects.toThrow("Escrow address required");
+    });
+
+    it("should resolve PaymentInfo from escrow events", async () => {
+      (
+        publicClient as unknown as { getContractEvents: ReturnType<typeof vi.fn> }
+      ).getContractEvents = vi
+        .fn()
+        .mockResolvedValue([
+          { args: { paymentInfoHash: testHash, paymentInfo: samplePaymentInfo } },
+        ]);
+
+      const merchant = new X402rMerchant({
+        publicClient,
+        walletClient,
+        operatorAddress,
+        escrowAddress,
+      });
+      const result = await merchant.getPaymentDetails(testHash);
+      expect(result.operator).toBe(samplePaymentInfo.operator);
+    });
+
+    it("should throw if not found", async () => {
+      (
+        publicClient as unknown as { getContractEvents: ReturnType<typeof vi.fn> }
+      ).getContractEvents = vi.fn().mockResolvedValue([]);
+
+      const merchant = new X402rMerchant({
+        publicClient,
+        walletClient,
+        operatorAddress,
+        escrowAddress,
+      });
+      await expect(merchant.getPaymentDetails(testHash)).rejects.toThrow("PaymentInfo not found");
     });
   });
 


### PR DESCRIPTION
## Summary

- **Resolve Tech Debt #14**: `getPaymentDetails(hash)` now works instead of throwing `NotImplementedError`. Uses a hybrid approach: local `PaymentStore` cache + escrow `PaymentAuthorized` event fallback — zero gas, zero contract changes, zero infra dependencies.
- **Add `PaymentStore` interface** with two implementations: `MemoryPaymentStore` (in-process Map) and `FilePaymentStore` (JSON files on disk, survives restarts).
- **Update `getPayerPayments()` and `getReceiverPayments()`** to return full `PaymentInfo` structs (breaking change — SDK not released yet) by resolving hashes via `getPaymentDetails()`.
- **Add `PaymentAuthorized` event ABI** to `AuthCaptureEscrowABI` so the SDK can decode escrow events for recovery.

### Resolution strategy
```
getPaymentDetails(hash)
  1. Check local PaymentStore         → instant, zero RPC
  2. Scan escrow PaymentAuthorized    → 1 getLogs call
  3. Cache-fill store if found        → future lookups are instant
```

## Test plan

- [x] 438 unit tests pass (`pnpm test`)
- [x] 52/52 SDK-contract validation checks pass (`/validate-sdk`)
- [x] 15 new storage tests (serialization, MemoryPaymentStore, FilePaymentStore)
- [x] 9 new client tests (store lookup, event fallback, cache-fill, not-found)
- [x] 6 new merchant tests (getReceiverPayments, getPaymentDetails)
- [x] E2E test on Base Sepolia — 28/28 assertions pass (`pnpm example:e2e-recovery`):
  - Recovery via escrow events (no store)
  - MemoryPaymentStore cache-fill + instant re-lookup
  - getPayerPayments() returns full PaymentInfo
  - FilePaymentStore: persist → disk wipe → re-recover from events
  - Merchant: getReceiverPayments + getPaymentDetails

🤖 Generated with [Claude Code](https://claude.com/claude-code)