### PR TITLE
Prep npm publish v0.0.1

### DIFF
--- a/packages/arbiter/README.md
+++ b/packages/arbiter/README.md
@@ -1,0 +1,46 @@
+# @x402r/arbiter
+
+Arbiter SDK for dispute resolution in x402r refundable payments. Resolve disputes, integrate AI decision-making, and manage batch operations.
+
+## Install
+
+```bash
+npm install @x402r/arbiter
+```
+
+## Usage
+
+```typescript
+import { X402rArbiter, createWebhookHandler } from "@x402r/arbiter";
+import { createWalletClient, http } from "viem";
+import { baseSepolia } from "viem/chains";
+
+const wallet = createWalletClient({
+  chain: baseSepolia,
+  transport: http(),
+  account, // your viem account
+});
+
+const arbiter = new X402rArbiter({ walletClient: wallet });
+
+// Resolve a dispute
+await arbiter.resolveDispute(paymentId, decision);
+
+// Create an AI-powered webhook handler
+const handler = createWebhookHandler({
+  arbiter,
+  evaluateCase: async (context) => {
+    // your AI evaluation logic
+    return { approved: true, reason: "Valid refund request" };
+  },
+});
+```
+
+## Links
+
+- [Documentation](https://docs.x402r.org)
+- [GitHub](https://github.com/x402r/x402r-sdk)
+
+## License
+
+Apache-2.0

--- a/packages/arbiter/package.json
+++ b/packages/arbiter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/arbiter",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Arbiter SDK for dispute resolution in X402r refundable payments",
   "author": "x402r.org",
   "license": "Apache-2.0",

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -1,0 +1,40 @@
+# @x402r/client
+
+Client SDK for payers using x402r refundable payments. Query payment state, request refunds, and freeze escrows.
+
+## Install
+
+```bash
+npm install @x402r/client
+```
+
+## Usage
+
+```typescript
+import { X402rClient } from "@x402r/client";
+import { createWalletClient, http } from "viem";
+import { baseSepolia } from "viem/chains";
+
+const wallet = createWalletClient({
+  chain: baseSepolia,
+  transport: http(),
+  account, // your viem account
+});
+
+const client = new X402rClient({ walletClient: wallet });
+
+// Query payment state
+const state = await client.getPaymentState(paymentId);
+
+// Request a refund
+await client.requestRefund(paymentId);
+```
+
+## Links
+
+- [Documentation](https://docs.x402r.org)
+- [GitHub](https://github.com/x402r/x402r-sdk)
+
+## License
+
+Apache-2.0

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/client",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Client SDK for payers using X402r refundable payments",
   "author": "x402r.org",
   "license": "Apache-2.0",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,42 @@
+# @x402r/core
+
+Core types, ABIs, and utilities for the x402r refundable payments protocol.
+
+## Install
+
+```bash
+npm install @x402r/core
+```
+
+## Usage
+
+```typescript
+import { getContractAddresses, PaymentState } from "@x402r/core";
+
+// Get contract addresses for Base Sepolia
+const addresses = getContractAddresses(84532);
+
+// Use payment state enum
+if (state === PaymentState.Authorized) {
+  // payment is authorized and held in escrow
+}
+```
+
+## Exports
+
+- **Types** — `PaymentInfo`, `PaymentState`, `RefundRequestData`, and more
+- **ABIs** — Contract ABIs for AuthCaptureEscrow, PaymentOperator, USDC
+- **Config** — Contract addresses and chain configuration
+- **Errors** — Typed error classes for SDK operations
+- **Factory** — Utilities for deploying and configuring operators
+- **Conditions** — Condition builder for escrow terms
+- **Fees** — Fee calculation utilities
+
+## Links
+
+- [Documentation](https://docs.x402r.org)
+- [GitHub](https://github.com/x402r/x402r-sdk)
+
+## License
+
+Apache-2.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/core",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Core types, ABIs, and utilities for the X402r SDK",
   "author": "x402r.org",
   "license": "Apache-2.0",

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -1,0 +1,36 @@
+# @x402r/helpers
+
+Server-side helpers for x402r refundable payments. Drop-in route helpers for Express, Hono, and other frameworks.
+
+## Install
+
+```bash
+npm install @x402r/helpers
+```
+
+## Usage
+
+```typescript
+import { refundable } from "@x402r/helpers";
+
+// Express example — protect a route with refundable payments
+app.get(
+  "/api/weather",
+  refundable("$0.01", {
+    operatorAddress: "0x...",
+    refundExpirySeconds: 3600,
+  }),
+  (req, res) => {
+    res.json({ weather: "sunny" });
+  },
+);
+```
+
+## Links
+
+- [Documentation](https://docs.x402r.org)
+- [GitHub](https://github.com/x402r/x402r-sdk)
+
+## License
+
+Apache-2.0

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/helpers",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Server-side helpers for x402r refundable payments",
   "author": "x402r.org",
   "license": "Apache-2.0",

--- a/packages/merchant/README.md
+++ b/packages/merchant/README.md
@@ -1,0 +1,40 @@
+# @x402r/merchant
+
+Merchant SDK for servers using x402r refundable payments. Release payments, handle charges, and process refunds on-chain.
+
+## Install
+
+```bash
+npm install @x402r/merchant
+```
+
+## Usage
+
+```typescript
+import { X402rMerchant } from "@x402r/merchant";
+import { createWalletClient, http } from "viem";
+import { baseSepolia } from "viem/chains";
+
+const wallet = createWalletClient({
+  chain: baseSepolia,
+  transport: http(),
+  account, // your viem account
+});
+
+const merchant = new X402rMerchant({ walletClient: wallet });
+
+// Release an authorized payment
+await merchant.releasePayment(paymentId);
+
+// Issue a refund
+await merchant.refundPayment(paymentId);
+```
+
+## Links
+
+- [Documentation](https://docs.x402r.org)
+- [GitHub](https://github.com/x402r/x402r-sdk)
+
+## License
+
+Apache-2.0

--- a/packages/merchant/package.json
+++ b/packages/merchant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/merchant",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "description": "Merchant SDK for servers using X402r refundable payments",
   "author": "x402r.org",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- Add README.md to all 5 SDK packages (`@x402r/core`, `client`, `merchant`, `arbiter`, `helpers`) for npm page content
- Downgrade version from 0.1.0 to 0.0.1 to signal early/experimental status

## Test plan
- [x] `pnpm build` — all 5 packages build successfully
- [x] `pnpm test` — 33 test files, 446 tests all pass
- [x] Pre-commit hooks pass (typecheck, lint, format, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)