### PR TITLE
Update examples for x402 v2 scheme compatibility

### DIFF
--- a/examples/clients/fetch/index.ts
+++ b/examples/clients/fetch/index.ts
@@ -1,0 +1,48 @@
+import { config } from "dotenv";
+import { x402Client, wrapFetchWithPayment, x402HTTPClient } from "@x402/fetch";
+import { registerEscrowScheme } from "@x402r/evm/escrow/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+config();
+
+const privateKey = process.env.PRIVATE_KEY as `0x${string}`;
+const baseURL = process.env.RESOURCE_SERVER_URL || "http://localhost:4021";
+const endpointPath = process.env.ENDPOINT_PATH || "/weather";
+const url = `${baseURL}${endpointPath}`;
+
+/**
+ * Example demonstrating how to use @x402/fetch with the x402r escrow scheme.
+ *
+ * The escrow scheme is registered as a standard x402 v2 scheme — any x402-compatible
+ * middleware (Express, Hono, etc.) works automatically.
+ *
+ * Required environment variables:
+ * - PRIVATE_KEY: The private key of the EVM signer
+ */
+async function main(): Promise<void> {
+  const signer = privateKeyToAccount(privateKey);
+
+  const client = new x402Client();
+  registerEscrowScheme(client, { signer, networks: "eip155:84532" });
+
+  const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+  console.log(`Making request to: ${url}\n`);
+  const response = await fetchWithPayment(url, { method: "GET" });
+  const body = await response.json();
+  console.log("Response body:", body);
+
+  if (response.ok) {
+    const paymentResponse = new x402HTTPClient(client).getPaymentSettleResponse(name =>
+      response.headers.get(name),
+    );
+    console.log("\nPayment response:", JSON.stringify(paymentResponse, null, 2));
+  } else {
+    console.log(`\nNo payment settled (response status: ${response.status})`);
+  }
+}
+
+main().catch(error => {
+  console.error(error?.response?.data?.error ?? error);
+  process.exit(1);
+});

--- a/examples/clients/fetch/package.json
+++ b/examples/clients/fetch/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@x402r/fetch-client-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "tsx index.ts",
+    "dev": "tsx index.ts"
+  },
+  "dependencies": {
+    "@x402/fetch": "^2.3.0",
+    "@x402r/evm": "file:../../../../x402r-scheme/packages/evm",
+    "dotenv": "^16.4.7",
+    "viem": "^2.21.0"
+  },
+  "devDependencies": {
+    "tsx": "^4.7.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/examples/clients/fetch/tsconfig.json
+++ b/examples/clients/fetch/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "types": ["node"]
+  },
+  "include": ["index.ts"]
+}

--- a/examples/dev-tools/client-cli/package.json
+++ b/examples/dev-tools/client-cli/package.json
@@ -8,6 +8,8 @@
     "start": "tsx src/index.ts"
   },
   "dependencies": {
+    "@x402/core": "^2.3.0",
+    "@x402/evm": "^2.3.0",
     "@x402r/client": "workspace:*",
     "@x402r/core": "workspace:*",
     "@x402r/evm": "file:../../../../x402r-scheme/packages/evm",

--- a/examples/dev-tools/client-cli/src/commands/pay.ts
+++ b/examples/dev-tools/client-cli/src/commands/pay.ts
@@ -5,12 +5,13 @@
  * Uses x402 v2 protocol (Payment-Signature header, amount field).
  */
 
-import { createPaymentPayload } from "@x402r/evm/escrow/client";
-import type { WalletClient } from "viem";
+import { EscrowEvmScheme, type EscrowPayload } from "@x402r/evm/escrow/client";
+import type { ClientEvmSigner } from "@x402/evm";
+import type { PaymentRequirements } from "@x402/core/types";
 
 export interface PayOptions {
   url: string;
-  walletClient: WalletClient;
+  signer: ClientEvmSigner;
 }
 
 export interface PayResult {
@@ -25,7 +26,7 @@ export interface PayResult {
  * Execute a paid request to a URL
  */
 export async function pay(options: PayOptions): Promise<PayResult> {
-  const { url, walletClient } = options;
+  const { url, signer } = options;
 
   console.log(`\nFetching payment requirements from ${url}...`);
 
@@ -81,7 +82,12 @@ export async function pay(options: PayOptions): Promise<PayResult> {
 
   // Step 2: Create payment payload
   console.log("\nCreating payment payload...");
-  const escrowPayload = await createPaymentPayload(requirements, walletClient);
+  const scheme = new EscrowEvmScheme(signer);
+  const { x402Version, payload } = await scheme.createPaymentPayload(
+    2,
+    requirements as unknown as PaymentRequirements,
+  );
+  const escrowPayload = payload as unknown as EscrowPayload;
 
   console.log("  Payer:", escrowPayload.authorization.from);
   console.log("  Value:", escrowPayload.authorization.value);
@@ -89,7 +95,7 @@ export async function pay(options: PayOptions): Promise<PayResult> {
 
   // Step 3: Build payment header and make paid request (x402 v2)
   const x402Payload = {
-    x402Version: 2,
+    x402Version,
     resource: paymentRequired.resource,
     accepted: requirements,
     payload: escrowPayload,

--- a/examples/dev-tools/client-cli/src/index.ts
+++ b/examples/dev-tools/client-cli/src/index.ts
@@ -51,11 +51,11 @@ program
   .description("Make a payment to a URL that returns 402")
   .requiredOption("-u, --url <url>", "URL to pay for")
   .action(async options => {
-    const { walletClient, networkId, operatorAddress } = initCli();
+    const { account, networkId, operatorAddress } = initCli();
 
     const result = await pay({
       url: options.url,
-      walletClient,
+      signer: account,
     });
 
     if (result.success) {

--- a/examples/servers/express/index.ts
+++ b/examples/servers/express/index.ts
@@ -43,10 +43,7 @@ app.use(
         mimeType: "application/json",
       },
     },
-    new x402ResourceServer(facilitatorClient).register(
-      "eip155:84532",
-      new EscrowServerScheme() as never,
-    ),
+    new x402ResourceServer(facilitatorClient).register("eip155:84532", new EscrowServerScheme()),
   ),
 );
 

--- a/examples/servers/hono/index.ts
+++ b/examples/servers/hono/index.ts
@@ -44,10 +44,7 @@ app.use(
         mimeType: "application/json",
       },
     },
-    new x402ResourceServer(facilitatorClient).register(
-      "eip155:84532",
-      new EscrowServerScheme() as never,
-    ),
+    new x402ResourceServer(facilitatorClient).register("eip155:84532", new EscrowServerScheme()),
   ),
 );
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "example:client-cli": "tsx examples/dev-tools/client-cli/src/index.ts",
     "example:merchant-cli": "tsx examples/dev-tools/merchant-cli/src/index.ts",
     "example:arbiter-cli": "tsx examples/dev-tools/arbiter-cli/src/index.ts",
+    "example:client:fetch": "tsx examples/clients/fetch/index.ts",
     "example:e2e-test": "tsx examples/e2e-test/index.ts",
     "example:e2e-recovery": "tsx examples/e2e-test/payment-recovery.ts",
     "example:e2e-ai-hooks": "tsx examples/e2e-test/ai-hooks-e2e.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,28 @@ importers:
         specifier: ^2.1.0
         version: 2.1.9(@types/node@20.19.30)
 
+  examples/clients/fetch:
+    dependencies:
+      '@x402/fetch':
+        specifier: ^2.3.0
+        version: 2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
+      '@x402r/evm':
+        specifier: file:../../../../x402r-scheme/packages/evm
+        version: file:../x402r-scheme/packages/evm(@x402/core@2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy))(@x402/evm@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10))(viem@2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76))
+      dotenv:
+        specifier: ^16.4.7
+        version: 16.6.1
+      viem:
+        specifier: ^2.21.0
+        version: 2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+    devDependencies:
+      tsx:
+        specifier: ^4.7.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   examples/dev-tools/arbiter-cli:
     dependencies:
       '@x402r/arbiter':
@@ -92,6 +114,12 @@ importers:
 
   examples/dev-tools/client-cli:
     dependencies:
+      '@x402/core':
+        specifier: ^2.3.0
+        version: 2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy)
+      '@x402/evm':
+        specifier: ^2.3.0
+        version: 2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)
       '@x402r/client':
         specifier: workspace:*
         version: link:../../../packages/client
@@ -2077,6 +2105,9 @@ packages:
 
   '@x402/extensions@2.3.0':
     resolution: {integrity: sha512-hpx4CQ/fvfimwKQgw2LVu5Nj4s6+mzOAu3bhYE/5YtkMe49r2nxlTdhBoqjXs1nP7osL08r06wr1EVdzEdtYYQ==}
+
+  '@x402/fetch@2.3.0':
+    resolution: {integrity: sha512-XyY5wcR1gClC5QXJ4ev8O95ZHpiF8UMh5KkMHPYlNqxi59WNXR563XZE8LVoBd/fgRhDdjAoXlqwqBuDL50HOw==}
 
   '@x402/hono@2.3.0':
     resolution: {integrity: sha512-1c6oqrvKHbtk+ZZiOSpe/fPf7X1gmzn1xeEWJB/X9VYDY+4AWkkG9Mi6TcDL/actsf2imnX1vi5JAc8PffLg8w==}
@@ -6104,6 +6135,16 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - ethers
+      - typescript
+      - utf-8-validate
+
+  '@x402/fetch@2.3.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)':
+    dependencies:
+      '@x402/core': 2.3.0(patch_hash=wng4rpihzpsrif3iprw527ojpy)
+      viem: 2.45.0(bufferutil@4.1.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
       - typescript
       - utf-8-validate
 


### PR DESCRIPTION
## Summary
- **client-cli**: Use `EscrowEvmScheme` class + `ClientEvmSigner` instead of standalone `createPaymentPayload` + `WalletClient` (Step 3)
- **Express/Hono servers**: Remove `as never` cast — `EscrowServerScheme` now implements `SchemeNetworkServer` (Step 3)
- **New fetch client example**: `wrapFetchWithPayment` + `registerEscrowScheme` one-liner pattern (Step 5)
- **@x402/core patch**: Verified still applies cleanly; upstream [PR #1139](https://github.com/coinbase/x402/pull/1139) still open (Step 4)

### Depends on
- x402r-scheme [PR #7](https://github.com/BackTrackCo/x402r-scheme/pull/7) (`aliabdoli/scheme-audit-fixes`) — must be merged first

### Context
Implements Steps 3–5 from [`x402r-notes/sdk/X402_COMPATIBILITY_PLAN.md`](../x402r-notes/sdk/X402_COMPATIBILITY_PLAN.md). After both PRs merge, any x402 v2 client can use escrow payments with zero custom code:

\`\`\`typescript
const client = new x402Client();
registerEscrowScheme(client, { signer, networks: "eip155:84532" });
const paidFetch = wrapFetchWithPayment(fetch, client);
\`\`\`

## Test plan
- [x] All 5 SDK packages typecheck clean (pre-commit hook)
- [x] All lint checks pass
- [x] All SDK tests pass (213 tests across 5 packages)
- [x] New `examples/clients/fetch/` typechecks against PR #7 branch
- [x] Verified `@x402/core` patch applies cleanly
- [ ] Run examples against live facilitator after scheme PR #7 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)