### PR TITLE
Consolidate duplicated SDK code into core/shared

### DIFF
--- a/packages/arbiter/src/arbiter.ts
+++ b/packages/arbiter/src/arbiter.ts
@@ -3,15 +3,18 @@
  * @module arbiter
  */
 
-import type { PublicClient, WalletClient } from "viem";
+import {
+  BaseError,
+  ContractFunctionRevertedError,
+  type PublicClient,
+  type WalletClient,
+} from "viem";
 import {
   PaymentOperatorABI,
-  AuthCaptureEscrowABI,
   RefundRequestABI,
   ArbiterRegistryABI,
   RequestStatus,
   PaymentState,
-  computePaymentInfoHash,
   toAbiPaymentInfo,
   hasRefundRequest as sharedHasRefundRequest,
   getRefundRequest as sharedGetRefundRequest,
@@ -27,6 +30,11 @@ import {
   getEvidenceBatch as sharedGetEvidenceBatch,
   getAllEvidence as sharedGetAllEvidence,
   watchEvidenceSubmissions as sharedWatchEvidenceSubmissions,
+  getPaymentState as sharedGetPaymentState,
+  createRefundReadCtx,
+  createRefundWriteCtx,
+  createEvidenceReadCtx,
+  createEvidenceWriteCtx,
   type PaymentInfo,
   type RefundRequestData,
   type ArbiterList,
@@ -41,7 +49,7 @@ import {
  */
 export type BatchResult =
   | { success: true; txHash: `0x${string}` }
-  | { success: false; error: string };
+  | { success: false; error: string; cause?: unknown };
 
 /**
  * Configuration for X402rArbiter
@@ -143,29 +151,12 @@ export class X402rArbiter {
 
   /** Get the refund read context, throwing if refundRequestAddress is not configured */
   private getRefundCtx() {
-    if (!this.refundRequestAddress) {
-      throw new Error(
-        "RefundRequest address required. Use resolveAddresses(networkId) from @x402r/core to get the address for your network.",
-      );
-    }
-    return {
-      publicClient: this.publicClient,
-      refundRequestAddress: this.refundRequestAddress,
-    };
+    return createRefundReadCtx(this);
   }
 
   /** Get the refund write context, throwing if refundRequestAddress is not configured */
   private getRefundWriteCtx() {
-    if (!this.refundRequestAddress) {
-      throw new Error(
-        "RefundRequest address required. Use resolveAddresses(networkId) from @x402r/core to get the address for your network.",
-      );
-    }
-    return {
-      publicClient: this.publicClient,
-      walletClient: this.walletClient,
-      refundRequestAddress: this.refundRequestAddress,
-    };
+    return createRefundWriteCtx(this);
   }
 
   // ============ Payment Queries ============
@@ -191,43 +182,10 @@ export class X402rArbiter {
       );
     }
 
-    const paymentInfoHash = computePaymentInfoHash(paymentInfo, this.escrowAddress, this.chainId);
-
-    const state = await this.publicClient.readContract({
-      address: this.escrowAddress,
-      abi: AuthCaptureEscrowABI,
-      functionName: "paymentState",
-      args: [paymentInfoHash],
-    });
-
-    const [hasCollectedPayment, capturableAmount, refundableAmount] = state as [
-      boolean,
-      bigint,
-      bigint,
-    ];
-
-    if (!hasCollectedPayment) {
-      return PaymentState.NonExistent;
-    }
-
-    const now = BigInt(Math.floor(Date.now() / 1000));
-    if (
-      capturableAmount > 0n &&
-      paymentInfo.authorizationExpiry > 0n &&
-      now > paymentInfo.authorizationExpiry
-    ) {
-      return PaymentState.Expired;
-    }
-
-    if (capturableAmount > 0n) {
-      return PaymentState.InEscrow;
-    }
-
-    if (refundableAmount > 0n) {
-      return PaymentState.Released;
-    }
-
-    return PaymentState.Settled;
+    return sharedGetPaymentState(
+      { publicClient: this.publicClient, escrowAddress: this.escrowAddress, chainId: this.chainId },
+      paymentInfo,
+    );
   }
 
   /** Check if a refund request exists for a payment */
@@ -325,7 +283,13 @@ export class X402rArbiter {
       } catch (err) {
         results.push({
           success: false,
-          error: err instanceof Error ? err.message : String(err),
+          error:
+            err instanceof BaseError
+              ? err.shortMessage
+              : err instanceof Error
+                ? err.message
+                : String(err),
+          cause: err instanceof ContractFunctionRevertedError ? err.data : undefined,
         });
       }
     }
@@ -361,7 +325,13 @@ export class X402rArbiter {
       } catch (err) {
         results.push({
           success: false,
-          error: err instanceof Error ? err.message : String(err),
+          error:
+            err instanceof BaseError
+              ? err.shortMessage
+              : err instanceof Error
+                ? err.message
+                : String(err),
+          cause: err instanceof ContractFunctionRevertedError ? err.data : undefined,
         });
       }
     }
@@ -791,29 +761,12 @@ export class X402rArbiter {
 
   /** Get the evidence read context, throwing if refundRequestEvidenceAddress is not configured */
   private getEvidenceCtx() {
-    if (!this.refundRequestEvidenceAddress) {
-      throw new Error(
-        "RefundRequestEvidence address required. Use resolveAddresses(networkId) from @x402r/core to get the evidence address for your network.",
-      );
-    }
-    return {
-      publicClient: this.publicClient,
-      refundRequestEvidenceAddress: this.refundRequestEvidenceAddress,
-    };
+    return createEvidenceReadCtx(this);
   }
 
   /** Get the evidence write context, throwing if refundRequestEvidenceAddress is not configured */
   private getEvidenceWriteCtx() {
-    if (!this.refundRequestEvidenceAddress) {
-      throw new Error(
-        "RefundRequestEvidence address required. Use resolveAddresses(networkId) from @x402r/core to get the evidence address for your network.",
-      );
-    }
-    return {
-      publicClient: this.publicClient,
-      walletClient: this.walletClient,
-      refundRequestEvidenceAddress: this.refundRequestEvidenceAddress,
-    };
+    return createEvidenceWriteCtx(this);
   }
 
   /**

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -11,7 +11,6 @@ import {
   EscrowPeriodABI,
   FreezeABI,
   PaymentState,
-  computePaymentInfoHash,
   toAbiPaymentInfo,
   hasRefundRequest as sharedHasRefundRequest,
   getRefundRequest as sharedGetRefundRequest,
@@ -25,6 +24,11 @@ import {
   getEvidenceBatch as sharedGetEvidenceBatch,
   getAllEvidence as sharedGetAllEvidence,
   watchEvidenceSubmissions as sharedWatchEvidenceSubmissions,
+  getPaymentState as sharedGetPaymentState,
+  getPaymentDetails as sharedGetPaymentDetails,
+  createRefundReadCtx,
+  createEvidenceReadCtx,
+  createEvidenceWriteCtx,
   type PaymentInfo,
   type PaymentStore,
   type RequestStatus,
@@ -117,15 +121,7 @@ export class X402rClient {
 
   /** Get the refund read context, throwing if refundRequestAddress is not configured */
   private getRefundCtx() {
-    if (!this.refundRequestAddress) {
-      throw new Error(
-        "RefundRequest address required. Use resolveAddresses(networkId) from @x402r/core to get the address for your network.",
-      );
-    }
-    return {
-      publicClient: this.publicClient,
-      refundRequestAddress: this.refundRequestAddress,
-    };
+    return createRefundReadCtx(this);
   }
 
   /** Assert that walletClient and account are available for write operations */
@@ -167,44 +163,10 @@ export class X402rClient {
       );
     }
 
-    const paymentInfoHash = computePaymentInfoHash(paymentInfo, this.escrowAddress, this.chainId);
-
-    const state = await this.publicClient.readContract({
-      address: this.escrowAddress,
-      abi: AuthCaptureEscrowABI,
-      functionName: "paymentState",
-      args: [paymentInfoHash],
-    });
-
-    const [hasCollectedPayment, capturableAmount, refundableAmount] = state as [
-      boolean,
-      bigint,
-      bigint,
-    ];
-
-    if (!hasCollectedPayment) {
-      return PaymentState.NonExistent;
-    }
-
-    // Check if authorization has expired with funds still capturable
-    const now = BigInt(Math.floor(Date.now() / 1000));
-    if (
-      capturableAmount > 0n &&
-      paymentInfo.authorizationExpiry > 0n &&
-      now > paymentInfo.authorizationExpiry
-    ) {
-      return PaymentState.Expired;
-    }
-
-    if (capturableAmount > 0n) {
-      return PaymentState.InEscrow;
-    }
-
-    if (refundableAmount > 0n) {
-      return PaymentState.Released;
-    }
-
-    return PaymentState.Settled;
+    return sharedGetPaymentState(
+      { publicClient: this.publicClient, escrowAddress: this.escrowAddress, chainId: this.chainId },
+      paymentInfo,
+    );
   }
 
   /**
@@ -275,78 +237,27 @@ export class X402rClient {
     paymentInfoHash: `0x${string}`,
     fromBlock?: bigint,
   ): Promise<PaymentInfo> {
-    // 1. Check local store first
+    // Check local store first (doesn't require escrowAddress)
     if (this.paymentStore) {
       const cached = await this.paymentStore.load(paymentInfoHash);
       if (cached) return cached;
     }
 
-    // 2. Fall back to scanning escrow PaymentAuthorized events
     if (!this.escrowAddress) {
       throw new Error(
         "Escrow address required. Use resolveAddresses(networkId) from @x402r/core to get the escrow address for your network.",
       );
     }
 
-    const logs = await this.publicClient.getContractEvents({
-      address: this.escrowAddress,
-      abi: AuthCaptureEscrowABI,
-      eventName: "PaymentAuthorized",
-      args: {
-        paymentInfoHash,
+    return sharedGetPaymentDetails(
+      {
+        publicClient: this.publicClient,
+        escrowAddress: this.escrowAddress,
+        paymentStore: this.paymentStore,
       },
-      fromBlock: fromBlock ?? "earliest",
-    });
-
-    if (logs.length === 0) {
-      throw new Error(
-        `PaymentInfo not found for hash ${paymentInfoHash}. ` +
-          "Payment may not exist or event logs may have been pruned.",
-      );
-    }
-
-    const eventArgs = logs[0].args as {
-      paymentInfo?: {
-        operator: `0x${string}`;
-        payer: `0x${string}`;
-        receiver: `0x${string}`;
-        token: `0x${string}`;
-        maxAmount: bigint;
-        preApprovalExpiry: bigint;
-        authorizationExpiry: bigint;
-        refundExpiry: bigint;
-        minFeeBps: number;
-        maxFeeBps: number;
-        feeReceiver: `0x${string}`;
-        salt: bigint;
-      };
-    };
-
-    if (!eventArgs.paymentInfo) {
-      throw new Error(`PaymentAuthorized event missing paymentInfo for hash ${paymentInfoHash}`);
-    }
-
-    const paymentInfo: PaymentInfo = {
-      operator: eventArgs.paymentInfo.operator,
-      payer: eventArgs.paymentInfo.payer,
-      receiver: eventArgs.paymentInfo.receiver,
-      token: eventArgs.paymentInfo.token,
-      maxAmount: eventArgs.paymentInfo.maxAmount,
-      preApprovalExpiry: eventArgs.paymentInfo.preApprovalExpiry,
-      authorizationExpiry: eventArgs.paymentInfo.authorizationExpiry,
-      refundExpiry: eventArgs.paymentInfo.refundExpiry,
-      minFeeBps: Number(eventArgs.paymentInfo.minFeeBps),
-      maxFeeBps: Number(eventArgs.paymentInfo.maxFeeBps),
-      feeReceiver: eventArgs.paymentInfo.feeReceiver,
-      salt: eventArgs.paymentInfo.salt,
-    };
-
-    // 3. Cache-fill: save to store for future lookups
-    if (this.paymentStore) {
-      await this.paymentStore.save(paymentInfoHash, paymentInfo);
-    }
-
-    return paymentInfo;
+      paymentInfoHash,
+      fromBlock,
+    );
   }
 
   /**
@@ -910,32 +821,12 @@ export class X402rClient {
 
   /** Get the evidence read context, throwing if refundRequestEvidenceAddress is not configured */
   private getEvidenceCtx() {
-    if (!this.refundRequestEvidenceAddress) {
-      throw new Error(
-        "RefundRequestEvidence address required. Use resolveAddresses(networkId) from @x402r/core to get the evidence address for your network.",
-      );
-    }
-    return {
-      publicClient: this.publicClient,
-      refundRequestEvidenceAddress: this.refundRequestEvidenceAddress,
-    };
+    return createEvidenceReadCtx(this);
   }
 
   /** Get the evidence write context, throwing if refundRequestEvidenceAddress is not configured */
   private getEvidenceWriteCtx() {
-    if (!this.refundRequestEvidenceAddress) {
-      throw new Error(
-        "RefundRequestEvidence address required. Use resolveAddresses(networkId) from @x402r/core to get the evidence address for your network.",
-      );
-    }
-    if (!this.walletClient) {
-      throw new Error("WalletClient required");
-    }
-    return {
-      publicClient: this.publicClient,
-      walletClient: this.walletClient,
-      refundRequestEvidenceAddress: this.refundRequestEvidenceAddress,
-    };
+    return createEvidenceWriteCtx(this);
   }
 
   /**

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -3,6 +3,8 @@
  * @module config
  */
 
+import { zeroAddress } from "viem";
+
 /**
  * Factory addresses for deploying protocol components
  */
@@ -427,7 +429,7 @@ export function isSupportedNetwork(networkId: string): boolean {
 /**
  * Zero address constant for checking if addresses are deployed
  */
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
+const ZERO_ADDRESS = zeroAddress;
 
 /**
  * Check if an address is a valid deployed address (not zero)

--- a/packages/core/src/fees/index.ts
+++ b/packages/core/src/fees/index.ts
@@ -3,7 +3,7 @@
  * @module fees
  */
 
-import type { PublicClient, Address } from "viem";
+import { zeroAddress, type PublicClient, type Address } from "viem";
 import type { PaymentInfo } from "../types/index.js";
 import { PaymentOperatorABI, IFeeCalculatorABI, ProtocolFeeConfigABI } from "../abis/index.js";
 import { toAbiPaymentInfo } from "../utils/index.js";
@@ -44,7 +44,7 @@ export interface FeeAddresses {
   protocolFeeRecipient: Address;
 }
 
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as Address;
+const ZERO_ADDRESS = zeroAddress;
 
 /**
  * Get the fee-related addresses from an operator

--- a/packages/core/src/shared/context-helpers.ts
+++ b/packages/core/src/shared/context-helpers.ts
@@ -1,0 +1,90 @@
+/**
+ * Shared context factory functions for creating operation contexts from class instances
+ * @module shared/context-helpers
+ */
+
+import type { PublicClient, WalletClient } from "viem";
+import type { RefundReadContext, RefundWriteContext } from "./refund-operations.js";
+import type { EvidenceReadContext, EvidenceWriteContext } from "./evidence-operations.js";
+
+/** Common shape of SDK class instances that have refund-related fields */
+interface RefundHost {
+  publicClient: PublicClient;
+  refundRequestAddress?: `0x${string}`;
+  walletClient?: WalletClient;
+}
+
+/** Common shape of SDK class instances that have evidence-related fields */
+interface EvidenceHost {
+  publicClient: PublicClient;
+  refundRequestEvidenceAddress?: `0x${string}`;
+  walletClient?: WalletClient;
+}
+
+/**
+ * Create a RefundReadContext from a host instance, throwing if refundRequestAddress is missing.
+ */
+export function createRefundReadCtx(host: RefundHost): RefundReadContext {
+  if (!host.refundRequestAddress) {
+    throw new Error(
+      "RefundRequest address required. Use resolveAddresses(networkId) from @x402r/core to get the address for your network.",
+    );
+  }
+  return {
+    publicClient: host.publicClient,
+    refundRequestAddress: host.refundRequestAddress,
+  };
+}
+
+/**
+ * Create a RefundWriteContext from a host instance, throwing if refundRequestAddress or walletClient is missing.
+ */
+export function createRefundWriteCtx(host: RefundHost): RefundWriteContext {
+  if (!host.refundRequestAddress) {
+    throw new Error(
+      "RefundRequest address required. Use resolveAddresses(networkId) from @x402r/core to get the address for your network.",
+    );
+  }
+  if (!host.walletClient) {
+    throw new Error("WalletClient required");
+  }
+  return {
+    publicClient: host.publicClient,
+    walletClient: host.walletClient,
+    refundRequestAddress: host.refundRequestAddress,
+  };
+}
+
+/**
+ * Create an EvidenceReadContext from a host instance, throwing if refundRequestEvidenceAddress is missing.
+ */
+export function createEvidenceReadCtx(host: EvidenceHost): EvidenceReadContext {
+  if (!host.refundRequestEvidenceAddress) {
+    throw new Error(
+      "RefundRequestEvidence address required. Use resolveAddresses(networkId) from @x402r/core to get the evidence address for your network.",
+    );
+  }
+  return {
+    publicClient: host.publicClient,
+    refundRequestEvidenceAddress: host.refundRequestEvidenceAddress,
+  };
+}
+
+/**
+ * Create an EvidenceWriteContext from a host instance, throwing if refundRequestEvidenceAddress or walletClient is missing.
+ */
+export function createEvidenceWriteCtx(host: EvidenceHost): EvidenceWriteContext {
+  if (!host.refundRequestEvidenceAddress) {
+    throw new Error(
+      "RefundRequestEvidence address required. Use resolveAddresses(networkId) from @x402r/core to get the evidence address for your network.",
+    );
+  }
+  if (!host.walletClient) {
+    throw new Error("WalletClient required");
+  }
+  return {
+    publicClient: host.publicClient,
+    walletClient: host.walletClient,
+    refundRequestEvidenceAddress: host.refundRequestEvidenceAddress,
+  };
+}

--- a/packages/core/src/shared/evidence-operations.ts
+++ b/packages/core/src/shared/evidence-operations.ts
@@ -7,6 +7,7 @@ import type { PublicClient, WalletClient } from "viem";
 import { RefundRequestEvidenceABI } from "../abis/index.js";
 import type { PaymentInfo, Evidence, EvidenceEventLog } from "../types/index.js";
 import { toAbiPaymentInfo } from "../utils/index.js";
+import { requireAccount } from "./require-account.js";
 
 /** Read-only context for evidence operations */
 export interface EvidenceReadContext {
@@ -17,20 +18,6 @@ export interface EvidenceReadContext {
 /** Read-write context for evidence operations */
 export interface EvidenceWriteContext extends EvidenceReadContext {
   walletClient: WalletClient;
-}
-
-/**
- * Asserts that a WalletClient has an account attached.
- */
-function requireAccount(walletClient: WalletClient): asserts walletClient is WalletClient & {
-  account: NonNullable<WalletClient["account"]>;
-} {
-  if (!walletClient.account) {
-    throw new Error(
-      "WalletClient must have an account. Pass an account when creating the WalletClient: " +
-        "createWalletClient({ account, chain, transport })",
-    );
-  }
 }
 
 /**

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -26,3 +26,17 @@ export {
   type EvidenceReadContext,
   type EvidenceWriteContext,
 } from "./evidence-operations.js";
+
+export {
+  getPaymentState,
+  getPaymentDetails,
+  type PaymentStateReadContext,
+  type PaymentDetailsContext,
+} from "./payment-state-operations.js";
+
+export {
+  createRefundReadCtx,
+  createRefundWriteCtx,
+  createEvidenceReadCtx,
+  createEvidenceWriteCtx,
+} from "./context-helpers.js";

--- a/packages/core/src/shared/payment-state-operations.ts
+++ b/packages/core/src/shared/payment-state-operations.ts
@@ -1,0 +1,167 @@
+/**
+ * Shared payment state operations used by client, merchant, and arbiter packages
+ * @module shared/payment-state-operations
+ */
+
+import type { PublicClient } from "viem";
+import { AuthCaptureEscrowABI } from "../abis/index.js";
+import { PaymentState, type PaymentInfo, type PaymentStore } from "../types/index.js";
+import { computePaymentInfoHash } from "../utils/index.js";
+
+/** Read-only context for payment state operations */
+export interface PaymentStateReadContext {
+  publicClient: PublicClient;
+  escrowAddress: `0x${string}`;
+  chainId: number;
+}
+
+/** Context for payment details resolution */
+export interface PaymentDetailsContext {
+  publicClient: PublicClient;
+  escrowAddress: `0x${string}`;
+  paymentStore?: PaymentStore;
+}
+
+/**
+ * Get the current state of a payment by reading the escrow contract.
+ *
+ * Derives the state from the on-chain escrow amounts and expiry timestamps:
+ * - NonExistent: payment has never been authorized
+ * - InEscrow: funds are held in escrow (capturableAmount > 0)
+ * - Released: funds released to receiver, may still be refundable
+ * - Settled: all funds have been moved (capturable = 0, refundable = 0)
+ * - Expired: authorization expiry has passed and funds are still in escrow
+ *
+ * @param ctx - Read context with publicClient, escrowAddress, and chainId
+ * @param paymentInfo - The payment information struct
+ * @returns The current PaymentState
+ */
+export async function getPaymentState(
+  ctx: PaymentStateReadContext,
+  paymentInfo: PaymentInfo,
+): Promise<PaymentState> {
+  const paymentInfoHash = computePaymentInfoHash(paymentInfo, ctx.escrowAddress, ctx.chainId);
+
+  const state = await ctx.publicClient.readContract({
+    address: ctx.escrowAddress,
+    abi: AuthCaptureEscrowABI,
+    functionName: "paymentState",
+    args: [paymentInfoHash],
+  });
+
+  const [hasCollectedPayment, capturableAmount, refundableAmount] = state as [
+    boolean,
+    bigint,
+    bigint,
+  ];
+
+  if (!hasCollectedPayment) {
+    return PaymentState.NonExistent;
+  }
+
+  const now = BigInt(Math.floor(Date.now() / 1000));
+  if (
+    capturableAmount > 0n &&
+    paymentInfo.authorizationExpiry > 0n &&
+    now > paymentInfo.authorizationExpiry
+  ) {
+    return PaymentState.Expired;
+  }
+
+  if (capturableAmount > 0n) {
+    return PaymentState.InEscrow;
+  }
+
+  if (refundableAmount > 0n) {
+    return PaymentState.Released;
+  }
+
+  return PaymentState.Settled;
+}
+
+/**
+ * Get the full PaymentInfo for a given hash.
+ *
+ * Resolution strategy:
+ * 1. Check local PaymentStore (instant, zero RPC)
+ * 2. Scan escrow `PaymentAuthorized` events by hash (1 getLogs call)
+ * 3. Cache-fill: save to store if found via events
+ *
+ * @param ctx - Context with publicClient, escrowAddress, and optional paymentStore
+ * @param paymentInfoHash - The hash of the PaymentInfo
+ * @param fromBlock - Starting block for event scan fallback (default: earliest)
+ * @returns The full PaymentInfo struct
+ * @throws Error if PaymentInfo cannot be found in store or events
+ */
+export async function getPaymentDetails(
+  ctx: PaymentDetailsContext,
+  paymentInfoHash: `0x${string}`,
+  fromBlock?: bigint,
+): Promise<PaymentInfo> {
+  // 1. Check local store first
+  if (ctx.paymentStore) {
+    const cached = await ctx.paymentStore.load(paymentInfoHash);
+    if (cached) return cached;
+  }
+
+  // 2. Fall back to scanning escrow PaymentAuthorized events
+  const logs = await ctx.publicClient.getContractEvents({
+    address: ctx.escrowAddress,
+    abi: AuthCaptureEscrowABI,
+    eventName: "PaymentAuthorized",
+    args: {
+      paymentInfoHash,
+    },
+    fromBlock: fromBlock ?? "earliest",
+  });
+
+  if (logs.length === 0) {
+    throw new Error(
+      `PaymentInfo not found for hash ${paymentInfoHash}. ` +
+        "Payment may not exist or event logs may have been pruned.",
+    );
+  }
+
+  const eventArgs = logs[0].args as {
+    paymentInfo?: {
+      operator: `0x${string}`;
+      payer: `0x${string}`;
+      receiver: `0x${string}`;
+      token: `0x${string}`;
+      maxAmount: bigint;
+      preApprovalExpiry: bigint;
+      authorizationExpiry: bigint;
+      refundExpiry: bigint;
+      minFeeBps: number;
+      maxFeeBps: number;
+      feeReceiver: `0x${string}`;
+      salt: bigint;
+    };
+  };
+
+  if (!eventArgs.paymentInfo) {
+    throw new Error(`PaymentAuthorized event missing paymentInfo for hash ${paymentInfoHash}`);
+  }
+
+  const paymentInfo: PaymentInfo = {
+    operator: eventArgs.paymentInfo.operator,
+    payer: eventArgs.paymentInfo.payer,
+    receiver: eventArgs.paymentInfo.receiver,
+    token: eventArgs.paymentInfo.token,
+    maxAmount: eventArgs.paymentInfo.maxAmount,
+    preApprovalExpiry: eventArgs.paymentInfo.preApprovalExpiry,
+    authorizationExpiry: eventArgs.paymentInfo.authorizationExpiry,
+    refundExpiry: eventArgs.paymentInfo.refundExpiry,
+    minFeeBps: Number(eventArgs.paymentInfo.minFeeBps),
+    maxFeeBps: Number(eventArgs.paymentInfo.maxFeeBps),
+    feeReceiver: eventArgs.paymentInfo.feeReceiver,
+    salt: eventArgs.paymentInfo.salt,
+  };
+
+  // 3. Cache-fill: save to store for future lookups
+  if (ctx.paymentStore) {
+    await ctx.paymentStore.save(paymentInfoHash, paymentInfo);
+  }
+
+  return paymentInfo;
+}

--- a/packages/core/src/shared/refund-operations.ts
+++ b/packages/core/src/shared/refund-operations.ts
@@ -7,6 +7,7 @@ import type { PublicClient, WalletClient } from "viem";
 import { RefundRequestABI } from "../abis/index.js";
 import { RequestStatus, type PaymentInfo, type RefundRequestData } from "../types/index.js";
 import { toAbiPaymentInfo } from "../utils/index.js";
+import { requireAccount } from "./require-account.js";
 
 /** Read-only context for refund operations */
 export interface RefundReadContext {
@@ -17,22 +18,6 @@ export interface RefundReadContext {
 /** Read-write context for refund operations */
 export interface RefundWriteContext extends RefundReadContext {
   walletClient: WalletClient;
-}
-
-/**
- * Asserts that a WalletClient has an account attached.
- * Throws a descriptive error if the account is missing, which can happen when
- * a WalletClient is created without passing an account (e.g., for browser wallet integration).
- */
-function requireAccount(walletClient: WalletClient): asserts walletClient is WalletClient & {
-  account: NonNullable<WalletClient["account"]>;
-} {
-  if (!walletClient.account) {
-    throw new Error(
-      "WalletClient must have an account. Pass an account when creating the WalletClient: " +
-        "createWalletClient({ account, chain, transport })",
-    );
-  }
 }
 
 /**

--- a/packages/core/src/shared/require-account.ts
+++ b/packages/core/src/shared/require-account.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared account assertion utility
+ * @module shared/require-account
+ */
+
+import type { WalletClient } from "viem";
+
+/**
+ * Asserts that a WalletClient has an account attached.
+ * Throws a descriptive error if the account is missing, which can happen when
+ * a WalletClient is created without passing an account (e.g., for browser wallet integration).
+ */
+export function requireAccount(walletClient: WalletClient): asserts walletClient is WalletClient & {
+  account: NonNullable<WalletClient["account"]>;
+} {
+  if (!walletClient.account) {
+    throw new Error(
+      "WalletClient must have an account. Pass an account when creating the WalletClient: " +
+        "createWalletClient({ account, chain, transport })",
+    );
+  }
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -3,6 +3,8 @@
  * @module types
  */
 
+import { zeroAddress } from "viem";
+
 /**
  * Payment lifecycle states matching the Solidity enum
  *
@@ -141,7 +143,7 @@ export interface FeeStructure {
 // ============ Constants ============
 
 /** Zero address constant for validation */
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
+const ZERO_ADDRESS = zeroAddress;
 
 /** Maximum uint32 value (used for authorizationExpiry) */
 export const MAX_UINT32 = 4294967295n;

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -3,7 +3,7 @@
  * @module utils
  */
 
-import { keccak256, encodeAbiParameters, toHex } from "viem";
+import { keccak256, encodeAbiParameters, toHex, zeroAddress } from "viem";
 import type { WalletClient } from "viem";
 import type { PaymentInfo } from "../types/index.js";
 
@@ -136,8 +136,7 @@ export function computeEscrowNonce(
   escrowAddress: `0x${string}`,
   chainId: number,
 ): `0x${string}` {
-  const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
-  const payerAgnostic: PaymentInfo = { ...paymentInfo, payer: ZERO_ADDRESS };
+  const payerAgnostic: PaymentInfo = { ...paymentInfo, payer: zeroAddress };
   return computePaymentInfoHash(payerAgnostic, escrowAddress, chainId);
 }
 

--- a/packages/core/src/validation/index.ts
+++ b/packages/core/src/validation/index.ts
@@ -3,9 +3,10 @@
  * @module validation
  */
 
+import { zeroAddress } from "viem";
 import type { PaymentInfo } from "../types/index.js";
 
-const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
+const ZERO_ADDRESS = zeroAddress;
 
 /**
  * Severity level for validation issues

--- a/packages/merchant/src/merchant.ts
+++ b/packages/merchant/src/merchant.ts
@@ -27,6 +27,12 @@ import {
   getEvidenceBatch as sharedGetEvidenceBatch,
   getAllEvidence as sharedGetAllEvidence,
   watchEvidenceSubmissions as sharedWatchEvidenceSubmissions,
+  getPaymentState as sharedGetPaymentState,
+  getPaymentDetails as sharedGetPaymentDetails,
+  createRefundReadCtx,
+  createRefundWriteCtx,
+  createEvidenceReadCtx,
+  createEvidenceWriteCtx,
   type PaymentInfo,
   type PaymentStore,
   type OperatorConfig,
@@ -138,29 +144,12 @@ export class X402rMerchant {
 
   /** Get the refund read context, throwing if refundRequestAddress is not configured */
   private getRefundCtx() {
-    if (!this.refundRequestAddress) {
-      throw new Error(
-        "RefundRequest address required. Use resolveAddresses(networkId) from @x402r/core to get the address for your network.",
-      );
-    }
-    return {
-      publicClient: this.publicClient,
-      refundRequestAddress: this.refundRequestAddress,
-    };
+    return createRefundReadCtx(this);
   }
 
   /** Get the refund write context, throwing if refundRequestAddress is not configured */
   private getRefundWriteCtx() {
-    if (!this.refundRequestAddress) {
-      throw new Error(
-        "RefundRequest address required. Use resolveAddresses(networkId) from @x402r/core to get the address for your network.",
-      );
-    }
-    return {
-      publicClient: this.publicClient,
-      walletClient: this.walletClient,
-      refundRequestAddress: this.refundRequestAddress,
-    };
+    return createRefundWriteCtx(this);
   }
 
   // ============ Payment Queries ============
@@ -186,43 +175,10 @@ export class X402rMerchant {
       );
     }
 
-    const paymentInfoHash = computePaymentInfoHash(paymentInfo, this.escrowAddress, this.chainId);
-
-    const state = await this.publicClient.readContract({
-      address: this.escrowAddress,
-      abi: AuthCaptureEscrowABI,
-      functionName: "paymentState",
-      args: [paymentInfoHash],
-    });
-
-    const [hasCollectedPayment, capturableAmount, refundableAmount] = state as [
-      boolean,
-      bigint,
-      bigint,
-    ];
-
-    if (!hasCollectedPayment) {
-      return PaymentState.NonExistent;
-    }
-
-    const now = BigInt(Math.floor(Date.now() / 1000));
-    if (
-      capturableAmount > 0n &&
-      paymentInfo.authorizationExpiry > 0n &&
-      now > paymentInfo.authorizationExpiry
-    ) {
-      return PaymentState.Expired;
-    }
-
-    if (capturableAmount > 0n) {
-      return PaymentState.InEscrow;
-    }
-
-    if (refundableAmount > 0n) {
-      return PaymentState.Released;
-    }
-
-    return PaymentState.Settled;
+    return sharedGetPaymentState(
+      { publicClient: this.publicClient, escrowAddress: this.escrowAddress, chainId: this.chainId },
+      paymentInfo,
+    );
   }
 
   /**
@@ -279,78 +235,21 @@ export class X402rMerchant {
     paymentInfoHash: `0x${string}`,
     fromBlock?: bigint,
   ): Promise<PaymentInfo> {
-    // 1. Check local store first
-    if (this.paymentStore) {
-      const cached = await this.paymentStore.load(paymentInfoHash);
-      if (cached) return cached;
-    }
-
-    // 2. Fall back to scanning escrow PaymentAuthorized events
     if (!this.escrowAddress) {
       throw new Error(
         "Escrow address required. Use resolveAddresses(networkId) from @x402r/core to get the escrow address for your network.",
       );
     }
 
-    const logs = await this.publicClient.getContractEvents({
-      address: this.escrowAddress,
-      abi: AuthCaptureEscrowABI,
-      eventName: "PaymentAuthorized",
-      args: {
-        paymentInfoHash,
+    return sharedGetPaymentDetails(
+      {
+        publicClient: this.publicClient,
+        escrowAddress: this.escrowAddress,
+        paymentStore: this.paymentStore,
       },
-      fromBlock: fromBlock ?? "earliest",
-    });
-
-    if (logs.length === 0) {
-      throw new Error(
-        `PaymentInfo not found for hash ${paymentInfoHash}. ` +
-          "Payment may not exist or event logs may have been pruned.",
-      );
-    }
-
-    const eventArgs = logs[0].args as {
-      paymentInfo?: {
-        operator: `0x${string}`;
-        payer: `0x${string}`;
-        receiver: `0x${string}`;
-        token: `0x${string}`;
-        maxAmount: bigint;
-        preApprovalExpiry: bigint;
-        authorizationExpiry: bigint;
-        refundExpiry: bigint;
-        minFeeBps: number;
-        maxFeeBps: number;
-        feeReceiver: `0x${string}`;
-        salt: bigint;
-      };
-    };
-
-    if (!eventArgs.paymentInfo) {
-      throw new Error(`PaymentAuthorized event missing paymentInfo for hash ${paymentInfoHash}`);
-    }
-
-    const paymentInfo: PaymentInfo = {
-      operator: eventArgs.paymentInfo.operator,
-      payer: eventArgs.paymentInfo.payer,
-      receiver: eventArgs.paymentInfo.receiver,
-      token: eventArgs.paymentInfo.token,
-      maxAmount: eventArgs.paymentInfo.maxAmount,
-      preApprovalExpiry: eventArgs.paymentInfo.preApprovalExpiry,
-      authorizationExpiry: eventArgs.paymentInfo.authorizationExpiry,
-      refundExpiry: eventArgs.paymentInfo.refundExpiry,
-      minFeeBps: Number(eventArgs.paymentInfo.minFeeBps),
-      maxFeeBps: Number(eventArgs.paymentInfo.maxFeeBps),
-      feeReceiver: eventArgs.paymentInfo.feeReceiver,
-      salt: eventArgs.paymentInfo.salt,
-    };
-
-    // 3. Cache-fill: save to store for future lookups
-    if (this.paymentStore) {
-      await this.paymentStore.save(paymentInfoHash, paymentInfo);
-    }
-
-    return paymentInfo;
+      paymentInfoHash,
+      fromBlock,
+    );
   }
 
   /**
@@ -947,29 +846,12 @@ export class X402rMerchant {
 
   /** Get the evidence read context, throwing if refundRequestEvidenceAddress is not configured */
   private getEvidenceCtx() {
-    if (!this.refundRequestEvidenceAddress) {
-      throw new Error(
-        "RefundRequestEvidence address required. Use resolveAddresses(networkId) from @x402r/core to get the evidence address for your network.",
-      );
-    }
-    return {
-      publicClient: this.publicClient,
-      refundRequestEvidenceAddress: this.refundRequestEvidenceAddress,
-    };
+    return createEvidenceReadCtx(this);
   }
 
   /** Get the evidence write context, throwing if refundRequestEvidenceAddress is not configured */
   private getEvidenceWriteCtx() {
-    if (!this.refundRequestEvidenceAddress) {
-      throw new Error(
-        "RefundRequestEvidence address required. Use resolveAddresses(networkId) from @x402r/core to get the evidence address for your network.",
-      );
-    }
-    return {
-      publicClient: this.publicClient,
-      walletClient: this.walletClient,
-      refundRequestEvidenceAddress: this.refundRequestEvidenceAddress,
-    };
+    return createEvidenceWriteCtx(this);
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Phase 1 (low-hanging fruit):** Replace 5 private `ZERO_ADDRESS` constants with `viem.zeroAddress` (UR-4), deduplicate `requireAccount` into `core/shared/require-account.ts` (UR-7), improve batch error handling with `BaseError.shortMessage` + `cause` field (Hack 4)
- **Phase 2 (DRY extractions):** Extract `getPaymentState` (45 lines × 3 classes → 1 shared function) into `payment-state-operations.ts` (UR-1), extract `getPaymentDetails` (70 lines × 2 classes → 1 shared function) (UR-2), extract 12 context getter methods into `context-helpers.ts` (UR-3)
- Net: 384 insertions, 389 deletions — code reduced while adding new shared infrastructure

## Test plan

- [x] `pnpm build` passes (all 5 packages)
- [x] `pnpm test` passes (33 test files, 446 tests)
- [x] Pre-commit hooks pass (typecheck, lint, format, docs:generate)
- [x] Verify no public API surface changes (class method signatures unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)