### PR TITLE
Fix Hack 6 (param order), Hack 1 (any→never), rename to toFacilitatorEvmSigner

### DIFF
--- a/examples/e2e-test/shared.ts
+++ b/examples/e2e-test/shared.ts
@@ -28,7 +28,7 @@ import {
   resolveAddresses,
   computePaymentInfoHash,
   toPaymentInfo,
-  createFacilitatorSignerFromViem,
+  toFacilitatorEvmSigner,
   createInProcessFacilitator,
   type PaymentInfo,
   type FacilitatorClientLike,
@@ -329,7 +329,7 @@ export async function setupHTTP402(
     transport: http(RPC_URL),
   }).extend(publicActions);
 
-  const signer = createFacilitatorSignerFromViem(facilitatorViemClient);
+  const signer = toFacilitatorEvmSigner(facilitatorViemClient);
   const { client: facilitatorClient } = createInProcessFacilitator(new x402Facilitator(), fac =>
     registerEscrowFacilitatorScheme(fac, {
       signer: signer as Parameters<typeof registerEscrowFacilitatorScheme>[1]["signer"],
@@ -481,9 +481,9 @@ export async function performHTTP402Payment(
   const paymentInfo = toPaymentInfo(verifiedPayload.payload as EscrowPayload);
 
   const escrowHash = computePaymentInfoHash(
-    paymentInfo,
-    accounts.networkConfig.authCaptureEscrow as Address,
     84532,
+    accounts.networkConfig.authCaptureEscrow as Address,
+    paymentInfo,
   );
 
   return {

--- a/packages/core/src/http402/index.ts
+++ b/packages/core/src/http402/index.ts
@@ -138,13 +138,11 @@ export interface FacilitatorEvmSignerLike {
  * @example
  * ```typescript
  * const viemClient = createWalletClient({ ... }).extend(publicActions);
- * const signer = createFacilitatorSignerFromViem(viemClient);
+ * const signer = toFacilitatorEvmSigner(viemClient);
  * registerEscrowFacilitatorScheme(facilitator, { signer, networks: "eip155:84532" });
  * ```
  */
-export function createFacilitatorSignerFromViem(
-  client: ViemExtendedClient,
-): FacilitatorEvmSignerLike {
+export function toFacilitatorEvmSigner(client: ViemExtendedClient): FacilitatorEvmSignerLike {
   return {
     getAddresses: () => [client.account.address],
     getCode: (args: { address: `0x${string}` }) => client.getCode(args),
@@ -168,6 +166,9 @@ export function createFacilitatorSignerFromViem(
       client.waitForTransactionReceipt(args),
   };
 }
+
+/** @deprecated Use toFacilitatorEvmSigner instead */
+export const createFacilitatorSignerFromViem = toFacilitatorEvmSigner;
 
 /**
  * FacilitatorClient shape from @x402/core — structural typing to avoid hard dep.
@@ -201,7 +202,7 @@ interface FacilitatorLike {
  *
  * @example
  * ```typescript
- * const signer = createFacilitatorSignerFromViem(viemClient);
+ * const signer = toFacilitatorEvmSigner(viemClient);
  * const { facilitator, client } = createInProcessFacilitator(
  *   new x402Facilitator(),
  *   (fac) => registerEscrowFacilitatorScheme(fac, { signer, networks: "eip155:84532" }),

--- a/packages/core/src/shared/payment-state-operations.ts
+++ b/packages/core/src/shared/payment-state-operations.ts
@@ -40,7 +40,7 @@ export async function getPaymentState(
   ctx: PaymentStateReadContext,
   paymentInfo: PaymentInfo,
 ): Promise<PaymentState> {
-  const paymentInfoHash = computePaymentInfoHash(paymentInfo, ctx.escrowAddress, ctx.chainId);
+  const paymentInfoHash = computePaymentInfoHash(ctx.chainId, ctx.escrowAddress, paymentInfo);
 
   const state = await ctx.publicClient.readContract({
     address: ctx.escrowAddress,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -51,12 +51,12 @@ const finalHashAbiParams: readonly { name: string; type: string }[] = [
  *
  * viem's strict ABI typing cannot infer our PaymentInfo interface as the expected
  * tuple type (the interface uses `bigint` and `number` which don't match viem's
- * inferred `uint120`/`uint48`/`uint16` types). This helper centralizes the cast
- * so callers don't need `as never` at every call site.
+ * inferred `uint120`/`uint48`/`uint16` types). The `never` return type is assignable
+ * to any parameter position without leaking `any` to callers, so this centralizes
+ * the cast at one boundary.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function toAbiPaymentInfo(paymentInfo: PaymentInfo): any {
-  return paymentInfo;
+export function toAbiPaymentInfo(paymentInfo: PaymentInfo): never {
+  return paymentInfo as never;
 }
 
 /**
@@ -72,24 +72,24 @@ export function toAbiPaymentInfo(paymentInfo: PaymentInfo): any {
  * return keccak256(abi.encode(block.chainid, address(this), paymentInfoHash));
  * ```
  *
- * @param paymentInfo - The payment information struct
- * @param escrowAddress - The escrow contract address
  * @param chainId - The chain ID (e.g., 84532 for Base Sepolia)
+ * @param escrowAddress - The escrow contract address
+ * @param paymentInfo - The payment information struct
  * @returns The bytes32 hash
  *
  * @example
  * ```typescript
  * const hash = computePaymentInfoHash(
- *   paymentInfo,
+ *   84532,
  *   '0xb9488351E48b23D798f24e8174514F28B741Eb4f',
- *   84532
+ *   paymentInfo
  * );
  * ```
  */
 export function computePaymentInfoHash(
-  paymentInfo: PaymentInfo,
-  escrowAddress: `0x${string}`,
   chainId: number,
+  escrowAddress: `0x${string}`,
+  paymentInfo: PaymentInfo,
 ): `0x${string}` {
   // Step 1: Encode and hash the PaymentInfo struct with typehash
   const encodedPaymentInfo = encodeAbiParameters(paymentInfoAbiParams, [
@@ -126,18 +126,18 @@ export function computePaymentInfoHash(
  * This is the same as `computePaymentInfoHash` but with `payer = address(0)`.
  * It matches `AuthCaptureEscrow.getHash()` with payer=0x0.
  *
- * @param paymentInfo - PaymentInfo (payer field is ignored — replaced with address(0))
- * @param escrowAddress - The escrow contract address
  * @param chainId - The chain ID
+ * @param escrowAddress - The escrow contract address
+ * @param paymentInfo - PaymentInfo (payer field is ignored — replaced with address(0))
  * @returns The bytes32 nonce for ERC-3009 signing
  */
 export function computeEscrowNonce(
-  paymentInfo: PaymentInfo,
-  escrowAddress: `0x${string}`,
   chainId: number,
+  escrowAddress: `0x${string}`,
+  paymentInfo: PaymentInfo,
 ): `0x${string}` {
   const payerAgnostic: PaymentInfo = { ...paymentInfo, payer: zeroAddress };
-  return computePaymentInfoHash(payerAgnostic, escrowAddress, chainId);
+  return computePaymentInfoHash(chainId, escrowAddress, payerAgnostic);
 }
 
 /**
@@ -177,7 +177,7 @@ export interface ERC3009Authorization {
  * import { signERC3009Authorization, computeEscrowNonce, resolveAddresses } from '@x402r/core';
  *
  * const addrs = resolveAddresses('eip155:84532');
- * const nonce = computeEscrowNonce(paymentInfo, addrs.escrowAddress, addrs.chainId);
+ * const nonce = computeEscrowNonce(addrs.chainId, addrs.escrowAddress, paymentInfo);
  *
  * const signature = await signERC3009Authorization(walletClient, addrs.usdc, {
  *   from: payerAddress,

--- a/packages/core/tests/erc3009.test.ts
+++ b/packages/core/tests/erc3009.test.ts
@@ -27,19 +27,19 @@ const chainId = 84532;
 
 describe("computeEscrowNonce", () => {
   it("should return a bytes32 hash", () => {
-    const nonce = computeEscrowNonce(samplePaymentInfo, escrowAddress, chainId);
+    const nonce = computeEscrowNonce(chainId, escrowAddress, samplePaymentInfo);
     expect(nonce).toMatch(/^0x[a-fA-F0-9]{64}$/);
   });
 
   it("should be deterministic", () => {
-    const nonce1 = computeEscrowNonce(samplePaymentInfo, escrowAddress, chainId);
-    const nonce2 = computeEscrowNonce(samplePaymentInfo, escrowAddress, chainId);
+    const nonce1 = computeEscrowNonce(chainId, escrowAddress, samplePaymentInfo);
+    const nonce2 = computeEscrowNonce(chainId, escrowAddress, samplePaymentInfo);
     expect(nonce1).toBe(nonce2);
   });
 
   it("should differ from computePaymentInfoHash (payer zeroed)", () => {
-    const nonce = computeEscrowNonce(samplePaymentInfo, escrowAddress, chainId);
-    const hash = computePaymentInfoHash(samplePaymentInfo, escrowAddress, chainId);
+    const nonce = computeEscrowNonce(chainId, escrowAddress, samplePaymentInfo);
+    const hash = computePaymentInfoHash(chainId, escrowAddress, samplePaymentInfo);
     expect(nonce).not.toBe(hash);
   });
 
@@ -53,8 +53,8 @@ describe("computeEscrowNonce", () => {
       payer: "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as `0x${string}`,
     };
 
-    const nonceA = computeEscrowNonce(payerA, escrowAddress, chainId);
-    const nonceB = computeEscrowNonce(payerB, escrowAddress, chainId);
+    const nonceA = computeEscrowNonce(chainId, escrowAddress, payerA);
+    const nonceB = computeEscrowNonce(chainId, escrowAddress, payerB);
     expect(nonceA).toBe(nonceB);
   });
 
@@ -62,8 +62,8 @@ describe("computeEscrowNonce", () => {
     const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
     const zeroPayer = { ...samplePaymentInfo, payer: ZERO_ADDRESS };
 
-    const nonce = computeEscrowNonce(samplePaymentInfo, escrowAddress, chainId);
-    const hash = computePaymentInfoHash(zeroPayer, escrowAddress, chainId);
+    const nonce = computeEscrowNonce(chainId, escrowAddress, samplePaymentInfo);
+    const hash = computePaymentInfoHash(chainId, escrowAddress, zeroPayer);
     expect(nonce).toBe(hash);
   });
 });

--- a/packages/core/tests/nonce-cross-repo.test.ts
+++ b/packages/core/tests/nonce-cross-repo.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Cross-repo nonce consistency test
+ *
+ * Verifies that the SDK's computeEscrowNonce() produces the same hash
+ * as the scheme's (@x402r/evm) nonce algorithm for identical inputs.
+ *
+ * Since @x402r/evm can't be a dependency of @x402r/core, this test
+ * inline-reimplements the scheme's algorithm and asserts both produce
+ * identical results.
+ */
+
+import { describe, it, expect } from "vitest";
+import { encodeAbiParameters, keccak256 } from "viem";
+import {
+  computeEscrowNonce,
+  computePaymentInfoHash,
+  PAYMENT_INFO_TYPEHASH,
+} from "../src/utils/index.js";
+import type { PaymentInfo } from "../src/types/index.js";
+
+// ============ Scheme-style nonce (inline reimplementation) ============
+
+/**
+ * Scheme computes PAYMENT_INFO_TYPEHASH using TextEncoder (Uint8Array)
+ * while SDK uses toHex (string). Both should produce the same keccak256.
+ */
+const SCHEME_PAYMENT_INFO_TYPEHASH = keccak256(
+  new TextEncoder().encode(
+    "PaymentInfo(address operator,address payer,address receiver,address token,uint120 maxAmount,uint48 preApprovalExpiry,uint48 authorizationExpiry,uint48 refundExpiry,uint16 minFeeBps,uint16 maxFeeBps,address feeReceiver,uint256 salt)",
+  ),
+);
+
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000" as const;
+
+/**
+ * Inline reimplementation of @x402r/evm's computeEscrowNonce.
+ * Uses scheme-style types (string amounts, number expiries).
+ */
+function schemeComputeEscrowNonce(
+  chainId: number,
+  escrowAddress: `0x${string}`,
+  paymentInfo: {
+    operator: `0x${string}`;
+    receiver: `0x${string}`;
+    token: `0x${string}`;
+    maxAmount: string;
+    preApprovalExpiry: number;
+    authorizationExpiry: number;
+    refundExpiry: number;
+    minFeeBps: number;
+    maxFeeBps: number;
+    feeReceiver: `0x${string}`;
+    salt: string;
+  },
+): `0x${string}` {
+  // Step 1: Encode paymentInfo with payer=0 (payer-agnostic)
+  const paymentInfoEncoded = encodeAbiParameters(
+    [
+      { name: "typehash", type: "bytes32" },
+      { name: "operator", type: "address" },
+      { name: "payer", type: "address" },
+      { name: "receiver", type: "address" },
+      { name: "token", type: "address" },
+      { name: "maxAmount", type: "uint120" },
+      { name: "preApprovalExpiry", type: "uint48" },
+      { name: "authorizationExpiry", type: "uint48" },
+      { name: "refundExpiry", type: "uint48" },
+      { name: "minFeeBps", type: "uint16" },
+      { name: "maxFeeBps", type: "uint16" },
+      { name: "feeReceiver", type: "address" },
+      { name: "salt", type: "uint256" },
+    ],
+    [
+      SCHEME_PAYMENT_INFO_TYPEHASH,
+      paymentInfo.operator,
+      ZERO_ADDRESS,
+      paymentInfo.receiver,
+      paymentInfo.token,
+      BigInt(paymentInfo.maxAmount),
+      paymentInfo.preApprovalExpiry,
+      paymentInfo.authorizationExpiry,
+      paymentInfo.refundExpiry,
+      paymentInfo.minFeeBps,
+      paymentInfo.maxFeeBps,
+      paymentInfo.feeReceiver,
+      BigInt(paymentInfo.salt),
+    ],
+  );
+  const paymentInfoHash = keccak256(paymentInfoEncoded);
+
+  // Step 2: Encode (chainId, escrow, paymentInfoHash)
+  const outerEncoded = encodeAbiParameters(
+    [
+      { name: "chainId", type: "uint256" },
+      { name: "escrow", type: "address" },
+      { name: "paymentInfoHash", type: "bytes32" },
+    ],
+    [BigInt(chainId), escrowAddress, paymentInfoHash],
+  );
+
+  return keccak256(outerEncoded);
+}
+
+// ============ Test fixtures (matching existing test values) ============
+
+const escrowAddress = "0xb9488351E48b23D798f24e8174514F28B741Eb4f" as const;
+const chainId = 84532;
+
+// SDK-style PaymentInfo (bigint amounts)
+const sdkPaymentInfo: PaymentInfo = {
+  operator: "0x1234567890123456789012345678901234567890",
+  payer: "0x2345678901234567890123456789012345678901",
+  receiver: "0x3456789012345678901234567890123456789012",
+  token: "0x4567890123456789012345678901234567890123",
+  maxAmount: BigInt("1000000"),
+  preApprovalExpiry: BigInt(1735689600),
+  authorizationExpiry: BigInt(1735689600),
+  refundExpiry: BigInt(1738368000),
+  minFeeBps: 0,
+  maxFeeBps: 500,
+  feeReceiver: "0x5678901234567890123456789012345678901234",
+  salt: BigInt("0x123456789abcdef"),
+};
+
+// Scheme-style paymentInfo (string amounts, number expiries)
+const schemePaymentInfo = {
+  operator: "0x1234567890123456789012345678901234567890" as `0x${string}`,
+  receiver: "0x3456789012345678901234567890123456789012" as `0x${string}`,
+  token: "0x4567890123456789012345678901234567890123" as `0x${string}`,
+  maxAmount: "1000000",
+  preApprovalExpiry: 1735689600,
+  authorizationExpiry: 1735689600,
+  refundExpiry: 1738368000,
+  minFeeBps: 0,
+  maxFeeBps: 500,
+  feeReceiver: "0x5678901234567890123456789012345678901234" as `0x${string}`,
+  salt: "0x0123456789abcdef",
+};
+
+// ============ Tests ============
+
+describe("Cross-repo nonce consistency", () => {
+  it("PAYMENT_INFO_TYPEHASH matches between SDK (toHex) and scheme (TextEncoder)", () => {
+    expect(PAYMENT_INFO_TYPEHASH).toBe(SCHEME_PAYMENT_INFO_TYPEHASH);
+  });
+
+  it("computeEscrowNonce matches scheme nonce for identical inputs", () => {
+    const sdkNonce = computeEscrowNonce(chainId, escrowAddress, sdkPaymentInfo);
+    const schemeNonce = schemeComputeEscrowNonce(chainId, escrowAddress, schemePaymentInfo);
+    expect(sdkNonce).toBe(schemeNonce);
+  });
+
+  it("computePaymentInfoHash with zero payer matches scheme nonce", () => {
+    const zeroPayer: PaymentInfo = { ...sdkPaymentInfo, payer: ZERO_ADDRESS };
+    const sdkHash = computePaymentInfoHash(chainId, escrowAddress, zeroPayer);
+    const schemeNonce = schemeComputeEscrowNonce(chainId, escrowAddress, schemePaymentInfo);
+    expect(sdkHash).toBe(schemeNonce);
+  });
+
+  it("both produce different results for different chainId", () => {
+    const sdkNonce = computeEscrowNonce(1, escrowAddress, sdkPaymentInfo);
+    const schemeNonce = schemeComputeEscrowNonce(1, escrowAddress, schemePaymentInfo);
+    expect(sdkNonce).toBe(schemeNonce);
+    // Also verify it's different from the Base Sepolia result
+    const baseSepoliaNonce = computeEscrowNonce(chainId, escrowAddress, sdkPaymentInfo);
+    expect(sdkNonce).not.toBe(baseSepoliaNonce);
+  });
+
+  it("both produce different results for different escrow address", () => {
+    const altEscrow = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const;
+    const sdkNonce = computeEscrowNonce(chainId, altEscrow, sdkPaymentInfo);
+    const schemeNonce = schemeComputeEscrowNonce(chainId, altEscrow, schemePaymentInfo);
+    expect(sdkNonce).toBe(schemeNonce);
+  });
+
+  it("both produce different results for different maxAmount", () => {
+    const altSdkInfo = { ...sdkPaymentInfo, maxAmount: BigInt("2000000") };
+    const altSchemeInfo = { ...schemePaymentInfo, maxAmount: "2000000" };
+    const sdkNonce = computeEscrowNonce(chainId, escrowAddress, altSdkInfo);
+    const schemeNonce = schemeComputeEscrowNonce(chainId, escrowAddress, altSchemeInfo);
+    expect(sdkNonce).toBe(schemeNonce);
+  });
+});

--- a/packages/core/tests/utils.test.ts
+++ b/packages/core/tests/utils.test.ts
@@ -39,40 +39,40 @@ describe("computePaymentInfoHash", () => {
   const chainId = 84532; // Base Sepolia
 
   it("should return a bytes32 hash", () => {
-    const hash = computePaymentInfoHash(samplePaymentInfo, escrowAddress, chainId);
+    const hash = computePaymentInfoHash(chainId, escrowAddress, samplePaymentInfo);
     expect(hash).toMatch(/^0x[a-fA-F0-9]{64}$/);
   });
 
   it("should be deterministic", () => {
-    const hash1 = computePaymentInfoHash(samplePaymentInfo, escrowAddress, chainId);
-    const hash2 = computePaymentInfoHash(samplePaymentInfo, escrowAddress, chainId);
+    const hash1 = computePaymentInfoHash(chainId, escrowAddress, samplePaymentInfo);
+    const hash2 = computePaymentInfoHash(chainId, escrowAddress, samplePaymentInfo);
     expect(hash1).toBe(hash2);
   });
 
   it("should produce different hashes for different payment info", () => {
-    const hash1 = computePaymentInfoHash(samplePaymentInfo, escrowAddress, chainId);
+    const hash1 = computePaymentInfoHash(chainId, escrowAddress, samplePaymentInfo);
 
     const differentPaymentInfo = {
       ...samplePaymentInfo,
       maxAmount: BigInt("2000000"),
     };
-    const hash2 = computePaymentInfoHash(differentPaymentInfo, escrowAddress, chainId);
+    const hash2 = computePaymentInfoHash(chainId, escrowAddress, differentPaymentInfo);
 
     expect(hash1).not.toBe(hash2);
   });
 
   it("should produce different hashes for different escrow addresses", () => {
-    const hash1 = computePaymentInfoHash(samplePaymentInfo, escrowAddress, chainId);
+    const hash1 = computePaymentInfoHash(chainId, escrowAddress, samplePaymentInfo);
 
     const differentEscrow = "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as const;
-    const hash2 = computePaymentInfoHash(samplePaymentInfo, differentEscrow, chainId);
+    const hash2 = computePaymentInfoHash(chainId, differentEscrow, samplePaymentInfo);
 
     expect(hash1).not.toBe(hash2);
   });
 
   it("should produce different hashes for different chain IDs", () => {
-    const hash1 = computePaymentInfoHash(samplePaymentInfo, escrowAddress, chainId);
-    const hash2 = computePaymentInfoHash(samplePaymentInfo, escrowAddress, 1); // mainnet
+    const hash1 = computePaymentInfoHash(chainId, escrowAddress, samplePaymentInfo);
+    const hash2 = computePaymentInfoHash(1, escrowAddress, samplePaymentInfo); // mainnet
 
     expect(hash1).not.toBe(hash2);
   });
@@ -93,7 +93,7 @@ describe("computePaymentInfoHash", () => {
       salt: BigInt(0),
     };
 
-    const hash = computePaymentInfoHash(zeroPaymentInfo, escrowAddress, chainId);
+    const hash = computePaymentInfoHash(chainId, escrowAddress, zeroPaymentInfo);
     expect(hash).toMatch(/^0x[a-fA-F0-9]{64}$/);
   });
 
@@ -104,7 +104,7 @@ describe("computePaymentInfoHash", () => {
       salt: BigInt("0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"), // uint256 max
     };
 
-    const hash = computePaymentInfoHash(largePaymentInfo, escrowAddress, chainId);
+    const hash = computePaymentInfoHash(chainId, escrowAddress, largePaymentInfo);
     expect(hash).toMatch(/^0x[a-fA-F0-9]{64}$/);
   });
 });

--- a/packages/merchant/src/merchant.ts
+++ b/packages/merchant/src/merchant.ts
@@ -281,7 +281,7 @@ export class X402rMerchant {
       );
     }
 
-    const paymentInfoHash = computePaymentInfoHash(paymentInfo, this.escrowAddress, this.chainId);
+    const paymentInfoHash = computePaymentInfoHash(this.chainId, this.escrowAddress, paymentInfo);
 
     const state = await this.publicClient.readContract({
       address: this.escrowAddress,


### PR DESCRIPTION
## Summary

- **Hack 6 (Critical):** Reorder `computePaymentInfoHash` and `computeEscrowNonce` params from `(paymentInfo, escrowAddress, chainId)` to `(chainId, escrowAddress, paymentInfo)` — matching the scheme and Solidity contract encoding order. All 21 call sites updated. Cross-repo nonce consistency test added.
- **Hack 1 (Medium):** Change `toAbiPaymentInfo` return type from `any` to `never` — stops type leakage without any call-site changes. `eslint-disable` comment removed.
- **15 (Low):** Rename `createFacilitatorSignerFromViem` → `toFacilitatorEvmSigner` to match x402 naming. Deprecated re-export alias kept for backward compatibility.

## Test plan

- [x] `pnpm build` — all 5 packages build
- [x] `pnpm typecheck` — zero errors (TypeScript catches any missed param-order call sites since `PaymentInfo` vs `number` are different types)
- [x] `pnpm test` — 455 tests pass including new `nonce-cross-repo.test.ts` (6 tests)
- [x] `pnpm lint` — clean
- [x] Grep for stale patterns (`computePaymentInfoHash(paymentInfo`, `computeEscrowNonce(samplePaymentInfo`) — 0 results
- [x] E2E test on Base Sepolia: `PRIVATE_KEY=0x... pnpm example:e2e-test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)