### PR TITLE
SDK v0.0.2: resolve arbiter blockers

### DIFF
--- a/examples/dev-tools/arbiter-cli/src/index.ts
+++ b/examples/dev-tools/arbiter-cli/src/index.ts
@@ -113,7 +113,7 @@ program
     console.log("  Receiver:", receiverAddress);
 
     try {
-      const { keys, total } = await arbiter.getPendingRefundRequests(
+      const { keys, total } = await arbiter.getReceiverRefundRequests(
         offset,
         count,
         receiverAddress,

--- a/examples/dev-tools/merchant-cli/src/index.ts
+++ b/examples/dev-tools/merchant-cli/src/index.ts
@@ -290,7 +290,7 @@ program
     console.log("\nFetching pending refund requests...");
 
     try {
-      const { keys, total } = await merchant.getPendingRefundRequests(offset, count);
+      const { keys, total } = await merchant.getReceiverRefundRequests(offset, count);
       console.log(`\nFound ${total} total refund requests`);
 
       if (keys.length === 0) {

--- a/packages/arbiter/package.json
+++ b/packages/arbiter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/arbiter",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Arbiter SDK for dispute resolution in X402r refundable payments",
   "author": "x402r.org",
   "license": "Apache-2.0",

--- a/packages/arbiter/src/arbiter.ts
+++ b/packages/arbiter/src/arbiter.ts
@@ -15,11 +15,13 @@ import {
   ArbiterRegistryABI,
   RequestStatus,
   PaymentState,
+  computePaymentInfoHash as sharedComputePaymentInfoHash,
   toAbiPaymentInfo,
   hasRefundRequest as sharedHasRefundRequest,
   getRefundRequest as sharedGetRefundRequest,
   getRefundStatus as sharedGetRefundStatus,
   getRefundRequestByKey as sharedGetRefundRequestByKey,
+  getRefundRequestsByKeys as sharedGetRefundRequestsByKeys,
   approveRefundRequest as sharedApproveRefundRequest,
   denyRefundRequest as sharedDenyRefundRequest,
   isFrozen as sharedIsFrozen,
@@ -31,6 +33,7 @@ import {
   getAllEvidence as sharedGetAllEvidence,
   watchEvidenceSubmissions as sharedWatchEvidenceSubmissions,
   getPaymentState as sharedGetPaymentState,
+  indexPaymentInfoFromEvents as sharedIndexPaymentInfoFromEvents,
   getRefundBudget as sharedGetRefundBudget,
   approveRefundBudget as sharedApproveRefundBudget,
   refundPostEscrow as sharedRefundPostEscrow,
@@ -204,6 +207,58 @@ export class X402rArbiter {
     return sharedGetPaymentState(
       { publicClient: this.publicClient, escrowAddress: this.escrowAddress, chainId: this.chainId },
       paymentInfo,
+    );
+  }
+
+  /**
+   * Compute the paymentInfoHash for a PaymentInfo struct.
+   *
+   * Convenience wrapper that uses the instance's chainId and escrowAddress.
+   *
+   * @param paymentInfo - The payment information struct
+   * @returns The bytes32 hash
+   * @throws Error if escrowAddress is not configured
+   */
+  computePaymentInfoHash(paymentInfo: PaymentInfo): `0x${string}` {
+    if (!this.escrowAddress) {
+      throw new Error(
+        "Escrow address required. Use resolveAddresses(networkId) from @x402r/core to get the escrow address for your network.",
+      );
+    }
+    return sharedComputePaymentInfoHash(this.chainId, this.escrowAddress, paymentInfo);
+  }
+
+  /**
+   * Build a Map of paymentInfoHash → PaymentInfo by scanning RefundRequested events.
+   *
+   * @param opts - Optional block range and receiver filter
+   * @returns Map from paymentInfoHash to PaymentInfo
+   * @throws Error if escrowAddress or refundRequestAddress is not configured
+   */
+  async indexPaymentInfo(opts?: {
+    fromBlock?: bigint;
+    toBlock?: bigint;
+    receiver?: `0x${string}`;
+  }): Promise<Map<`0x${string}`, PaymentInfo>> {
+    if (!this.escrowAddress) {
+      throw new Error(
+        "Escrow address required. Use resolveAddresses(networkId) from @x402r/core to get the escrow address for your network.",
+      );
+    }
+    if (!this.refundRequestAddress) {
+      throw new Error(
+        "RefundRequest address required. Use resolveAddresses(networkId) from @x402r/core to get the address for your network.",
+      );
+    }
+
+    return sharedIndexPaymentInfoFromEvents(
+      {
+        publicClient: this.publicClient,
+        escrowAddress: this.escrowAddress,
+        chainId: this.chainId,
+        refundRequestAddress: this.refundRequestAddress,
+      },
+      opts,
     );
   }
 
@@ -463,19 +518,15 @@ export class X402rArbiter {
    * @param offset - Starting index (0-based)
    * @param count - Number of keys to return
    * @param receiverAddress - The receiver address to query (defaults to wallet account)
+   * @param options - Optional ordering: 'newest' returns newest-first, 'oldest' (default) returns oldest-first
    * @returns Object with keys array and total count
    * @throws Error if refundRequestAddress is not configured
-   *
-   * @example
-   * ```typescript
-   * const { keys, total } = await arbiter.getPendingRefundRequests(0n, 10n, '0x...');
-   * console.log(`${total} total cases, showing first ${keys.length}`);
-   * ```
    */
-  async getPendingRefundRequests(
+  async getReceiverRefundRequests(
     offset: bigint,
     count: bigint,
     receiverAddress?: `0x${string}`,
+    options?: { order?: "newest" | "oldest" },
   ): Promise<{ keys: readonly `0x${string}`[]; total: bigint }> {
     if (!this.refundRequestAddress) {
       throw new Error(
@@ -485,6 +536,25 @@ export class X402rArbiter {
 
     const address = receiverAddress ?? this.walletClient.account!.address;
 
+    if (options?.order === "newest") {
+      const total = await this.getRefundRequestCount(address);
+      const reverseOffset = total > offset + count ? total - offset - count : 0n;
+      const reverseCount = total > offset + count ? count : total - offset;
+
+      if (reverseCount <= 0n) {
+        return { keys: [], total };
+      }
+
+      const [keys] = (await this.publicClient.readContract({
+        address: this.refundRequestAddress,
+        abi: RefundRequestABI,
+        functionName: "getReceiverRefundRequests",
+        args: [address, reverseOffset, reverseCount],
+      })) as [readonly `0x${string}`[], bigint];
+
+      return { keys: [...keys].reverse(), total };
+    }
+
     const [keys, total] = (await this.publicClient.readContract({
       address: this.refundRequestAddress,
       abi: RefundRequestABI,
@@ -493,6 +563,18 @@ export class X402rArbiter {
     })) as [readonly `0x${string}`[], bigint];
 
     return { keys, total };
+  }
+
+  /**
+   * @deprecated Use `getReceiverRefundRequests` instead. This method returns all statuses, not just pending.
+   */
+  async getPendingRefundRequests(
+    offset: bigint,
+    count: bigint,
+    receiverAddress?: `0x${string}`,
+    options?: { order?: "newest" | "oldest" },
+  ): Promise<{ keys: readonly `0x${string}`[]; total: bigint }> {
+    return this.getReceiverRefundRequests(offset, count, receiverAddress, options);
   }
 
   /** Get the status of a refund request */
@@ -538,6 +620,14 @@ export class X402rArbiter {
   /** Get refund request data by composite key */
   async getRefundRequestByKey(compositeKey: `0x${string}`): Promise<RefundRequestData> {
     return sharedGetRefundRequestByKey(this.getRefundCtx(), compositeKey);
+  }
+
+  /** Batch-fetch refund request data for multiple composite keys */
+  async getRefundRequestsByKeys(
+    keys: readonly `0x${string}`[],
+    options?: { concurrency?: number },
+  ): Promise<Array<{ key: `0x${string}`; data?: RefundRequestData; error?: string }>> {
+    return sharedGetRefundRequestsByKeys(this.getRefundCtx(), keys, options);
   }
 
   // ============ Freeze Operations ============

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/client",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Client SDK for payers using X402r refundable payments",
   "author": "x402r.org",
   "license": "Apache-2.0",

--- a/packages/client/src/client.ts
+++ b/packages/client/src/client.ts
@@ -11,11 +11,13 @@ import {
   EscrowPeriodABI,
   FreezeABI,
   PaymentState,
+  computePaymentInfoHash as sharedComputePaymentInfoHash,
   toAbiPaymentInfo,
   hasRefundRequest as sharedHasRefundRequest,
   getRefundRequest as sharedGetRefundRequest,
   getRefundStatus as sharedGetRefundStatus,
   getRefundRequestByKey as sharedGetRefundRequestByKey,
+  getRefundRequestsByKeys as sharedGetRefundRequestsByKeys,
   isFrozen as sharedIsFrozen,
   watchFreezeEvents as sharedWatchFreezeEvents,
   submitEvidence as sharedSubmitEvidence,
@@ -174,6 +176,24 @@ export class X402rClient {
       { publicClient: this.publicClient, escrowAddress: this.escrowAddress, chainId: this.chainId },
       paymentInfo,
     );
+  }
+
+  /**
+   * Compute the paymentInfoHash for a PaymentInfo struct.
+   *
+   * Convenience wrapper that uses the instance's chainId and escrowAddress.
+   *
+   * @param paymentInfo - The payment information struct
+   * @returns The bytes32 hash
+   * @throws Error if escrowAddress is not configured
+   */
+  computePaymentInfoHash(paymentInfo: PaymentInfo): `0x${string}` {
+    if (!this.escrowAddress) {
+      throw new Error(
+        "Escrow address required. Use resolveAddresses(networkId) from @x402r/core to get the escrow address for your network.",
+      );
+    }
+    return sharedComputePaymentInfoHash(this.chainId, this.escrowAddress, paymentInfo);
   }
 
   /**
@@ -485,6 +505,14 @@ export class X402rClient {
   /** Get refund request data by composite key */
   async getRefundRequestByKey(compositeKey: `0x${string}`): Promise<RefundRequestData> {
     return sharedGetRefundRequestByKey(this.getRefundCtx(), compositeKey);
+  }
+
+  /** Batch-fetch refund request data for multiple composite keys */
+  async getRefundRequestsByKeys(
+    keys: readonly `0x${string}`[],
+    options?: { concurrency?: number },
+  ): Promise<Array<{ key: `0x${string}`; data?: RefundRequestData; error?: string }>> {
+    return sharedGetRefundRequestsByKeys(this.getRefundCtx(), keys, options);
   }
 
   // ============ Freeze Operations ============

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/core",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Core types, ABIs, and utilities for the X402r SDK",
   "author": "x402r.org",
   "license": "Apache-2.0",

--- a/packages/core/src/shared/evidence-operations.ts
+++ b/packages/core/src/shared/evidence-operations.ts
@@ -169,6 +169,47 @@ export async function getAllEvidence(
 }
 
 /**
+ * Resolve evidence content from an inline JSON string or an IPFS CID.
+ *
+ * Evidence entries store a `cid` field that may contain either:
+ * 1. Inline JSON (a stringified JSON object) — returned directly after parsing
+ * 2. An IPFS CID — fetched from the gateway and returned as parsed JSON
+ *
+ * @param cid - The evidence CID field value (inline JSON or IPFS CID)
+ * @param options - Optional gateway URL and custom fetch function
+ * @returns The parsed evidence content
+ * @throws Error if the content cannot be parsed or fetched
+ */
+export async function resolveEvidenceContent(
+  cid: string,
+  options?: { gateway?: string; fetchFn?: typeof fetch },
+): Promise<Record<string, unknown>> {
+  // Try inline JSON first
+  try {
+    const parsed = JSON.parse(cid);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Not inline JSON — treat as IPFS CID
+  }
+
+  const gateway = options?.gateway ?? "https://ipfs.io/ipfs/";
+  const fetchFn = options?.fetchFn ?? fetch;
+  const url = `${gateway}${cid}`;
+
+  const response = await fetchFn(url);
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch evidence from IPFS: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  const content = await response.json();
+  return content as Record<string, unknown>;
+}
+
+/**
  * Watch for new evidence submissions
  *
  * @param ctx - Read context with publicClient and refundRequestEvidenceAddress

--- a/packages/core/src/shared/index.ts
+++ b/packages/core/src/shared/index.ts
@@ -8,6 +8,7 @@ export {
   getRefundRequest,
   getRefundStatus,
   getRefundRequestByKey,
+  getRefundRequestsByKeys,
   approveRefundRequest,
   denyRefundRequest,
   type RefundReadContext,
@@ -22,6 +23,7 @@ export {
   getEvidenceCount,
   getEvidenceBatch,
   getAllEvidence,
+  resolveEvidenceContent,
   watchEvidenceSubmissions,
   type EvidenceReadContext,
   type EvidenceWriteContext,
@@ -30,6 +32,7 @@ export {
 export {
   getPaymentState,
   getPaymentDetails,
+  indexPaymentInfoFromEvents,
   type PaymentStateReadContext,
   type PaymentDetailsContext,
 } from "./payment-state-operations.js";

--- a/packages/core/src/shared/payment-state-operations.ts
+++ b/packages/core/src/shared/payment-state-operations.ts
@@ -4,7 +4,7 @@
  */
 
 import type { PublicClient } from "viem";
-import { AuthCaptureEscrowABI } from "../abis/index.js";
+import { AuthCaptureEscrowABI, RefundRequestABI } from "../abis/index.js";
 import { PaymentState, type PaymentInfo, type PaymentStore } from "../types/index.js";
 import { computePaymentInfoHash } from "../utils/index.js";
 
@@ -164,4 +164,78 @@ export async function getPaymentDetails(
   }
 
   return paymentInfo;
+}
+
+/** Maximum block range per RPC request (Base Sepolia limit) */
+const MAX_BLOCK_RANGE = 50_000n;
+
+/**
+ * Build a Map of paymentInfoHash → PaymentInfo by scanning RefundRequested events.
+ *
+ * The RefundRequest contract emits the full PaymentInfo tuple in each
+ * `RefundRequested` event, so this function can reconstruct PaymentInfo
+ * structs without requiring a separate PaymentStore.
+ *
+ * @param ctx - Read context with publicClient, escrowAddress, chainId, and refundRequestAddress
+ * @param opts - Optional block range and receiver filter
+ * @returns Map from paymentInfoHash to PaymentInfo
+ */
+export async function indexPaymentInfoFromEvents(
+  ctx: PaymentStateReadContext & { refundRequestAddress: `0x${string}` },
+  opts?: { fromBlock?: bigint; toBlock?: bigint; receiver?: `0x${string}` },
+): Promise<Map<`0x${string}`, PaymentInfo>> {
+  const toBlock = opts?.toBlock ?? (await ctx.publicClient.getBlockNumber());
+  const fromBlock = opts?.fromBlock ?? (toBlock > MAX_BLOCK_RANGE ? toBlock - MAX_BLOCK_RANGE : 0n);
+
+  const logs = await ctx.publicClient.getContractEvents({
+    address: ctx.refundRequestAddress,
+    abi: RefundRequestABI,
+    eventName: "RefundRequested",
+    args: opts?.receiver ? { receiver: opts.receiver } : undefined,
+    fromBlock,
+    toBlock,
+  });
+
+  const result = new Map<`0x${string}`, PaymentInfo>();
+
+  for (const log of logs) {
+    const args = log.args as {
+      paymentInfo?: {
+        operator: `0x${string}`;
+        payer: `0x${string}`;
+        receiver: `0x${string}`;
+        token: `0x${string}`;
+        maxAmount: bigint;
+        preApprovalExpiry: bigint;
+        authorizationExpiry: bigint;
+        refundExpiry: bigint;
+        minFeeBps: number;
+        maxFeeBps: number;
+        feeReceiver: `0x${string}`;
+        salt: bigint;
+      };
+    };
+
+    if (!args.paymentInfo) continue;
+
+    const paymentInfo: PaymentInfo = {
+      operator: args.paymentInfo.operator,
+      payer: args.paymentInfo.payer,
+      receiver: args.paymentInfo.receiver,
+      token: args.paymentInfo.token,
+      maxAmount: args.paymentInfo.maxAmount,
+      preApprovalExpiry: args.paymentInfo.preApprovalExpiry,
+      authorizationExpiry: args.paymentInfo.authorizationExpiry,
+      refundExpiry: args.paymentInfo.refundExpiry,
+      minFeeBps: Number(args.paymentInfo.minFeeBps),
+      maxFeeBps: Number(args.paymentInfo.maxFeeBps),
+      feeReceiver: args.paymentInfo.feeReceiver,
+      salt: args.paymentInfo.salt,
+    };
+
+    const hash = computePaymentInfoHash(ctx.chainId, ctx.escrowAddress, paymentInfo);
+    result.set(hash, paymentInfo);
+  }
+
+  return result;
 }

--- a/packages/core/src/shared/refund-operations.ts
+++ b/packages/core/src/shared/refund-operations.ts
@@ -113,6 +113,45 @@ export async function getRefundRequestByKey(
 }
 
 /**
+ * Batch-fetch refund request data for multiple composite keys.
+ *
+ * Processes keys in concurrent chunks using `Promise.allSettled` on
+ * the existing `getRefundRequestByKey` function.
+ *
+ * @param ctx - Read context with publicClient and refundRequestAddress
+ * @param keys - Array of composite keys to fetch
+ * @param options - Optional concurrency limit (default: 10)
+ * @returns Array of results with key, data (on success), and error (on failure)
+ */
+export async function getRefundRequestsByKeys(
+  ctx: RefundReadContext,
+  keys: readonly `0x${string}`[],
+  options?: { concurrency?: number },
+): Promise<Array<{ key: `0x${string}`; data?: RefundRequestData; error?: string }>> {
+  const concurrency = options?.concurrency ?? 10;
+  const results: Array<{ key: `0x${string}`; data?: RefundRequestData; error?: string }> = [];
+
+  for (let i = 0; i < keys.length; i += concurrency) {
+    const chunk = keys.slice(i, i + concurrency);
+    const settled = await Promise.allSettled(chunk.map(key => getRefundRequestByKey(ctx, key)));
+
+    for (let j = 0; j < chunk.length; j++) {
+      const result = settled[j];
+      if (result.status === "fulfilled") {
+        results.push({ key: chunk[j], data: result.value });
+      } else {
+        results.push({
+          key: chunk[j],
+          error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+        });
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
  * Approve a refund request
  *
  * @param ctx - Write context with publicClient, walletClient, and refundRequestAddress

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -311,6 +311,38 @@ export interface EvidenceEventLog {
   logIndex: number;
 }
 
+// ============ Evidence Content Types ============
+
+/** Evidence submitted by an arbiter with a ruling decision */
+export interface ArbiterRulingEvidence {
+  type: "arbiter-ruling";
+  decision: "approve" | "deny";
+  reasoning: string;
+  confidence?: number;
+  commitment?: string;
+  model?: string;
+}
+
+/** Evidence submitted by a payer requesting a refund */
+export interface PayerRefundEvidence {
+  type: "payer-refund-request";
+  reason: string;
+  description?: string;
+}
+
+/** Evidence submitted by a merchant responding to a dispute */
+export interface MerchantResponseEvidence {
+  type: "merchant-response";
+  response: string;
+  description?: string;
+}
+
+/** Union of all standard evidence content types */
+export type EvidenceContent =
+  | ArbiterRulingEvidence
+  | PayerRefundEvidence
+  | MerchantResponseEvidence;
+
 /**
  * Typed event log for PaymentOperator events (ReleaseExecuted, AuthorizationCreated, etc.)
  */

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/helpers",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Server-side helpers for x402r refundable payments",
   "author": "x402r.org",
   "license": "Apache-2.0",

--- a/packages/merchant/package.json
+++ b/packages/merchant/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/merchant",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Merchant SDK for servers using X402r refundable payments",
   "author": "x402r.org",
   "license": "Apache-2.0",

--- a/packages/merchant/src/merchant.ts
+++ b/packages/merchant/src/merchant.ts
@@ -17,6 +17,7 @@ import {
   getRefundRequest as sharedGetRefundRequest,
   getRefundStatus as sharedGetRefundStatus,
   getRefundRequestByKey as sharedGetRefundRequestByKey,
+  getRefundRequestsByKeys as sharedGetRefundRequestsByKeys,
   approveRefundRequest as sharedApproveRefundRequest,
   denyRefundRequest as sharedDenyRefundRequest,
   isFrozen as sharedIsFrozen,
@@ -198,6 +199,24 @@ export class X402rMerchant {
       { publicClient: this.publicClient, escrowAddress: this.escrowAddress, chainId: this.chainId },
       paymentInfo,
     );
+  }
+
+  /**
+   * Compute the paymentInfoHash for a PaymentInfo struct.
+   *
+   * Convenience wrapper that uses the instance's chainId and escrowAddress.
+   *
+   * @param paymentInfo - The payment information struct
+   * @returns The bytes32 hash
+   * @throws Error if escrowAddress is not configured
+   */
+  computePaymentInfoHash(paymentInfo: PaymentInfo): `0x${string}` {
+    if (!this.escrowAddress) {
+      throw new Error(
+        "Escrow address required. Use resolveAddresses(networkId) from @x402r/core to get the escrow address for your network.",
+      );
+    }
+    return computePaymentInfoHash(this.chainId, this.escrowAddress, paymentInfo);
   }
 
   /**
@@ -744,18 +763,14 @@ export class X402rMerchant {
    *
    * @param offset - Starting index (0-based)
    * @param count - Number of keys to return
+   * @param options - Optional ordering: 'newest' returns newest-first, 'oldest' (default) returns oldest-first
    * @returns Object with keys array and total count
    * @throws Error if refundRequestAddress is not configured
-   *
-   * @example
-   * ```typescript
-   * const { keys, total } = await merchant.getPendingRefundRequests(0n, 10n);
-   * console.log(`Found ${total} refund requests, showing first ${keys.length}`);
-   * ```
    */
-  async getPendingRefundRequests(
+  async getReceiverRefundRequests(
     offset: bigint,
     count: bigint,
+    options?: { order?: "newest" | "oldest" },
   ): Promise<{ keys: readonly `0x${string}`[]; total: bigint }> {
     if (!this.refundRequestAddress) {
       throw new Error(
@@ -763,14 +778,46 @@ export class X402rMerchant {
       );
     }
 
+    const address = this.walletClient.account!.address;
+
+    if (options?.order === "newest") {
+      const total = await this.getRefundRequestCount();
+      const reverseOffset = total > offset + count ? total - offset - count : 0n;
+      const reverseCount = total > offset + count ? count : total - offset;
+
+      if (reverseCount <= 0n) {
+        return { keys: [], total };
+      }
+
+      const [keys] = (await this.publicClient.readContract({
+        address: this.refundRequestAddress,
+        abi: RefundRequestABI,
+        functionName: "getReceiverRefundRequests",
+        args: [address, reverseOffset, reverseCount],
+      })) as [readonly `0x${string}`[], bigint];
+
+      return { keys: [...keys].reverse(), total };
+    }
+
     const [keys, total] = (await this.publicClient.readContract({
       address: this.refundRequestAddress,
       abi: RefundRequestABI,
       functionName: "getReceiverRefundRequests",
-      args: [this.walletClient.account!.address, offset, count],
+      args: [address, offset, count],
     })) as [readonly `0x${string}`[], bigint];
 
     return { keys, total };
+  }
+
+  /**
+   * @deprecated Use `getReceiverRefundRequests` instead. This method returns all statuses, not just pending.
+   */
+  async getPendingRefundRequests(
+    offset: bigint,
+    count: bigint,
+    options?: { order?: "newest" | "oldest" },
+  ): Promise<{ keys: readonly `0x${string}`[]; total: bigint }> {
+    return this.getReceiverRefundRequests(offset, count, options);
   }
 
   /**
@@ -805,6 +852,14 @@ export class X402rMerchant {
   /** Get refund request data by composite key */
   async getRefundRequestByKey(compositeKey: `0x${string}`): Promise<RefundRequestData> {
     return sharedGetRefundRequestByKey(this.getRefundCtx(), compositeKey);
+  }
+
+  /** Batch-fetch refund request data for multiple composite keys */
+  async getRefundRequestsByKeys(
+    keys: readonly `0x${string}`[],
+    options?: { concurrency?: number },
+  ): Promise<Array<{ key: `0x${string}`; data?: RefundRequestData; error?: string }>> {
+    return sharedGetRefundRequestsByKeys(this.getRefundCtx(), keys, options);
   }
 
   // ============ Freeze Management ============


### PR DESCRIPTION
## Summary

- **Version bump** to 0.0.2 across all 5 packages (core, arbiter, client, merchant, helpers)
- **`indexPaymentInfoFromEvents()`** — scan `RefundRequested` events to build `Map<hash, PaymentInfo>`, eliminating ~50 lines of arbiter boilerplate
- **`getRefundRequestsByKeys()`** — batch-fetch refund request data with configurable concurrency (default 10), replacing N sequential RPC calls
- **`resolveEvidenceContent()`** — resolve evidence from inline JSON or IPFS CID with a single function call
- **`computePaymentInfoHash()` instance methods** — convenience wrappers on arbiter, client, merchant that use the instance's chainId/escrowAddress
- **Newest-first pagination** — `{ order: 'newest' }` option on `getReceiverRefundRequests()` in arbiter and merchant
- **Standard evidence content types** — `ArbiterRulingEvidence`, `PayerRefundEvidence`, `MerchantResponseEvidence`, `EvidenceContent` union
- **Rename `getPendingRefundRequests` → `getReceiverRefundRequests`** — old name kept as `@deprecated` alias for backwards compat
- **Example updates** — arbiter-cli and merchant-cli use the new method name

### Why `workspace:*` is fixed without code changes

`pnpm -r publish` (not `npm publish`) rewrites `"@x402r/core": "workspace:*"` → `"@x402r/core": "0.0.2"` in the tarball. v0.0.1 was broken because bare `npm publish` was used.

## Test plan

- [x] `pnpm build` — 5 packages built
- [x] `pnpm test` — 480 tests pass (37 files, 5 packages)
- [x] `pnpm lint:check` — clean
- [x] `pnpm typecheck` — clean
- [x] `prettier --check` — clean
- [x] `pnpm docs:generate` — TypeDoc regenerated
- [x] **E2E on Base Sepolia** — 19/19 steps pass (full payment lifecycle: authorize → refund → freeze → evidence → approve → execute → distribute fees)

🤖 Generated with [Claude Code](https://claude.com/claude-code)