### PR TITLE
fix(core): deduplicate fixtures, use viem utilities, add refundExpiry check

### DIFF
--- a/packages/core/src/validation/index.ts
+++ b/packages/core/src/validation/index.ts
@@ -57,4 +57,8 @@ export function validatePaymentInfo(paymentInfo: PaymentInfo): void {
         'an expired value will cause the authorization signature to be rejected',
     )
   }
+
+  if (paymentInfo.refundExpiry > 0 && paymentInfo.refundExpiry <= nowSeconds) {
+    throw new ValidationError('refundExpiry is in the past')
+  }
 }

--- a/packages/core/tests/fixtures.ts
+++ b/packages/core/tests/fixtures.ts
@@ -1,0 +1,36 @@
+import { zeroAddress } from 'viem'
+import type { PaymentInfo } from '../src/types/index.js'
+
+export { zeroAddress }
+
+export const TEST_CHAIN_ID = 84532
+export const TEST_ESCROW_ADDRESS =
+  '0xb9488351E48b23D798f24e8174514F28B741Eb4f' as const
+
+export const TEST_ADDRESSES = {
+  operator: '0x1234567890123456789012345678901234567890',
+  payer: '0x2345678901234567890123456789012345678901',
+  receiver: '0x3456789012345678901234567890123456789012',
+  token: '0x4567890123456789012345678901234567890123',
+  feeReceiver: '0x5678901234567890123456789012345678901234',
+} as const
+
+export function makePaymentInfo(
+  overrides: Partial<PaymentInfo> = {},
+): PaymentInfo {
+  return {
+    operator: TEST_ADDRESSES.operator,
+    payer: TEST_ADDRESSES.payer,
+    receiver: TEST_ADDRESSES.receiver,
+    token: TEST_ADDRESSES.token,
+    maxAmount: 1000000n,
+    preApprovalExpiry: 0,
+    authorizationExpiry: 1735689600,
+    refundExpiry: 1738368000,
+    minFeeBps: 0,
+    maxFeeBps: 500,
+    feeReceiver: TEST_ADDRESSES.feeReceiver,
+    salt: 0x123456789abcdefn,
+    ...overrides,
+  }
+}

--- a/packages/core/tests/hashing.test.ts
+++ b/packages/core/tests/hashing.test.ts
@@ -4,25 +4,14 @@ import {
   computePaymentInfoHash,
   PAYMENT_INFO_TYPEHASH,
 } from '../src/hashing/index.js'
-import type { PaymentInfo } from '../src/types/index.js'
+import {
+  makePaymentInfo,
+  TEST_CHAIN_ID,
+  TEST_ESCROW_ADDRESS,
+  zeroAddress,
+} from './fixtures.js'
 
-const samplePaymentInfo: PaymentInfo = {
-  operator: '0x1234567890123456789012345678901234567890',
-  payer: '0x2345678901234567890123456789012345678901',
-  receiver: '0x3456789012345678901234567890123456789012',
-  token: '0x4567890123456789012345678901234567890123',
-  maxAmount: 1000000n,
-  preApprovalExpiry: 0,
-  authorizationExpiry: 1735689600,
-  refundExpiry: 1738368000,
-  minFeeBps: 0,
-  maxFeeBps: 500,
-  feeReceiver: '0x5678901234567890123456789012345678901234',
-  salt: 0x123456789abcdefn,
-}
-
-const escrowAddress = '0xb9488351E48b23D798f24e8174514F28B741Eb4f' as const
-const chainId = 84532
+const samplePaymentInfo = makePaymentInfo()
 
 // ---------------------------------------------------------------------------
 // PAYMENT_INFO_TYPEHASH
@@ -44,11 +33,11 @@ describe('PAYMENT_INFO_TYPEHASH', () => {
 describe('computePaymentInfoHash', () => {
   it('produces different hashes for different payment info', () => {
     const hash1 = computePaymentInfoHash(
-      chainId,
-      escrowAddress,
+      TEST_CHAIN_ID,
+      TEST_ESCROW_ADDRESS,
       samplePaymentInfo,
     )
-    const hash2 = computePaymentInfoHash(chainId, escrowAddress, {
+    const hash2 = computePaymentInfoHash(TEST_CHAIN_ID, TEST_ESCROW_ADDRESS, {
       ...samplePaymentInfo,
       maxAmount: 2000000n,
     })
@@ -57,12 +46,12 @@ describe('computePaymentInfoHash', () => {
 
   it('produces different hashes for different escrow addresses', () => {
     const hash1 = computePaymentInfoHash(
-      chainId,
-      escrowAddress,
+      TEST_CHAIN_ID,
+      TEST_ESCROW_ADDRESS,
       samplePaymentInfo,
     )
     const hash2 = computePaymentInfoHash(
-      chainId,
+      TEST_CHAIN_ID,
       '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       samplePaymentInfo,
     )
@@ -71,11 +60,15 @@ describe('computePaymentInfoHash', () => {
 
   it('produces different hashes for different chain IDs', () => {
     const hash1 = computePaymentInfoHash(
-      chainId,
-      escrowAddress,
+      TEST_CHAIN_ID,
+      TEST_ESCROW_ADDRESS,
       samplePaymentInfo,
     )
-    const hash2 = computePaymentInfoHash(1, escrowAddress, samplePaymentInfo)
+    const hash2 = computePaymentInfoHash(
+      1,
+      TEST_ESCROW_ADDRESS,
+      samplePaymentInfo,
+    )
     expect(hash1).not.toBe(hash2)
   })
 })
@@ -86,8 +79,12 @@ describe('computePaymentInfoHash', () => {
 
 describe('computeEscrowNonce', () => {
   it('is payer-agnostic (ignores payer field)', () => {
-    const n1 = computeEscrowNonce(chainId, escrowAddress, samplePaymentInfo)
-    const n2 = computeEscrowNonce(chainId, escrowAddress, {
+    const n1 = computeEscrowNonce(
+      TEST_CHAIN_ID,
+      TEST_ESCROW_ADDRESS,
+      samplePaymentInfo,
+    )
+    const n2 = computeEscrowNonce(TEST_CHAIN_ID, TEST_ESCROW_ADDRESS, {
       ...samplePaymentInfo,
       payer: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     })
@@ -95,17 +92,25 @@ describe('computeEscrowNonce', () => {
   })
 
   it('matches computePaymentInfoHash with zero payer', () => {
-    const nonce = computeEscrowNonce(chainId, escrowAddress, samplePaymentInfo)
-    const hash = computePaymentInfoHash(chainId, escrowAddress, {
+    const nonce = computeEscrowNonce(
+      TEST_CHAIN_ID,
+      TEST_ESCROW_ADDRESS,
+      samplePaymentInfo,
+    )
+    const hash = computePaymentInfoHash(TEST_CHAIN_ID, TEST_ESCROW_ADDRESS, {
       ...samplePaymentInfo,
-      payer: '0x0000000000000000000000000000000000000000',
+      payer: zeroAddress,
     })
     expect(nonce).toBe(hash)
   })
 
   it('produces different nonces for different maxAmount', () => {
-    const n1 = computeEscrowNonce(chainId, escrowAddress, samplePaymentInfo)
-    const n2 = computeEscrowNonce(chainId, escrowAddress, {
+    const n1 = computeEscrowNonce(
+      TEST_CHAIN_ID,
+      TEST_ESCROW_ADDRESS,
+      samplePaymentInfo,
+    )
+    const n2 = computeEscrowNonce(TEST_CHAIN_ID, TEST_ESCROW_ADDRESS, {
       ...samplePaymentInfo,
       maxAmount: 2000000n,
     })

--- a/packages/core/tests/nonce-cross-repo.test.ts
+++ b/packages/core/tests/nonce-cross-repo.test.ts
@@ -6,6 +6,7 @@ import {
   PAYMENT_INFO_TYPEHASH,
 } from '../src/hashing/index.js'
 import type { PaymentInfo } from '../src/types/index.js'
+import { TEST_CHAIN_ID, TEST_ESCROW_ADDRESS, zeroAddress } from './fixtures.js'
 
 // --- Scheme-style nonce (inline reimplementation) ---
 
@@ -16,8 +17,6 @@ const SCHEME_PAYMENT_INFO_TYPEHASH = keccak256(
     'PaymentInfo(address operator,address payer,address receiver,address token,uint120 maxAmount,uint48 preApprovalExpiry,uint48 authorizationExpiry,uint48 refundExpiry,uint16 minFeeBps,uint16 maxFeeBps,address feeReceiver,uint256 salt)',
   ),
 )
-
-const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000' as const
 
 function schemeComputeEscrowNonce(
   chainId: number,
@@ -55,7 +54,7 @@ function schemeComputeEscrowNonce(
     [
       SCHEME_PAYMENT_INFO_TYPEHASH,
       paymentInfo.operator,
-      ZERO_ADDRESS,
+      zeroAddress,
       paymentInfo.receiver,
       paymentInfo.token,
       BigInt(paymentInfo.maxAmount),
@@ -82,10 +81,7 @@ function schemeComputeEscrowNonce(
   return keccak256(outerEncoded)
 }
 
-// --- Test fixtures ---
-
-const escrowAddress = '0xb9488351E48b23D798f24e8174514F28B741Eb4f' as const
-const chainId = 84532
+// --- Test fixtures (local — scheme uses string-typed fields) ---
 
 const sdkPaymentInfo: PaymentInfo = {
   operator: '0x1234567890123456789012345678901234567890',
@@ -124,10 +120,14 @@ describe('Cross-repo nonce consistency', () => {
   })
 
   it('computeEscrowNonce matches scheme nonce for identical inputs', () => {
-    const sdkNonce = computeEscrowNonce(chainId, escrowAddress, sdkPaymentInfo)
+    const sdkNonce = computeEscrowNonce(
+      TEST_CHAIN_ID,
+      TEST_ESCROW_ADDRESS,
+      sdkPaymentInfo,
+    )
     const schemeNonce = schemeComputeEscrowNonce(
-      chainId,
-      escrowAddress,
+      TEST_CHAIN_ID,
+      TEST_ESCROW_ADDRESS,
       schemePaymentInfo,
     )
     expect(sdkNonce).toBe(schemeNonce)
@@ -136,12 +136,16 @@ describe('Cross-repo nonce consistency', () => {
   it('computePaymentInfoHash with zero payer matches scheme nonce', () => {
     const zeroPayer: PaymentInfo = {
       ...sdkPaymentInfo,
-      payer: ZERO_ADDRESS,
+      payer: zeroAddress,
     }
-    const sdkHash = computePaymentInfoHash(chainId, escrowAddress, zeroPayer)
+    const sdkHash = computePaymentInfoHash(
+      TEST_CHAIN_ID,
+      TEST_ESCROW_ADDRESS,
+      zeroPayer,
+    )
     const schemeNonce = schemeComputeEscrowNonce(
-      chainId,
-      escrowAddress,
+      TEST_CHAIN_ID,
+      TEST_ESCROW_ADDRESS,
       schemePaymentInfo,
     )
     expect(sdkHash).toBe(schemeNonce)

--- a/packages/core/tests/serialization.test.ts
+++ b/packages/core/tests/serialization.test.ts
@@ -1,11 +1,12 @@
 import type { EscrowPayload } from '@x402r/evm'
 import { describe, expect, it } from 'vitest'
 import { toPaymentInfo } from '../src/serialization/index.js'
+import { TEST_ADDRESSES } from './fixtures.js'
 
 const basePayload: EscrowPayload = {
   authorization: {
-    from: '0xPayerAddress0000000000000000000000000001',
-    to: '0xReceiverAddr000000000000000000000000001',
+    from: TEST_ADDRESSES.payer,
+    to: TEST_ADDRESSES.receiver,
     value: '1000000',
     validAfter: '0',
     validBefore: '1700000000',
@@ -13,16 +14,16 @@ const basePayload: EscrowPayload = {
   },
   signature: '0xdeadbeef',
   paymentInfo: {
-    operator: '0xOperatorAddr000000000000000000000000001',
-    receiver: '0xReceiverAddr000000000000000000000000001',
-    token: '0xTokenAddress00000000000000000000000000001',
+    operator: TEST_ADDRESSES.operator,
+    receiver: TEST_ADDRESSES.receiver,
+    token: TEST_ADDRESSES.token,
     maxAmount: '1000000',
     preApprovalExpiry: 1700000000,
     authorizationExpiry: 1700001000,
     refundExpiry: 1700002000,
     minFeeBps: 50,
     maxFeeBps: 500,
-    feeReceiver: '0xFeeReceiverA000000000000000000000000001',
+    feeReceiver: TEST_ADDRESSES.feeReceiver,
     salt: '0x3039',
   },
 }
@@ -36,15 +37,15 @@ describe('toPaymentInfo', () => {
 
   it('extracts payer from authorization.from', () => {
     const result = toPaymentInfo(basePayload)
-    expect(result.payer).toBe('0xPayerAddress0000000000000000000000000001')
+    expect(result.payer).toBe(TEST_ADDRESSES.payer)
   })
 
   it('passes through address and number fields unchanged', () => {
     const result = toPaymentInfo(basePayload)
-    expect(result.operator).toBe('0xOperatorAddr000000000000000000000000001')
-    expect(result.receiver).toBe('0xReceiverAddr000000000000000000000000001')
-    expect(result.token).toBe('0xTokenAddress00000000000000000000000000001')
-    expect(result.feeReceiver).toBe('0xFeeReceiverA000000000000000000000000001')
+    expect(result.operator).toBe(TEST_ADDRESSES.operator)
+    expect(result.receiver).toBe(TEST_ADDRESSES.receiver)
+    expect(result.token).toBe(TEST_ADDRESSES.token)
+    expect(result.feeReceiver).toBe(TEST_ADDRESSES.feeReceiver)
     expect(result.minFeeBps).toBe(50)
     expect(result.maxFeeBps).toBe(500)
   })

--- a/packages/core/tests/validation.test.ts
+++ b/packages/core/tests/validation.test.ts
@@ -1,78 +1,79 @@
 import { describe, expect, it } from 'vitest'
 import { ValidationError } from '../src/errors/index.js'
-import type { PaymentInfo } from '../src/types/index.js'
 import { validatePaymentInfo } from '../src/validation/index.js'
+import { makePaymentInfo, zeroAddress } from './fixtures.js'
 
 const futureTimestamp = Math.floor(Date.now() / 1000) + 3600
-
-function makeValidPaymentInfo(
-  overrides: Partial<PaymentInfo> = {},
-): PaymentInfo {
-  return {
-    operator: '0x1234567890123456789012345678901234567890',
-    payer: '0x2345678901234567890123456789012345678901',
-    receiver: '0x3456789012345678901234567890123456789012',
-    token: '0x036CbD53842c5426634e7929541eC2318f3dCF7e',
-    maxAmount: 1000000n,
-    preApprovalExpiry: futureTimestamp,
-    authorizationExpiry: futureTimestamp,
-    refundExpiry: futureTimestamp + 86400,
-    minFeeBps: 0,
-    maxFeeBps: 1000,
-    feeReceiver: '0x1234567890123456789012345678901234567890',
-    salt: 12345n,
-    ...overrides,
-  }
+const validOverrides = {
+  preApprovalExpiry: futureTimestamp,
+  authorizationExpiry: futureTimestamp,
+  refundExpiry: futureTimestamp + 86400,
 }
-
-const ZERO = '0x0000000000000000000000000000000000000000' as const
 
 describe('validatePaymentInfo', () => {
   it('does not throw for valid PaymentInfo', () => {
-    expect(() => validatePaymentInfo(makeValidPaymentInfo())).not.toThrow()
+    expect(() =>
+      validatePaymentInfo(makePaymentInfo(validOverrides)),
+    ).not.toThrow()
   })
 
   it('throws for zero operator', () => {
     expect(() =>
-      validatePaymentInfo(makeValidPaymentInfo({ operator: ZERO })),
+      validatePaymentInfo(
+        makePaymentInfo({ ...validOverrides, operator: zeroAddress }),
+      ),
     ).toThrow(ValidationError)
   })
 
   it('throws for zero receiver', () => {
     expect(() =>
-      validatePaymentInfo(makeValidPaymentInfo({ receiver: ZERO })),
+      validatePaymentInfo(
+        makePaymentInfo({ ...validOverrides, receiver: zeroAddress }),
+      ),
     ).toThrow(ValidationError)
   })
 
   it('throws for zero token', () => {
     expect(() =>
-      validatePaymentInfo(makeValidPaymentInfo({ token: ZERO })),
+      validatePaymentInfo(
+        makePaymentInfo({ ...validOverrides, token: zeroAddress }),
+      ),
     ).toThrow(ValidationError)
   })
 
   it('throws for zero feeReceiver', () => {
     expect(() =>
-      validatePaymentInfo(makeValidPaymentInfo({ feeReceiver: ZERO })),
+      validatePaymentInfo(
+        makePaymentInfo({ ...validOverrides, feeReceiver: zeroAddress }),
+      ),
     ).toThrow(ValidationError)
   })
 
   it('throws for zero maxAmount', () => {
     expect(() =>
-      validatePaymentInfo(makeValidPaymentInfo({ maxAmount: 0n })),
+      validatePaymentInfo(
+        makePaymentInfo({ ...validOverrides, maxAmount: 0n }),
+      ),
     ).toThrow(ValidationError)
   })
 
   it('throws when minFeeBps > maxFeeBps', () => {
     expect(() =>
       validatePaymentInfo(
-        makeValidPaymentInfo({ minFeeBps: 500, maxFeeBps: 100 }),
+        makePaymentInfo({
+          ...validOverrides,
+          minFeeBps: 500,
+          maxFeeBps: 100,
+        }),
       ),
     ).toThrow(ValidationError)
   })
 
   it('throws when maxFeeBps > 10000', () => {
     expect(() =>
-      validatePaymentInfo(makeValidPaymentInfo({ maxFeeBps: 15000 })),
+      validatePaymentInfo(
+        makePaymentInfo({ ...validOverrides, maxFeeBps: 15000 }),
+      ),
     ).toThrow(ValidationError)
   })
 
@@ -80,7 +81,10 @@ describe('validatePaymentInfo', () => {
     const pastTimestamp = Math.floor(Date.now() / 1000) - 3600
     expect(() =>
       validatePaymentInfo(
-        makeValidPaymentInfo({ authorizationExpiry: pastTimestamp }),
+        makePaymentInfo({
+          ...validOverrides,
+          authorizationExpiry: pastTimestamp,
+        }),
       ),
     ).toThrow(ValidationError)
   })
@@ -89,20 +93,44 @@ describe('validatePaymentInfo', () => {
     const pastTimestamp = Math.floor(Date.now() / 1000) - 3600
     expect(() =>
       validatePaymentInfo(
-        makeValidPaymentInfo({ preApprovalExpiry: pastTimestamp }),
+        makePaymentInfo({
+          ...validOverrides,
+          preApprovalExpiry: pastTimestamp,
+        }),
       ),
     ).toThrow(ValidationError)
   })
 
   it('does not throw when preApprovalExpiry is zero', () => {
     expect(() =>
-      validatePaymentInfo(makeValidPaymentInfo({ preApprovalExpiry: 0 })),
+      validatePaymentInfo(
+        makePaymentInfo({ ...validOverrides, preApprovalExpiry: 0 }),
+      ),
     ).not.toThrow()
   })
 
   it('allows payer to be zero address (payer-agnostic)', () => {
     expect(() =>
-      validatePaymentInfo(makeValidPaymentInfo({ payer: ZERO })),
+      validatePaymentInfo(
+        makePaymentInfo({ ...validOverrides, payer: zeroAddress }),
+      ),
+    ).not.toThrow()
+  })
+
+  it('throws for expired refundExpiry', () => {
+    const pastTimestamp = Math.floor(Date.now() / 1000) - 3600
+    expect(() =>
+      validatePaymentInfo(
+        makePaymentInfo({ ...validOverrides, refundExpiry: pastTimestamp }),
+      ),
+    ).toThrow(ValidationError)
+  })
+
+  it('does not throw when refundExpiry is zero', () => {
+    expect(() =>
+      validatePaymentInfo(
+        makePaymentInfo({ ...validOverrides, refundExpiry: 0 }),
+      ),
     ).not.toThrow()
   })
 })


### PR DESCRIPTION
## Summary
- Extract shared test constants (`TEST_CHAIN_ID`, `TEST_ESCROW_ADDRESS`, `TEST_ADDRESSES`) and `makePaymentInfo()` builder into `tests/fixtures.ts`, eliminating duplication across 4 test files
- Replace hardcoded zero addresses with viem's `zeroAddress` in all test files
- Fix malformed non-hex test addresses (`0xPayerAddress...`) in serialization tests
- Add `refundExpiry` past-check to `validatePaymentInfo()` — a past `refundExpiry` means the escrow can never be refunded

## Test plan
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — 51 tests passing (49 existing + 2 new refundExpiry tests)
- [x] `pnpm biome check .` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)