### PR TITLE
test(sdk): address PR #69 review feedback

### DIFF
--- a/packages/sdk/tests/actions/refund.test.ts
+++ b/packages/sdk/tests/actions/refund.test.ts
@@ -1,5 +1,5 @@
 import { ValidationError } from '@x402r/core'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createRefundActions } from '../../src/actions/refund.js'
 import {
   createTestConfig,
@@ -79,6 +79,8 @@ import {
 // ---------------------------------------------------------------------------
 
 describe('createRefundActions', () => {
+  beforeEach(() => vi.clearAllMocks())
+
   // ---- Existing tests (fixed assertions) ------------------------------------
 
   it('request injects refundRequestAddress as contractAddress', async () => {

--- a/packages/sdk/tests/fixtures.ts
+++ b/packages/sdk/tests/fixtures.ts
@@ -42,7 +42,7 @@ export const mockPaymentInfo = {
   maxFeeBps: 500,
   feeReceiver: '0x4234567890abcdef1234567890abcdef12345678',
   salt: 1n,
-} as unknown as PaymentInfo
+} satisfies PaymentInfo
 
 export function createTestConfig(
   overrides?: Partial<ResolvedConfig>,


### PR DESCRIPTION
## Summary
- Add `beforeEach(() => vi.clearAllMocks())` to refund tests to prevent mock call history leaking between tests
- Replace `as unknown as PaymentInfo` with `satisfies PaymentInfo` in test fixtures for compile-time type checking

## Context
Addresses valid suggestions from PR #69 review:
1. **clearAllMocks** — defensive hygiene to prevent future test fragility if `toHaveBeenCalledTimes()` assertions are added
2. **satisfies** — catches type mismatches at compile time instead of silently casting

## Test plan
- [x] All 53 SDK tests pass (`pnpm --filter=@x402r/sdk test`)
- [x] Pre-commit hooks pass (biome check, build, typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)