### PR TITLE
chore(sdk): trim internal core re-exports

### DIFF
--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -6,11 +6,8 @@
 // Core re-exports — types
 // ---------------------------------------------------------------------------
 export type {
-  ConditionConfig,
-  ConditionSingletonAddresses,
   ConditionSlot,
   EvidenceEntry,
-  FactoryAddresses,
   FeeAddresses,
   FeeCalculationResult,
   GetAuthorizedFeesReturnType,
@@ -32,18 +29,13 @@ export type {
 export {
   ConfigError,
   ContractCallError,
-  computeEscrowNonce,
   computePaymentInfoHash,
   formatFeeBreakdown,
-  fromNetworkId,
   getChainConfig,
   isSupportedChain,
-  NotImplementedError,
   RefundRequestStatus,
   SubmitterRole,
   supportedChainIds,
-  toNetworkId,
-  toPaymentInfo,
   ValidationError,
   validateFeeBounds,
   validatePaymentInfo,


### PR DESCRIPTION
## Summary
- Remove 3 type re-exports (`ConditionConfig`, `ConditionSingletonAddresses`, `FactoryAddresses`) — deploy-time concerns not needed by SDK consumers
- Remove 5 value re-exports (`NotImplementedError`, `computeEscrowNonce`, `fromNetworkId`, `toNetworkId`, `toPaymentInfo`) — internal helpers the SDK handles internally
- Barrel now exports 16 types + 12 values from `@x402r/core`

## Test plan
- [x] `pnpm --filter=@x402r/sdk build` — passes
- [x] `pnpm --filter=@x402r/sdk typecheck` — passes
- [x] `pnpm --filter=@x402r/sdk test` — all 71 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)