### PR TITLE
docs: add viem-inspired README for V2 SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,80 @@
+[![npm version](https://img.shields.io/npm/v/@x402r/sdk?colorB=1a1a1a)](https://www.npmjs.com/package/@x402r/sdk)
+[![License](https://img.shields.io/npm/l/@x402r/sdk?colorB=1a1a1a)](https://github.com/BackTrackCo/x402r-sdk/blob/main/LICENSE)
+
+# @x402r
+
+Refundable payments SDK for EVM chains.
+
+## Quickstart
+
+```bash
+npm install @x402r/sdk viem
+```
+
+```ts
+import { createMerchantClient } from '@x402r/sdk'
+import { createPublicClient, createWalletClient, http } from 'viem'
+import { baseSepolia } from 'viem/chains'
+
+const merchant = createMerchantClient({
+  publicClient: createPublicClient({ chain: baseSepolia, transport: http() }),
+  walletClient: createWalletClient({ account, chain: baseSepolia, transport: http() }),
+  operatorAddress: '0x...',
+})
+
+// Release a payment after escrow
+await merchant.operator.release({ paymentInfo, amount })
+
+// Check payment state
+const amounts = await merchant.escrow.getPaymentAmounts({ paymentInfo, chainId: 84532 })
+```
+
+## Packages
+
+| Package | Description |
+| --- | --- |
+| [`@x402r/core`](./packages/core) | Contract interaction primitives, types, config, deploy utilities |
+| [`@x402r/sdk`](./packages/sdk) | High-level client with role presets, action groups, `.extend()` plugin system |
+
+## Action Groups
+
+`escrow` · `evidence` · `freeze` · `operator` · `payment` · `refund` · `watch`
+
+Role presets: `createPayerClient` · `createMerchantClient` · `createArbiterClient`
+
+## Networks
+
+Same contract addresses on every chain via CREATE3.
+
+| Chain | Chain ID |
+| --- | --- |
+| Base Sepolia | 84532 |
+| Ethereum Sepolia | 11155111 |
+| Ethereum | 1 |
+| Base | 8453 |
+| Polygon | 137 |
+| Arbitrum One | 42161 |
+| Optimism | 10 |
+| Celo | 42220 |
+| Avalanche C-Chain | 43114 |
+| Monad | 143 |
+| Linea | 59144 |
+
+## Development
+
+```bash
+pnpm install        # install dependencies
+pnpm build          # build all packages
+pnpm test           # run tests
+pnpm typecheck      # type-check
+pnpm check          # lint (biome)
+```
+
+## Links
+
+- [Documentation](https://docs.x402r.org)
+- [GitHub](https://github.com/BackTrackCo/x402r-sdk)
+
+## License
+
+[Apache-2.0](./LICENSE)

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,24 @@
+# @x402r/core
+
+Contract interaction primitives for the x402r refundable payments protocol.
+
+## Install
+
+```bash
+npm install @x402r/core viem
+```
+
+## Usage
+
+```ts
+import { authorize, getPaymentState } from '@x402r/core/actions'
+import { getChainConfig } from '@x402r/core/config'
+
+const config = getChainConfig(84532) // Base Sepolia
+```
+
+## Links
+
+- [Documentation](https://docs.x402r.org/sdk/overview)
+- [GitHub](https://github.com/BackTrackCo/x402r-sdk)
+- [License](../../LICENSE)

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -1,0 +1,21 @@
+# @x402r/sdk
+
+High-level client for x402r refundable payments with role presets and action groups.
+
+## Install
+
+```bash
+npm install @x402r/sdk viem
+```
+
+## Usage
+
+```ts
+import { createMerchantClient } from '@x402r/sdk'
+```
+
+## Links
+
+- [Documentation](https://docs.x402r.org/sdk/overview)
+- [GitHub](https://github.com/BackTrackCo/x402r-sdk)
+- [License](../../LICENSE)


### PR DESCRIPTION
## Summary
- Root `README.md` (80 lines): badges, quickstart code, package table, action groups, 11-chain network table, dev commands
- `packages/core/README.md` (24 lines): install, usage snippet, links
- `packages/sdk/README.md` (21 lines): install, usage snippet, links
- Follows viem README conventions: no emoji in headings, code-first, no filler

## Test plan
- [x] All imports and paths verified against codebase
- [x] Markdown renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)