### PR TITLE
perf(deploy): parallelize contract deployments and preview reads

### DIFF
--- a/packages/core/src/deploy/conditions.ts
+++ b/packages/core/src/deploy/conditions.ts
@@ -116,19 +116,14 @@ export async function resolveCondition(
     }
 
     case 'and': {
-      // Resolve children sequentially for deterministic transaction ordering
-      const childAddresses: Address[] = []
-      const allDeployments: DeployResult[] = []
-      for (const child of node.conditions) {
-        const resolved = await resolveCondition(
-          walletClient,
-          publicClient,
-          factoryAddresses,
-          child,
-        )
-        childAddresses.push(resolved.address)
-        allDeployments.push(...resolved.deployments)
-      }
+      // Resolve children in parallel (Promise.all preserves positional ordering)
+      const childResults = await Promise.all(
+        node.conditions.map((child) =>
+          resolveCondition(walletClient, publicClient, factoryAddresses, child),
+        ),
+      )
+      const childAddresses = childResults.map((r) => r.address)
+      const allDeployments = childResults.flatMap((r) => r.deployments)
       const result = await deployAndCondition(walletClient, publicClient, {
         factoryAddress: factoryAddresses.andCondition,
         conditions: childAddresses,
@@ -140,18 +135,14 @@ export async function resolveCondition(
     }
 
     case 'or': {
-      const childAddresses: Address[] = []
-      const allDeployments: DeployResult[] = []
-      for (const child of node.conditions) {
-        const resolved = await resolveCondition(
-          walletClient,
-          publicClient,
-          factoryAddresses,
-          child,
-        )
-        childAddresses.push(resolved.address)
-        allDeployments.push(...resolved.deployments)
-      }
+      // Resolve children in parallel (Promise.all preserves positional ordering)
+      const childResults = await Promise.all(
+        node.conditions.map((child) =>
+          resolveCondition(walletClient, publicClient, factoryAddresses, child),
+        ),
+      )
+      const childAddresses = childResults.map((r) => r.address)
+      const allDeployments = childResults.flatMap((r) => r.deployments)
       const result = await deployOrCondition(walletClient, publicClient, {
         factoryAddress: factoryAddresses.orCondition,
         conditions: childAddresses,

--- a/packages/core/src/deploy/factory-helpers.ts
+++ b/packages/core/src/deploy/factory-helpers.ts
@@ -87,7 +87,15 @@ export async function deployViaFactory(
     return { address: existing, hash: null, isNew: false }
   }
 
-  // 3. Deploy via factory
+  // 3. Compute deterministic address (pure view function, independent of deployment)
+  const address = (await publicClient.readContract({
+    address: factoryAddress,
+    abi,
+    functionName: computeAddressFn,
+    args,
+  })) as Address
+
+  // 4. Deploy via factory
   const hash = await wrapContractCall(opName, () =>
     walletClient.writeContract({
       address: factoryAddress,
@@ -99,16 +107,8 @@ export async function deployViaFactory(
     }),
   )
 
-  // 4. Wait for transaction receipt
+  // 5. Wait for transaction receipt
   await publicClient.waitForTransactionReceipt({ hash })
-
-  // 5. Read deterministic address via computeAddress (pure function, no RPC cache issues)
-  const address = (await publicClient.readContract({
-    address: factoryAddress,
-    abi,
-    functionName: computeAddressFn,
-    args,
-  })) as Address
 
   return { address, hash, isNew: true }
 }

--- a/packages/core/src/deploy/presets.ts
+++ b/packages/core/src/deploy/presets.ts
@@ -120,67 +120,61 @@ export async function previewMarketplaceOperator(
     operatorFeeBps,
   } = resolveOptions(options)
 
-  // 1. EscrowPeriod
-  const escrowPeriodAddress = await computeEscrowPeriodAddress(publicClient, {
-    factoryAddress: factories.escrowPeriod,
-    escrowPeriod: options.escrowPeriodSeconds,
-    authorizedCodehash,
-  })
+  // Batch 1 (parallel): independent computations
+  const [escrowPeriodAddress, signatureConditionAddress, feeCalculatorAddress] =
+    await Promise.all([
+      computeEscrowPeriodAddress(publicClient, {
+        factoryAddress: factories.escrowPeriod,
+        escrowPeriod: options.escrowPeriodSeconds,
+        authorizedCodehash,
+      }),
+      computeSignatureConditionAddress(publicClient, {
+        factoryAddress: factories.signatureCondition,
+        signer: options.arbiter,
+      }),
+      operatorFeeBps > 0n
+        ? computeFeeCalculatorAddress(publicClient, {
+            factoryAddress: factories.staticFeeCalculator,
+            feeBps: operatorFeeBps,
+          })
+        : Promise.resolve(null),
+    ])
 
-  // 2. Freeze + AndCondition (only when freezeDurationSeconds > 0)
-  let freezeAddress: Address | null = null
+  // Batch 2 (parallel): depends on batch 1 results
+  const [
+    freezeAddress,
+    refundInEscrowConditionAddress,
+    signatureRefundRequestAddress,
+  ] = await Promise.all([
+    freezeDurationSeconds > 0n
+      ? computeFreezeAddress(publicClient, {
+          factoryAddress: factories.freeze,
+          freezeCondition: singletons.payer,
+          unfreezeCondition: singletons.receiver,
+          freezeDuration: freezeDurationSeconds,
+          escrowPeriodContract: escrowPeriodAddress,
+        })
+      : Promise.resolve(null),
+    computeOrConditionAddress(publicClient, {
+      factoryAddress: factories.orCondition,
+      conditions: [singletons.receiver, signatureConditionAddress],
+    }),
+    computeSignatureRefundRequestAddress(publicClient, {
+      factoryAddress: factories.signatureRefundRequest,
+      signatureCondition: signatureConditionAddress,
+    }),
+  ])
+
+  // Batch 3: andCondition (only when freeze enabled, depends on batch 2)
   let releaseConditionAddress: Address = escrowPeriodAddress
-
-  if (freezeDurationSeconds > 0n) {
-    freezeAddress = await computeFreezeAddress(publicClient, {
-      factoryAddress: factories.freeze,
-      freezeCondition: singletons.payer,
-      unfreezeCondition: singletons.receiver,
-      freezeDuration: freezeDurationSeconds,
-      escrowPeriodContract: escrowPeriodAddress,
-    })
-
+  if (freezeDurationSeconds > 0n && freezeAddress) {
     releaseConditionAddress = await computeAndConditionAddress(publicClient, {
       factoryAddress: factories.andCondition,
       conditions: [escrowPeriodAddress, freezeAddress],
     })
   }
 
-  // 3. SignatureCondition(arbiter)
-  const signatureConditionAddress = await computeSignatureConditionAddress(
-    publicClient,
-    {
-      factoryAddress: factories.signatureCondition,
-      signer: options.arbiter,
-    },
-  )
-
-  // 4. RefundInEscrow: OR(receiver singleton, signature condition)
-  const refundInEscrowConditionAddress = await computeOrConditionAddress(
-    publicClient,
-    {
-      factoryAddress: factories.orCondition,
-      conditions: [singletons.receiver, signatureConditionAddress],
-    },
-  )
-
-  // 5. SignatureRefundRequest(signatureCondition)
-  const signatureRefundRequestAddress =
-    await computeSignatureRefundRequestAddress(publicClient, {
-      factoryAddress: factories.signatureRefundRequest,
-      signatureCondition: signatureConditionAddress,
-    })
-
-  // 6. FeeCalculator (only if operatorFeeBps > 0)
-  const feeCalculatorAddress =
-    operatorFeeBps > 0n
-      ? await computeFeeCalculatorAddress(publicClient, {
-          factoryAddress: factories.staticFeeCalculator,
-          feeBps: operatorFeeBps,
-        })
-      : null
-
-  // 7. Build OperatorConfig
+  // Batch 4: operator (depends on everything)
   const operatorConfig: OperatorConfig = {
     feeRecipient: options.feeRecipient,
     feeCalculator: feeCalculatorAddress ?? zeroAddress,
@@ -196,7 +190,6 @@ export async function previewMarketplaceOperator(
     refundPostEscrowRecorder: zeroAddress,
   }
 
-  // 8. Compute operator address
   const operatorAddress = await computeOperatorAddress(publicClient, {
     factoryAddress: factories.paymentOperator,
     config: operatorConfig,
@@ -234,86 +227,71 @@ export async function deployMarketplaceOperator(
 
   const deployments: DeployResult[] = []
 
-  // 1. EscrowPeriod
-  const escrowResult = await deployEscrowPeriod(walletClient, publicClient, {
-    factoryAddress: factories.escrowPeriod,
-    escrowPeriod: options.escrowPeriodSeconds,
-    authorizedCodehash,
-  })
-  deployments.push(escrowResult)
+  // Batch 1 (parallel): independent deployments
+  const [escrowResult, signatureConditionResult, feeResult] = await Promise.all(
+    [
+      deployEscrowPeriod(walletClient, publicClient, {
+        factoryAddress: factories.escrowPeriod,
+        escrowPeriod: options.escrowPeriodSeconds,
+        authorizedCodehash,
+      }),
+      deploySignatureCondition(walletClient, publicClient, {
+        factoryAddress: factories.signatureCondition,
+        signer: options.arbiter,
+      }),
+      operatorFeeBps > 0n
+        ? deployFeeCalculator(walletClient, publicClient, {
+            factoryAddress: factories.staticFeeCalculator,
+            feeBps: operatorFeeBps,
+          })
+        : Promise.resolve(null),
+    ],
+  )
+  deployments.push(escrowResult, signatureConditionResult)
+  if (feeResult) deployments.push(feeResult)
   const escrowPeriodAddress = escrowResult.address
+  const signatureConditionAddress = signatureConditionResult.address
+  const feeCalculatorAddress = feeResult?.address ?? null
 
-  // 2. Freeze + AndCondition (only when freezeDurationSeconds > 0)
-  let freezeAddress: Address | null = null
+  // Batch 2 (parallel): depends on batch 1
+  const [freezeResult, refundInEscrowResult, signatureRefundRequestResult] =
+    await Promise.all([
+      freezeDurationSeconds > 0n
+        ? deployFreeze(walletClient, publicClient, {
+            factoryAddress: factories.freeze,
+            freezeCondition: singletons.payer,
+            unfreezeCondition: singletons.receiver,
+            freezeDuration: freezeDurationSeconds,
+            escrowPeriodContract: escrowPeriodAddress,
+          })
+        : Promise.resolve(null),
+      deployOrCondition(walletClient, publicClient, {
+        factoryAddress: factories.orCondition,
+        conditions: [singletons.receiver, signatureConditionAddress],
+      }),
+      deploySignatureRefundRequest(walletClient, publicClient, {
+        factoryAddress: factories.signatureRefundRequest,
+        signatureCondition: signatureConditionAddress,
+      }),
+    ])
+  if (freezeResult) deployments.push(freezeResult)
+  deployments.push(refundInEscrowResult, signatureRefundRequestResult)
+  const freezeAddress = freezeResult?.address ?? null
+  const refundInEscrowConditionAddress = refundInEscrowResult.address
+  const signatureRefundRequestAddress = signatureRefundRequestResult.address
+
+  // Batch 3: andCondition (only when freeze enabled, depends on batch 2)
   let releaseConditionAddress: Address = escrowPeriodAddress
-
-  if (freezeDurationSeconds > 0n) {
-    const freezeResult = await deployFreeze(walletClient, publicClient, {
-      factoryAddress: factories.freeze,
-      freezeCondition: singletons.payer,
-      unfreezeCondition: singletons.receiver,
-      freezeDuration: freezeDurationSeconds,
-      escrowPeriodContract: escrowPeriodAddress,
-    })
-    deployments.push(freezeResult)
-    freezeAddress = freezeResult.address
-
+  if (freezeDurationSeconds > 0n && freezeResult) {
     const andResult = await deployAndCondition(walletClient, publicClient, {
       factoryAddress: factories.andCondition,
-      conditions: [escrowPeriodAddress, freezeAddress],
+      conditions: [escrowPeriodAddress, freezeAddress!],
     })
     deployments.push(andResult)
     releaseConditionAddress = andResult.address
   }
 
-  // 3. SignatureCondition(arbiter)
-  const signatureConditionResult = await deploySignatureCondition(
-    walletClient,
-    publicClient,
-    {
-      factoryAddress: factories.signatureCondition,
-      signer: options.arbiter,
-    },
-  )
-  deployments.push(signatureConditionResult)
-  const signatureConditionAddress = signatureConditionResult.address
-
-  // 4. RefundInEscrow: OR(receiver singleton, signature condition)
-  const refundInEscrowResult = await deployOrCondition(
-    walletClient,
-    publicClient,
-    {
-      factoryAddress: factories.orCondition,
-      conditions: [singletons.receiver, signatureConditionAddress],
-    },
-  )
-  deployments.push(refundInEscrowResult)
-  const refundInEscrowConditionAddress = refundInEscrowResult.address
-
-  // 5. SignatureRefundRequest(signatureCondition)
-  const signatureRefundRequestResult = await deploySignatureRefundRequest(
-    walletClient,
-    publicClient,
-    {
-      factoryAddress: factories.signatureRefundRequest,
-      signatureCondition: signatureConditionAddress,
-    },
-  )
-  deployments.push(signatureRefundRequestResult)
-  const signatureRefundRequestAddress = signatureRefundRequestResult.address
-
-  // 6. FeeCalculator (only if operatorFeeBps > 0)
-  let feeCalculatorAddress: Address | null = null
-  if (operatorFeeBps > 0n) {
-    const feeResult = await deployFeeCalculator(walletClient, publicClient, {
-      factoryAddress: factories.staticFeeCalculator,
-      feeBps: operatorFeeBps,
-    })
-    deployments.push(feeResult)
-    feeCalculatorAddress = feeResult.address
-  }
-
-  // 7. Build OperatorConfig
+  // Batch 4: operator (depends on everything)
   const operatorConfig: OperatorConfig = {
     feeRecipient: options.feeRecipient,
     feeCalculator: feeCalculatorAddress ?? zeroAddress,
@@ -329,7 +307,6 @@ export async function deployMarketplaceOperator(
     refundPostEscrowRecorder: zeroAddress,
   }
 
-  // 8. Deploy PaymentOperator
   const operatorResult = await deployOperator(walletClient, publicClient, {
     factoryAddress: factories.paymentOperator,
     config: operatorConfig,

--- a/packages/core/tests/deploy/presets.test.ts
+++ b/packages/core/tests/deploy/presets.test.ts
@@ -1,6 +1,7 @@
 import type { Address } from 'viem'
 import { zeroAddress } from 'viem'
 import { describe, expect, it } from 'vitest'
+import { getFactoryAddresses } from '../../src/config/index.js'
 import {
   type ArbiterSetupOptions,
   deployArbiterSetup,
@@ -17,6 +18,7 @@ import {
 } from '../fixtures.js'
 
 const COMPUTED_ADDR = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address
+const F = getFactoryAddresses(84532)
 
 function makeOptions(
   overrides: Partial<MarketplaceOperatorOptions> = {},
@@ -62,47 +64,58 @@ describe('previewMarketplaceOperator', () => {
   })
 
   it('freezeAddress is null and releaseCondition equals escrowPeriodAddress when freeze disabled', async () => {
-    const addresses = [
-      '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', // escrowPeriod
-      '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB', // signatureCondition
-      '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC', // orCondition
-      '0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD', // signatureRefundRequest
-      '0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE', // operator
-    ] as Address[]
-    const publicClient = createSequentialMockPublicClient(addresses)
+    const escrowAddr = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address
+    const sigCondAddr = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' as Address
+    const orAddr = '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' as Address
+    const sigRefundAddr =
+      '0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD' as Address
+    const operatorAddr = '0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE' as Address
+    const publicClient = createMockPublicClient({
+      [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
+      [`${F.signatureCondition}:computeAddress`]: sigCondAddr,
+      [`${F.orCondition}:computeAddress`]: orAddr,
+      [`${F.signatureRefundRequest}:computeAddress`]: sigRefundAddr,
+      [`${F.paymentOperator}:computeAddress`]: operatorAddr,
+    })
 
     const result = await previewMarketplaceOperator(publicClient, makeOptions())
 
     expect(result.freezeAddress).toBeNull()
-    // releaseCondition must literally be the escrowPeriod address (first computed)
-    expect(result.operatorConfig.releaseCondition).toBe(addresses[0])
-    expect(result.escrowPeriodAddress).toBe(addresses[0])
-    expect(result.signatureRefundRequestAddress).toBe(addresses[3])
+    expect(result.operatorConfig.releaseCondition).toBe(escrowAddr)
+    expect(result.escrowPeriodAddress).toBe(escrowAddr)
+    expect(result.signatureRefundRequestAddress).toBe(sigRefundAddr)
   })
 
   it('freezeAddress is non-null and releaseCondition is AndCondition when freeze enabled', async () => {
-    const addresses = [
-      '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', // escrowPeriod
-      '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB', // freeze
-      '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC', // andCondition
-      '0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD', // signatureCondition
-      '0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE', // orCondition
-      '0x1111111111111111111111111111111111111111', // signatureRefundRequest
-      '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF', // operator
-    ] as Address[]
-    const publicClient = createSequentialMockPublicClient(addresses)
+    const escrowAddr = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address
+    const freezeAddr = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' as Address
+    const andAddr = '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' as Address
+    const sigCondAddr = '0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD' as Address
+    const orAddr = '0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE' as Address
+    const sigRefundAddr =
+      '0x1111111111111111111111111111111111111111' as Address
+    const operatorAddr = '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF' as Address
+    const publicClient = createMockPublicClient({
+      [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
+      [`${F.signatureCondition}:computeAddress`]: sigCondAddr,
+      [`${F.freeze}:computeAddress`]: freezeAddr,
+      [`${F.orCondition}:computeAddress`]: orAddr,
+      [`${F.signatureRefundRequest}:computeAddress`]: sigRefundAddr,
+      [`${F.andCondition}:computeAddress`]: andAddr,
+      [`${F.paymentOperator}:computeAddress`]: operatorAddr,
+    })
 
     const result = await previewMarketplaceOperator(
       publicClient,
       makeOptions({ freezeDurationSeconds: 86400n }),
     )
 
-    expect(result.freezeAddress).toBe(addresses[1]) // freeze address
-    expect(result.operatorConfig.releaseCondition).toBe(addresses[2]) // andCondition, NOT escrowPeriod
+    expect(result.freezeAddress).toBe(freezeAddr)
+    expect(result.operatorConfig.releaseCondition).toBe(andAddr)
     expect(result.operatorConfig.releaseCondition).not.toBe(
       result.escrowPeriodAddress,
     )
-    expect(result.signatureRefundRequestAddress).toBe(addresses[5])
+    expect(result.signatureRefundRequestAddress).toBe(sigRefundAddr)
   })
 
   it('feeCalculatorAddress is non-null when operatorFeeBps > 0', async () => {
@@ -122,16 +135,17 @@ describe('previewMarketplaceOperator', () => {
 
 describe('deployMarketplaceOperator', () => {
   it('summary correctly counts new vs existing (freeze disabled)', async () => {
-    const addresses = [
-      '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', // escrowPeriod
-      '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB', // signatureCondition
-      '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC', // orCondition
-      '0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD', // signatureRefundRequest
-      '0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE', // operator
-    ] as Address[]
-    // First 2 are new (return zero), rest are existing (return non-zero)
-    const publicClient = createSequentialMockPublicClient(addresses, {
-      getDeployedBehavior: (idx) => (idx < 2 ? zeroAddress : COMPUTED_ADDR),
+    const escrowAddr = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address
+    const sigCondAddr = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' as Address
+    // escrowPeriod + signatureCondition are new; orCondition + signatureRefundRequest + operator are existing
+    const publicClient = createMockPublicClient({
+      [`${F.escrowPeriod}:getDeployed`]: zeroAddress,
+      [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
+      [`${F.signatureCondition}:getDeployed`]: zeroAddress,
+      [`${F.signatureCondition}:computeAddress`]: sigCondAddr,
+      [`${F.orCondition}:getDeployed`]: COMPUTED_ADDR,
+      [`${F.signatureRefundRequest}:getDeployed`]: COMPUTED_ADDR,
+      [`${F.paymentOperator}:getOperator`]: COMPUTED_ADDR,
     })
     const walletClient = createMockWalletClient()
 
@@ -144,10 +158,8 @@ describe('deployMarketplaceOperator', () => {
     // Without freeze or fee calculator: escrow + signatureCondition + orCondition + signatureRefundRequest + operator = 5
     expect(result.deployments).toHaveLength(5)
     expect(result.freezeAddress).toBeNull()
-    // releaseCondition is escrowPeriod (first address), not some other contract
-    expect(result.operatorConfig.releaseCondition).toBe(addresses[0])
-    expect(result.escrowPeriodAddress).toBe(addresses[0])
-    // signatureRefundRequest is existing (getDeployed idx 3 >= 2), so address = COMPUTED_ADDR
+    expect(result.operatorConfig.releaseCondition).toBe(escrowAddr)
+    expect(result.escrowPeriodAddress).toBe(escrowAddr)
     expect(result.signatureRefundRequestAddress).toBe(COMPUTED_ADDR)
     expect(result.summary.newCount).toBe(2)
     expect(result.summary.existingCount).toBe(3)
@@ -174,16 +186,30 @@ describe('deployMarketplaceOperator', () => {
   })
 
   it('deploys freeze + andCondition when freezeDurationSeconds > 0', async () => {
-    const addresses = [
-      '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', // escrowPeriod
-      '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB', // freeze
-      '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC', // andCondition
-      '0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD', // signatureCondition
-      '0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE', // orCondition
-      '0x1111111111111111111111111111111111111111', // signatureRefundRequest
-      '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF', // operator
-    ] as Address[]
-    const publicClient = createSequentialMockPublicClient(addresses)
+    const escrowAddr = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address
+    const freezeAddr = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' as Address
+    const andAddr = '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' as Address
+    const sigCondAddr = '0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD' as Address
+    const orAddr = '0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE' as Address
+    const sigRefundAddr =
+      '0x1111111111111111111111111111111111111111' as Address
+    const operatorAddr = '0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF' as Address
+    const publicClient = createMockPublicClient({
+      [`${F.escrowPeriod}:getDeployed`]: zeroAddress,
+      [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
+      [`${F.signatureCondition}:getDeployed`]: zeroAddress,
+      [`${F.signatureCondition}:computeAddress`]: sigCondAddr,
+      [`${F.freeze}:getDeployed`]: zeroAddress,
+      [`${F.freeze}:computeAddress`]: freezeAddr,
+      [`${F.orCondition}:getDeployed`]: zeroAddress,
+      [`${F.orCondition}:computeAddress`]: orAddr,
+      [`${F.signatureRefundRequest}:getDeployed`]: zeroAddress,
+      [`${F.signatureRefundRequest}:computeAddress`]: sigRefundAddr,
+      [`${F.andCondition}:getDeployed`]: zeroAddress,
+      [`${F.andCondition}:computeAddress`]: andAddr,
+      [`${F.paymentOperator}:getOperator`]: zeroAddress,
+      [`${F.paymentOperator}:computeAddress`]: operatorAddr,
+    })
     const walletClient = createMockWalletClient()
 
     const result = await deployMarketplaceOperator(
@@ -195,22 +221,31 @@ describe('deployMarketplaceOperator', () => {
     // With freeze: escrow + freeze + andCondition + signatureCondition + orCondition + signatureRefundRequest + operator = 7
     expect(result.deployments).toHaveLength(7)
     expect(result.freezeAddress).not.toBeNull()
-    // releaseCondition should be the AndCondition address, not escrowPeriodAddress
     expect(result.operatorConfig.releaseCondition).not.toBe(
       result.escrowPeriodAddress,
     )
-    expect(result.signatureRefundRequestAddress).toBe(addresses[5])
+    expect(result.signatureRefundRequestAddress).toBe(sigRefundAddr)
   })
 
   it('skips freeze when freezeDurationSeconds omitted', async () => {
-    const addresses = [
-      '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA', // escrowPeriod
-      '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB', // signatureCondition
-      '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC', // orCondition
-      '0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD', // signatureRefundRequest
-      '0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE', // operator
-    ] as Address[]
-    const publicClient = createSequentialMockPublicClient(addresses)
+    const escrowAddr = '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as Address
+    const sigCondAddr = '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' as Address
+    const orAddr = '0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC' as Address
+    const sigRefundAddr =
+      '0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD' as Address
+    const operatorAddr = '0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE' as Address
+    const publicClient = createMockPublicClient({
+      [`${F.escrowPeriod}:getDeployed`]: zeroAddress,
+      [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
+      [`${F.signatureCondition}:getDeployed`]: zeroAddress,
+      [`${F.signatureCondition}:computeAddress`]: sigCondAddr,
+      [`${F.orCondition}:getDeployed`]: zeroAddress,
+      [`${F.orCondition}:computeAddress`]: orAddr,
+      [`${F.signatureRefundRequest}:getDeployed`]: zeroAddress,
+      [`${F.signatureRefundRequest}:computeAddress`]: sigRefundAddr,
+      [`${F.paymentOperator}:getOperator`]: zeroAddress,
+      [`${F.paymentOperator}:computeAddress`]: operatorAddr,
+    })
     const walletClient = createMockWalletClient()
 
     const result = await deployMarketplaceOperator(
@@ -220,11 +255,11 @@ describe('deployMarketplaceOperator', () => {
     )
 
     expect(result.freezeAddress).toBeNull()
-    expect(result.operatorConfig.releaseCondition).toBe(addresses[0])
+    expect(result.operatorConfig.releaseCondition).toBe(escrowAddr)
     expect(result.operatorConfig.releaseCondition).toBe(
       result.escrowPeriodAddress,
     )
-    expect(result.signatureRefundRequestAddress).toBe(addresses[3])
+    expect(result.signatureRefundRequestAddress).toBe(sigRefundAddr)
   })
 })
 


### PR DESCRIPTION
## Summary
- Move `computeAddress` before `writeContract` in `deployViaFactory` to eliminate 1 post-receipt RPC round trip per new deployment
- Parallelize AND/OR child resolution in `resolveCondition` with `Promise.all`
- Batch independent `computeXxx` and `deployXxx` calls in `previewMarketplaceOperator` and `deployMarketplaceOperator` (5-8 sequential RPCs → 3-4 batches)
- Convert preset tests from sequential mock to composite-key mock for order-independent assertions

## Test plan
- [x] All 174 existing tests pass (`pnpm test`)
- [x] Pre-commit hooks pass (biome check + build + typecheck)
- [x] Integration fork tests confirm preview/deploy behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)