### PR TITLE
chore: bump @x402r/core, @x402r/sdk, @x402r/helpers to 0.1.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/core",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "license": "Apache-2.0",
   "exports": {

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/helpers",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "license": "Apache-2.0",
   "exports": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/sdk",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "license": "Apache-2.0",
   "exports": {


### PR DESCRIPTION
## Summary
- Bump all 3 packages from `0.0.0` (workspace) to `0.1.0` for V2 SDK launch
- V1 users on `^0.0.2` are unaffected (`^0.0.2` resolves to `>=0.0.2 <0.1.0`)

## Publish checklist (post-merge)
- [x] `pnpm build` — pass
- [x] `pnpm test` — 413 tests pass
- [x] `publint --strict` — all 3 packages pass
- [x] `attw --pack` — all green
- [ ] `pnpm -r publish --access public` — after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)