### PR TITLE
Add Arbitrum Sepolia (421614) to supported chains

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -102,6 +102,11 @@ export const x402rChains = {
     11155111,
     '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
   ),
+  421614: chainConfig(
+    'Arbitrum Sepolia',
+    421614,
+    '0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d',
+  ),
 
   // Mainnets
   1: chainConfig('Ethereum', 1, '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48'),


### PR DESCRIPTION
## Summary
- Deploy all x402r protocol contracts to Arbitrum Sepolia (chain ID 421614) at unified CREATE3 addresses
- Add chain config with Circle's official USDC testnet address (`0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d`)

## Deployed contracts
All 24 contracts deployed and verified on [Arbiscan Sepolia](https://sepolia.arbiscan.io):
- 21 core contracts via `DeployCreate3.s.sol` (unified addresses)
- 3 additional factories via `DeployViaCreateX.s.sol` (PaymentOperatorFactory v2, RefundRequestFactory, RefundRequestEvidenceFactory)

## Test plan
- [x] SDK builds cleanly (`npm run build`)
- [x] Unit tests pass (fork tests excluded — require Anvil)
- [x] Dry-run verified all CREATE3 addresses match unified protocol addresses
- [x] All contracts verified on Arbiscan Sepolia

🤖 Generated with [Claude Code](https://claude.com/claude-code)