### PR TITLE
feat(core): add SKALE Base chain support

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -138,6 +138,12 @@ export const x402rChains = {
     59144,
     '0x176211869cA2b568f2A7D4EE941E073a821EE1ff',
   ),
+
+  1187947933: chainConfig(
+    'SKALE Base',
+    1187947933,
+    '0x85889c8c714505E0c94b30fcfcF64fE3Ac8FCb20',
+  ),
 } as const satisfies Record<number, X402rChainConfig>
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add SKALE Base Mainnet (chain ID `1187947933`) to supported chains
- All contracts deployed via CREATE3 with unified addresses (same as every other chain)
- USDC.e (bridged USDC) at `0x85889c8c714505E0c94b30fcfcF64fE3Ac8FCb20` — supports ERC-3009 `transferWithAuthorization`

## Deployment details
- Deployed CreateX factory to SKALE Base (was not previously available)
- Ran `DeployCreate3.s.sol` to get unified protocol addresses
- Verified on-chain: contracts have bytecode, USDC.e has ERC-3009 + DOMAIN_SEPARATOR

## Test plan
- [ ] Verify `getChainConfig(1187947933)` returns correct config
- [ ] Verify `isSupportedChain(1187947933)` returns true
- [ ] End-to-end payment flow on SKALE Base

🤖 Generated with [Claude Code](https://claude.com/claude-code)