### PR TITLE
feat(helpers): forward paymentPayload and improve error context

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -57,7 +57,8 @@ export const receiverRefundCollector =
 export const usdcTvlLimit =
   '0x96a585F0e23eE9FD8722C7a61d3b8B3FAd2419df' as const satisfies Address
 
-export const factoryAddresses = {
+/** Chain-invariant CREATE3 factory addresses. Same as `getChainConfig(chainId).factories`. */
+export const factories = {
   paymentOperator: '0x3Cd5c76Fefe46CB07788Ee8f80B93B20D81941D4',
   escrowPeriod: '0x22E42a1bC9Fc64ab77E4Bb9968b105034a978bfb',
   freeze: '0x67657BefCd872A3AF36F437D53b2D4722392a940',
@@ -72,7 +73,8 @@ export const factoryAddresses = {
   refundRequestEvidence: '0x6514e417f48c1828A2443C6173fa6E04324166E3',
 } as const satisfies FactoryAddresses
 
-export const conditionAddresses = {
+/** Chain-invariant CREATE3 condition singleton addresses. Same as `getChainConfig(chainId).conditions`. */
+export const conditions = {
   payer: '0x808bB293AE1473A38Dd4017afa3db941924fD0F3',
   receiver: '0xB82697792e5Fcd644bDEAB23aa4e4511d9024C17',
   alwaysTrue: '0xA367323189f20706488A1D83430eda82a2eA5320',
@@ -85,8 +87,8 @@ const PROTOCOL_ADDRESSES = {
   arbiterRegistry,
   receiverRefundCollector,
   usdcTvlLimit,
-  factories: factoryAddresses,
-  conditions: conditionAddresses,
+  factories,
+  conditions,
 } as const
 
 /** Build a chain config by spreading unified protocol addresses + chain-specific USDC */

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -44,32 +44,49 @@ export interface X402rChainConfig {
 // Unified CREATE3 addresses (same on every chain)
 // ---------------------------------------------------------------------------
 
+export const authCaptureEscrow =
+  '0xBC151792f80C0EB1973d56b0235e6bee2A60e245' as const satisfies Address
+export const tokenCollector =
+  '0x9A12A116a44636F55c9e135189A1321Abcfe2f30' as const satisfies Address
+export const protocolFeeConfig =
+  '0xf62788834C99B2E85a6891C0b46D1EB996f8f596' as const satisfies Address
+export const arbiterRegistry =
+  '0xdd3954f83CF6D65B07A8a88B117300AE73602333' as const satisfies Address
+export const receiverRefundCollector =
+  '0x2C0eC8B33196071cA6d08299844235fD81e1466A' as const satisfies Address
+export const usdcTvlLimit =
+  '0x96a585F0e23eE9FD8722C7a61d3b8B3FAd2419df' as const satisfies Address
+
+export const factoryAddresses = {
+  paymentOperator: '0x3Cd5c76Fefe46CB07788Ee8f80B93B20D81941D4',
+  escrowPeriod: '0x22E42a1bC9Fc64ab77E4Bb9968b105034a978bfb',
+  freeze: '0x67657BefCd872A3AF36F437D53b2D4722392a940',
+  staticFeeCalculator: '0x8a9C93F3401A5C712bEd8A52436Ac09cD9aFe2De',
+  staticAddressCondition: '0xE606cA9568c92115a3Deb76E9f3891BEfac141f3',
+  andCondition: '0x6c3c57071C0Ac144D04e6C66BC809d2951dDF47D',
+  orCondition: '0x3dF6b5B840989Ce466161C31A49b8FadF2DA52E5',
+  notCondition: '0x269Db5f049A7225E4968Ef7Dee885922da0B8D73',
+  recorderCombinator: '0xb7571b80C24Ce81C65F6b322a75573B61327cA23',
+  signatureCondition: '0xc34EFa7C20940dc2aB50bE23eF150D8B87aEFAc3',
+  refundRequest: '0x69e9BF2b40Ed472b55E47e9D4205d93Ed673093F',
+  refundRequestEvidence: '0x6514e417f48c1828A2443C6173fa6E04324166E3',
+} as const satisfies FactoryAddresses
+
+export const conditionAddresses = {
+  payer: '0x808bB293AE1473A38Dd4017afa3db941924fD0F3',
+  receiver: '0xB82697792e5Fcd644bDEAB23aa4e4511d9024C17',
+  alwaysTrue: '0xA367323189f20706488A1D83430eda82a2eA5320',
+} as const satisfies ConditionSingletonAddresses
+
 const PROTOCOL_ADDRESSES = {
-  authCaptureEscrow: '0xBC151792f80C0EB1973d56b0235e6bee2A60e245',
-  tokenCollector: '0x9A12A116a44636F55c9e135189A1321Abcfe2f30',
-  protocolFeeConfig: '0xf62788834C99B2E85a6891C0b46D1EB996f8f596',
-  arbiterRegistry: '0xdd3954f83CF6D65B07A8a88B117300AE73602333',
-  receiverRefundCollector: '0x2C0eC8B33196071cA6d08299844235fD81e1466A',
-  usdcTvlLimit: '0x96a585F0e23eE9FD8722C7a61d3b8B3FAd2419df',
-  factories: {
-    paymentOperator: '0x3Cd5c76Fefe46CB07788Ee8f80B93B20D81941D4',
-    escrowPeriod: '0x22E42a1bC9Fc64ab77E4Bb9968b105034a978bfb',
-    freeze: '0x67657BefCd872A3AF36F437D53b2D4722392a940',
-    staticFeeCalculator: '0x8a9C93F3401A5C712bEd8A52436Ac09cD9aFe2De',
-    staticAddressCondition: '0xE606cA9568c92115a3Deb76E9f3891BEfac141f3',
-    andCondition: '0x6c3c57071C0Ac144D04e6C66BC809d2951dDF47D',
-    orCondition: '0x3dF6b5B840989Ce466161C31A49b8FadF2DA52E5',
-    notCondition: '0x269Db5f049A7225E4968Ef7Dee885922da0B8D73',
-    recorderCombinator: '0xb7571b80C24Ce81C65F6b322a75573B61327cA23',
-    signatureCondition: '0xc34EFa7C20940dc2aB50bE23eF150D8B87aEFAc3',
-    refundRequest: '0x69e9BF2b40Ed472b55E47e9D4205d93Ed673093F',
-    refundRequestEvidence: '0x6514e417f48c1828A2443C6173fa6E04324166E3',
-  },
-  conditions: {
-    payer: '0x808bB293AE1473A38Dd4017afa3db941924fD0F3',
-    receiver: '0xB82697792e5Fcd644bDEAB23aa4e4511d9024C17',
-    alwaysTrue: '0xA367323189f20706488A1D83430eda82a2eA5320',
-  },
+  authCaptureEscrow,
+  tokenCollector,
+  protocolFeeConfig,
+  arbiterRegistry,
+  receiverRefundCollector,
+  usdcTvlLimit,
+  factories: factoryAddresses,
+  conditions: conditionAddresses,
 } as const
 
 /** Build a chain config by spreading unified protocol addresses + chain-specific USDC */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -215,8 +215,8 @@ export type {
 export {
   arbiterRegistry,
   authCaptureEscrow,
-  conditionAddresses,
-  factoryAddresses,
+  conditions,
+  factories,
   fromNetworkId,
   getChainConfig,
   getConditionSingletons,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -213,6 +213,10 @@ export type {
   X402rChainConfig,
 } from './config/index.js'
 export {
+  arbiterRegistry,
+  authCaptureEscrow,
+  conditionAddresses,
+  factoryAddresses,
   fromNetworkId,
   getChainConfig,
   getConditionSingletons,
@@ -221,8 +225,12 @@ export {
   hasConditionSingletons,
   hasFactories,
   isSupportedChain,
+  protocolFeeConfig,
+  receiverRefundCollector,
   supportedChainIds,
+  tokenCollector,
   toNetworkId,
+  usdcTvlLimit,
   x402rChains,
 } from './config/index.js'
 // ---------------------------------------------------------------------------

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -1,13 +1,22 @@
 import { describe, expect, it } from 'vitest'
 import {
+  arbiterRegistry,
+  authCaptureEscrow,
   ConfigError,
+  conditions,
+  factories,
   fromNetworkId,
   getChainConfig,
   getConditionSingletons,
   getFactoryAddress,
   getFactoryAddresses,
   isSupportedChain,
+  protocolFeeConfig,
+  receiverRefundCollector,
+  supportedChainIds,
+  tokenCollector,
   toNetworkId,
+  usdcTvlLimit,
 } from '../src/index.js'
 
 describe('getChainConfig', () => {
@@ -75,6 +84,22 @@ describe('getConditionSingletons', () => {
   it('throws ConfigError for unsupported chain', () => {
     expect(() => getConditionSingletons(999999)).toThrow(ConfigError)
   })
+})
+
+describe('named address constants match getChainConfig()', () => {
+  for (const chainId of supportedChainIds) {
+    it(`chain ${chainId}`, () => {
+      const config = getChainConfig(chainId)
+      expect(config.authCaptureEscrow).toBe(authCaptureEscrow)
+      expect(config.tokenCollector).toBe(tokenCollector)
+      expect(config.protocolFeeConfig).toBe(protocolFeeConfig)
+      expect(config.arbiterRegistry).toBe(arbiterRegistry)
+      expect(config.receiverRefundCollector).toBe(receiverRefundCollector)
+      expect(config.usdcTvlLimit).toBe(usdcTvlLimit)
+      expect(config.factories).toEqual(factories)
+      expect(config.conditions).toEqual(conditions)
+    })
+  }
 })
 
 describe('toNetworkId / fromNetworkId', () => {

--- a/packages/core/tests/setup/scenario-helper.ts
+++ b/packages/core/tests/setup/scenario-helper.ts
@@ -80,5 +80,11 @@ export async function setupScenario(
     salt: opts.salt,
   }
 
-  return { publicClient, testClient, fixtures, escrowPeriodAddress, paymentInfo }
+  return {
+    publicClient,
+    testClient,
+    fixtures,
+    escrowPeriodAddress,
+    paymentInfo,
+  }
 }

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -24,8 +24,8 @@ const resourceServer = new x402ResourceServer(facilitatorClient)
 
 Creates an `onAfterSettle` hook that forwards the response body to an arbiter service for evaluation. Fire-and-forget — does not block the response to the client.
 
-- Only fires for successful escrow scheme settlements
-- POSTs `{ responseBody, network, transaction, scheme }` to `{arbiterUrl}/verify`
+- Only fires for successful commerce scheme settlements
+- POSTs `{ responseBody, transaction, paymentPayload }` to `{arbiterUrl}/verify`
 - Errors silently caught (arbiter being down shouldn't break payment flow)
 
 #### Options

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -23,10 +23,12 @@
     "prepublishOnly": "publint --strict && attw --pack --ignore-rules no-resolution cjs-resolves-to-esm"
   },
   "peerDependencies": {
-    "@x402/core": ">=2.5.0"
+    "@x402/core": ">=2.5.0",
+    "@x402r/core": ">=0.1.0"
   },
   "devDependencies": {
-    "@x402/core": "2.5.0"
+    "@x402/core": "2.5.0",
+    "@x402r/core": "workspace:*"
   },
   "size-limit": [
     {

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -22,9 +22,11 @@
     "typecheck": "tsc --noEmit",
     "prepublishOnly": "publint --strict && attw --pack --ignore-rules no-resolution cjs-resolves-to-esm"
   },
+  "dependencies": {
+    "@x402r/core": "workspace:*"
+  },
   "peerDependencies": {
-    "@x402/core": ">=2.5.0",
-    "@x402r/core": ">=0.1.0"
+    "@x402/core": ">=2.5.0"
   },
   "devDependencies": {
     "@x402/core": "2.5.0",

--- a/packages/helpers/src/forward-to-arbiter.ts
+++ b/packages/helpers/src/forward-to-arbiter.ts
@@ -50,9 +50,8 @@ export function forwardToArbiter(
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           responseBody: responseBody.toString('utf-8'),
-          network: context.requirements.network,
           transaction: context.result.transaction,
-          scheme: 'escrow',
+          paymentPayload: context.paymentPayload,
         }),
       })
       .catch((err: unknown) =>

--- a/packages/helpers/src/forward-to-arbiter.ts
+++ b/packages/helpers/src/forward-to-arbiter.ts
@@ -1,4 +1,5 @@
 import type { SettleResultContext } from '@x402/core/server'
+import { X402rError } from '@x402r/core'
 
 export interface ForwardToArbiterOptions {
   /** Custom error handler. Defaults to `console.warn`. */
@@ -56,10 +57,10 @@ export function forwardToArbiter(
       })
       .catch((err: unknown) =>
         errorHandler(
-          new Error(
-            `[forwardToArbiter] ${arbiterUrl}: ${err instanceof Error ? err.message : err}`,
-            { cause: err },
-          ),
+          new X402rError(`Arbiter request to ${arbiterUrl} failed`, {
+            cause: err instanceof Error ? err : undefined,
+            details: `POST ${url}`,
+          }),
         ),
       )
   }

--- a/packages/helpers/src/forward-to-arbiter.ts
+++ b/packages/helpers/src/forward-to-arbiter.ts
@@ -55,6 +55,14 @@ export function forwardToArbiter(
           scheme: 'escrow',
         }),
       })
-      .catch(errorHandler)
+      .catch((err: unknown) =>
+        errorHandler(
+          err instanceof Error
+            ? Object.assign(err, {
+                message: `[forwardToArbiter] ${arbiterUrl}: ${err.message}`,
+              })
+            : new Error(`[forwardToArbiter] ${arbiterUrl}: ${err}`),
+        ),
+      )
   }
 }

--- a/packages/helpers/src/forward-to-arbiter.ts
+++ b/packages/helpers/src/forward-to-arbiter.ts
@@ -10,7 +10,7 @@ export interface ForwardToArbiterOptions {
  * arbiter service for evaluation. Fire-and-forget — does not block the
  * response to the client.
  *
- * Only fires for escrow scheme settlements. Non-escrow schemes are skipped.
+ * Only fires for commerce scheme settlements. Non-commerce schemes are skipped.
  *
  * @example
  * ```ts
@@ -35,7 +35,7 @@ export function forwardToArbiter(
 
   return async (context: SettleResultContext): Promise<void> => {
     if (!context.result.success) return
-    if (context.requirements.scheme !== 'escrow') return
+    if (context.requirements.scheme !== 'commerce') return
 
     const transportCtx = context.transportContext as
       | { responseBody?: { toString(encoding: string): string } }

--- a/packages/helpers/src/forward-to-arbiter.ts
+++ b/packages/helpers/src/forward-to-arbiter.ts
@@ -31,7 +31,7 @@ export function forwardToArbiter(
 ): (context: SettleResultContext) => Promise<void> {
   const errorHandler =
     options?.onError ??
-    ((err: unknown) => console.warn('[forwardToArbiter] failed:', err))
+    ((err: unknown) => console.warn('[forwardToArbiter]', err))
 
   return async (context: SettleResultContext): Promise<void> => {
     if (!context.result.success) return
@@ -57,11 +57,10 @@ export function forwardToArbiter(
       })
       .catch((err: unknown) =>
         errorHandler(
-          err instanceof Error
-            ? Object.assign(err, {
-                message: `[forwardToArbiter] ${arbiterUrl}: ${err.message}`,
-              })
-            : new Error(`[forwardToArbiter] ${arbiterUrl}: ${err}`),
+          new Error(
+            `[forwardToArbiter] ${arbiterUrl}: ${err instanceof Error ? err.message : err}`,
+            { cause: err },
+          ),
         ),
       )
   }

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -1,2 +1,18 @@
 export type { ForwardToArbiterOptions } from './forward-to-arbiter.js'
 export { forwardToArbiter } from './forward-to-arbiter.js'
+
+// ---------------------------------------------------------------------------
+// Re-exports from @x402r/core — unified CREATE3 addresses (same on every chain)
+// ---------------------------------------------------------------------------
+export {
+  arbiterRegistry,
+  authCaptureEscrow,
+  conditionAddresses,
+  factoryAddresses,
+  getChainConfig,
+  protocolFeeConfig,
+  receiverRefundCollector,
+  supportedChainIds,
+  tokenCollector,
+  usdcTvlLimit,
+} from '@x402r/core'

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -1,6 +1,3 @@
-export type { ForwardToArbiterOptions } from './forward-to-arbiter.js'
-export { forwardToArbiter } from './forward-to-arbiter.js'
-
 // ---------------------------------------------------------------------------
 // Re-exports from @x402r/core — unified CREATE3 addresses (same on every chain)
 // ---------------------------------------------------------------------------
@@ -16,3 +13,5 @@ export {
   tokenCollector,
   usdcTvlLimit,
 } from '@x402r/core'
+export type { ForwardToArbiterOptions } from './forward-to-arbiter.js'
+export { forwardToArbiter } from './forward-to-arbiter.js'

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -4,8 +4,8 @@
 export {
   arbiterRegistry,
   authCaptureEscrow,
-  conditionAddresses,
-  factoryAddresses,
+  conditions,
+  factories,
   getChainConfig,
   protocolFeeConfig,
   receiverRefundCollector,

--- a/packages/helpers/tests/forward-to-arbiter.test.ts
+++ b/packages/helpers/tests/forward-to-arbiter.test.ts
@@ -111,7 +111,7 @@ describe('forwardToArbiter', () => {
       await new Promise((r) => setTimeout(r, 50))
 
       expect(warnSpy).toHaveBeenCalledWith(
-        '[forwardToArbiter] failed:',
+        '[forwardToArbiter]',
         expect.any(Error),
       )
     } finally {

--- a/packages/helpers/tests/forward-to-arbiter.test.ts
+++ b/packages/helpers/tests/forward-to-arbiter.test.ts
@@ -120,7 +120,7 @@ describe('forwardToArbiter', () => {
     }
   })
 
-  it('calls onError option on fetch failure', async () => {
+  it('calls onError with arbiter context on fetch failure', async () => {
     const original = globalThis.fetch
     globalThis.fetch = vi.fn(async () => {
       throw new Error('network failure')
@@ -133,6 +133,10 @@ describe('forwardToArbiter', () => {
       await new Promise((r) => setTimeout(r, 50))
 
       expect(onError).toHaveBeenCalledWith(expect.any(Error))
+      const msg = (onError.mock.calls[0][0] as Error).message
+      expect(msg).toContain('[forwardToArbiter]')
+      expect(msg).toContain('http://localhost:3001')
+      expect(msg).toContain('network failure')
     } finally {
       globalThis.fetch = original
     }

--- a/packages/helpers/tests/forward-to-arbiter.test.ts
+++ b/packages/helpers/tests/forward-to-arbiter.test.ts
@@ -30,7 +30,7 @@ function makeContext(overrides: {
 }
 
 describe('forwardToArbiter', () => {
-  it('POSTs to arbiter on successful escrow settlement', async () => {
+  it('POSTs to arbiter on successful commerce settlement', async () => {
     let capturedUrl = ''
     let capturedBody = ''
     const original = globalThis.fetch
@@ -50,6 +50,8 @@ describe('forwardToArbiter', () => {
       expect(parsed.responseBody).toBe('{"temp": 72}')
       expect(parsed.transaction).toBe('0xabc')
       expect(parsed.paymentPayload).toEqual(MOCK_PAYMENT_PAYLOAD)
+      expect(parsed.scheme).toBeUndefined()
+      expect(parsed.network).toBeUndefined()
     } finally {
       globalThis.fetch = original
     }
@@ -71,7 +73,7 @@ describe('forwardToArbiter', () => {
     }
   })
 
-  it('skips on non-escrow scheme', async () => {
+  it('skips on non-commerce scheme', async () => {
     const original = globalThis.fetch
     const spy = vi.fn()
     globalThis.fetch = spy as any
@@ -121,6 +123,9 @@ describe('forwardToArbiter', () => {
         '[forwardToArbiter]',
         expect.any(Error),
       )
+      const err = warnSpy.mock.calls[0][1] as Error
+      expect(err.message).toContain('http://localhost:3001')
+      expect(err.message).toContain('network failure')
     } finally {
       globalThis.fetch = original
       warnSpy.mockRestore()
@@ -144,6 +149,9 @@ describe('forwardToArbiter', () => {
       expect(msg).toContain('[forwardToArbiter]')
       expect(msg).toContain('http://localhost:3001')
       expect(msg).toContain('network failure')
+      const err = onError.mock.calls[0][0] as Error
+      expect(err.cause).toBeInstanceOf(Error)
+      expect((err.cause as Error).message).toBe('network failure')
     } finally {
       globalThis.fetch = original
     }

--- a/packages/helpers/tests/forward-to-arbiter.test.ts
+++ b/packages/helpers/tests/forward-to-arbiter.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it, vi } from 'vitest'
 import { forwardToArbiter } from '../src/forward-to-arbiter.js'
 
+const MOCK_PAYMENT_PAYLOAD = {
+  x402Version: 2,
+  accepted: { scheme: 'escrow', network: 'eip155:84532' },
+  payload: { paymentInfo: { operator: '0x1', payer: '0x2', salt: '123' } },
+}
+
 function makeContext(overrides: {
   success?: boolean
   scheme?: string
@@ -16,6 +22,7 @@ function makeContext(overrides: {
       scheme: overrides.scheme ?? 'escrow',
       network: 'eip155:84532',
     },
+    paymentPayload: MOCK_PAYMENT_PAYLOAD,
     transportContext: overrides.responseBody
       ? { responseBody: Buffer.from(overrides.responseBody) }
       : undefined,
@@ -41,8 +48,8 @@ describe('forwardToArbiter', () => {
       expect(capturedUrl).toBe('http://localhost:3001/verify')
       const parsed = JSON.parse(capturedBody)
       expect(parsed.responseBody).toBe('{"temp": 72}')
-      expect(parsed.scheme).toBe('escrow')
       expect(parsed.transaction).toBe('0xabc')
+      expect(parsed.paymentPayload).toEqual(MOCK_PAYMENT_PAYLOAD)
     } finally {
       globalThis.fetch = original
     }

--- a/packages/helpers/tests/forward-to-arbiter.test.ts
+++ b/packages/helpers/tests/forward-to-arbiter.test.ts
@@ -1,3 +1,4 @@
+import { X402rError } from '@x402r/core'
 import { describe, expect, it, vi } from 'vitest'
 import { forwardToArbiter } from '../src/forward-to-arbiter.js'
 
@@ -121,11 +122,13 @@ describe('forwardToArbiter', () => {
 
       expect(warnSpy).toHaveBeenCalledWith(
         '[forwardToArbiter]',
-        expect.any(Error),
+        expect.any(X402rError),
       )
-      const err = warnSpy.mock.calls[0][1] as Error
-      expect(err.message).toContain('http://localhost:3001')
-      expect(err.message).toContain('network failure')
+      const err = warnSpy.mock.calls[0][1] as X402rError
+      expect(err.shortMessage).toContain('http://localhost:3001')
+      expect(err.cause).toBeInstanceOf(Error)
+      expect((err.cause as Error).message).toBe('network failure')
+      expect(err.details).toContain('/verify')
     } finally {
       globalThis.fetch = original
       warnSpy.mockRestore()
@@ -144,14 +147,12 @@ describe('forwardToArbiter', () => {
       await hook(makeContext({ responseBody: '{"temp": 72}' }))
       await new Promise((r) => setTimeout(r, 50))
 
-      expect(onError).toHaveBeenCalledWith(expect.any(Error))
-      const msg = (onError.mock.calls[0][0] as Error).message
-      expect(msg).toContain('[forwardToArbiter]')
-      expect(msg).toContain('http://localhost:3001')
-      expect(msg).toContain('network failure')
-      const err = onError.mock.calls[0][0] as Error
+      expect(onError).toHaveBeenCalledWith(expect.any(X402rError))
+      const err = onError.mock.calls[0][0] as X402rError
+      expect(err.shortMessage).toContain('http://localhost:3001')
       expect(err.cause).toBeInstanceOf(Error)
       expect((err.cause as Error).message).toBe('network failure')
+      expect(err.details).toContain('/verify')
     } finally {
       globalThis.fetch = original
     }

--- a/packages/helpers/tests/forward-to-arbiter.test.ts
+++ b/packages/helpers/tests/forward-to-arbiter.test.ts
@@ -3,7 +3,7 @@ import { forwardToArbiter } from '../src/forward-to-arbiter.js'
 
 const MOCK_PAYMENT_PAYLOAD = {
   x402Version: 2,
-  accepted: { scheme: 'escrow', network: 'eip155:84532' },
+  accepted: { scheme: 'commerce', network: 'eip155:84532' },
   payload: { paymentInfo: { operator: '0x1', payer: '0x2', salt: '123' } },
 }
 
@@ -19,7 +19,7 @@ function makeContext(overrides: {
       network: 'eip155:84532',
     },
     requirements: {
-      scheme: overrides.scheme ?? 'escrow',
+      scheme: overrides.scheme ?? 'commerce',
       network: 'eip155:84532',
     },
     paymentPayload: MOCK_PAYMENT_PAYLOAD,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ importers:
       '@x402/core':
         specifier: 2.5.0
         version: 2.5.0
+      '@x402r/core':
+        specifier: workspace:*
+        version: link:../core
 
   packages/sdk:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,13 +96,14 @@ importers:
         version: 0.2.3
 
   packages/helpers:
+    dependencies:
+      '@x402r/core':
+        specifier: workspace:*
+        version: link:../core
     devDependencies:
       '@x402/core':
         specifier: 2.5.0
         version: 2.5.0
-      '@x402r/core':
-        specifier: workspace:*
-        version: link:../core
 
   packages/sdk:
     dependencies:


### PR DESCRIPTION
## Summary

- **Forward `paymentPayload`** in `forwardToArbiter()` POST so arbiters can access `paymentInfo` directly from the payload instead of decoding on-chain events
- Remove redundant `scheme` and `network` fields — already available in `paymentPayload.accepted`
- Wrap fetch errors with arbiter URL context for easier debugging

## Payload shape (before → after)

```diff
 {
   responseBody: "...",
-  network: "eip155:84532",
   transaction: "0xabc...",
-  scheme: "escrow",
+  paymentPayload: {
+    x402Version: 2,
+    accepted: { scheme: "escrow", network: "eip155:84532", ... },
+    payload: { paymentInfo: { operator, payer, receiver, ... } },
+  },
 }
```

Arbiters that need `paymentInfo` for `release()` can now read it from `paymentPayload.payload.paymentInfo` — no extra RPC call needed.

## Test plan

- [x] All 7 existing tests pass
- [x] New assertion: `paymentPayload` is included in POST body
- [ ] Verify arbiter-examples garbage detector works with new payload shape (BackTrackCo/arbiter-examples#3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)