### PR TITLE
feat: resolve issues #96-#101 (arbiter helpers, ArbiterClient release, config cleanup)

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -247,26 +247,6 @@ export function getConditionSingletons(
   return config.conditions
 }
 
-export function hasFactories(chainId: number): boolean {
-  const config = x402rChains[chainId as keyof typeof x402rChains] as
-    | X402rChainConfig
-    | undefined
-  return !!config?.factories
-}
-
-export function hasConditionSingletons(chainId: number): boolean {
-  const config = x402rChains[chainId as keyof typeof x402rChains] as
-    | X402rChainConfig
-    | undefined
-  if (!config?.conditions) return false
-  const { payer, receiver, alwaysTrue } = config.conditions
-  return (
-    payer !== zeroAddress &&
-    receiver !== zeroAddress &&
-    alwaysTrue !== zeroAddress
-  )
-}
-
 // ---------------------------------------------------------------------------
 // CAIP-2 bridge
 // ---------------------------------------------------------------------------

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -222,8 +222,6 @@ export {
   getConditionSingletons,
   getFactoryAddress,
   getFactoryAddresses,
-  hasConditionSingletons,
-  hasFactories,
   isSupportedChain,
   protocolFeeConfig,
   receiverRefundCollector,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -355,6 +355,9 @@ export {
   signReceiveAuthorization,
 } from './payment/index.js'
 export {
+  deserializePaymentInfo,
+  type SerializedPaymentInfo,
+  serializePaymentInfo,
   type ToPaymentInfoReturnType,
   toPaymentInfo,
 } from './payment/serialization.js'

--- a/packages/core/src/payment/serialization.ts
+++ b/packages/core/src/payment/serialization.ts
@@ -1,4 +1,5 @@
 import type { EscrowPayload } from '@x402r/evm'
+import type { Address } from 'viem'
 import type { PaymentInfo } from '../types/index.js'
 
 // ---------------------------------------------------------------------------
@@ -6,6 +7,26 @@ import type { PaymentInfo } from '../types/index.js'
 // ---------------------------------------------------------------------------
 
 export type ToPaymentInfoReturnType = PaymentInfo
+
+/** JSON-safe representation of PaymentInfo (bigint fields stored as strings). */
+export interface SerializedPaymentInfo {
+  operator: Address
+  payer: Address
+  receiver: Address
+  token: Address
+  maxAmount: string
+  preApprovalExpiry: number
+  authorizationExpiry: number
+  refundExpiry: number
+  minFeeBps: number
+  maxFeeBps: number
+  feeReceiver: Address
+  salt: string
+}
+
+// ---------------------------------------------------------------------------
+// EscrowPayload → PaymentInfo
+// ---------------------------------------------------------------------------
 
 /** Convert an EscrowPayload (from verified x402 payment) to a PaymentInfo struct. */
 export function toPaymentInfo(
@@ -25,5 +46,47 @@ export function toPaymentInfo(
     maxFeeBps: pi.maxFeeBps,
     feeReceiver: pi.feeReceiver,
     salt: BigInt(pi.salt),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// PaymentInfo ↔ JSON serialization
+// ---------------------------------------------------------------------------
+
+/** Serialize PaymentInfo to a JSON-safe object (bigint → string). */
+export function serializePaymentInfo(pi: PaymentInfo): SerializedPaymentInfo {
+  return {
+    operator: pi.operator,
+    payer: pi.payer,
+    receiver: pi.receiver,
+    token: pi.token,
+    maxAmount: pi.maxAmount.toString(),
+    preApprovalExpiry: pi.preApprovalExpiry,
+    authorizationExpiry: pi.authorizationExpiry,
+    refundExpiry: pi.refundExpiry,
+    minFeeBps: pi.minFeeBps,
+    maxFeeBps: pi.maxFeeBps,
+    feeReceiver: pi.feeReceiver,
+    salt: pi.salt.toString(),
+  }
+}
+
+/** Deserialize a JSON-safe object back to PaymentInfo (string → bigint). */
+export function deserializePaymentInfo(
+  raw: SerializedPaymentInfo,
+): PaymentInfo {
+  return {
+    operator: raw.operator,
+    payer: raw.payer,
+    receiver: raw.receiver,
+    token: raw.token,
+    maxAmount: BigInt(raw.maxAmount),
+    preApprovalExpiry: raw.preApprovalExpiry,
+    authorizationExpiry: raw.authorizationExpiry,
+    refundExpiry: raw.refundExpiry,
+    minFeeBps: raw.minFeeBps,
+    maxFeeBps: raw.maxFeeBps,
+    feeReceiver: raw.feeReceiver,
+    salt: BigInt(raw.salt),
   }
 }

--- a/packages/helpers/src/deploy-context.ts
+++ b/packages/helpers/src/deploy-context.ts
@@ -1,0 +1,65 @@
+import { ValidationError } from '@x402r/core'
+
+/** Minimal deployment context for persistence (addresses only). */
+export interface DeployContext {
+  operatorAddress: `0x${string}`
+  escrowPeriodAddress: `0x${string}`
+  arbiterConditionAddress: `0x${string}`
+}
+
+/**
+ * Extract the minimal deploy context from a deployment result.
+ *
+ * Returns a JSON-serializable object containing only the addresses
+ * needed to interact with the deployed operator.
+ *
+ * @example
+ * ```ts
+ * import { toDeployContext } from '@x402r/helpers'
+ * import { writeFileSync } from 'node:fs'
+ *
+ * const deployment = await deployDeliveryProtectionOperator(wallet, public, opts)
+ * writeFileSync('context.json', JSON.stringify(toDeployContext(deployment), null, 2))
+ * ```
+ */
+export function toDeployContext(deployment: DeployContext): DeployContext {
+  return {
+    operatorAddress: deployment.operatorAddress,
+    escrowPeriodAddress: deployment.escrowPeriodAddress,
+    arbiterConditionAddress: deployment.arbiterConditionAddress,
+  }
+}
+
+/**
+ * Parse and validate a deploy context from a plain object (e.g. parsed JSON).
+ *
+ * @example
+ * ```ts
+ * import { parseDeployContext } from '@x402r/helpers'
+ * import { readFileSync } from 'node:fs'
+ *
+ * const raw = JSON.parse(readFileSync('context.json', 'utf-8'))
+ * const ctx = parseDeployContext(raw)
+ * // ctx.operatorAddress, ctx.escrowPeriodAddress, ctx.arbiterConditionAddress
+ * ```
+ */
+export function parseDeployContext(raw: unknown): DeployContext {
+  if (!raw || typeof raw !== 'object') {
+    throw new ValidationError('Expected an object for deploy context')
+  }
+  const obj = raw as Record<string, unknown>
+  if (
+    typeof obj.operatorAddress !== 'string' ||
+    typeof obj.escrowPeriodAddress !== 'string' ||
+    typeof obj.arbiterConditionAddress !== 'string'
+  ) {
+    throw new ValidationError(
+      'Invalid deploy context: missing required address fields (operatorAddress, escrowPeriodAddress, arbiterConditionAddress)',
+    )
+  }
+  return {
+    operatorAddress: obj.operatorAddress as `0x${string}`,
+    escrowPeriodAddress: obj.escrowPeriodAddress as `0x${string}`,
+    arbiterConditionAddress: obj.arbiterConditionAddress as `0x${string}`,
+  }
+}

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -13,6 +13,8 @@ export {
   tokenCollector,
   usdcTvlLimit,
 } from '@x402r/core'
+export type { DeployContext } from './deploy-context.js'
+export { parseDeployContext, toDeployContext } from './deploy-context.js'
 export type { ForwardToArbiterOptions } from './forward-to-arbiter.js'
 export { forwardToArbiter } from './forward-to-arbiter.js'
 export type { ParsedForwardedPayload } from './parse-forwarded-payload.js'

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -15,3 +15,5 @@ export {
 } from '@x402r/core'
 export type { ForwardToArbiterOptions } from './forward-to-arbiter.js'
 export { forwardToArbiter } from './forward-to-arbiter.js'
+export type { ParsedForwardedPayload } from './parse-forwarded-payload.js'
+export { parseForwardedPayload } from './parse-forwarded-payload.js'

--- a/packages/helpers/src/parse-forwarded-payload.ts
+++ b/packages/helpers/src/parse-forwarded-payload.ts
@@ -1,0 +1,97 @@
+import {
+  deserializePaymentInfo,
+  type PaymentInfo,
+  type SerializedPaymentInfo,
+  ValidationError,
+} from '@x402r/core'
+
+/**
+ * Parsed result from an arbiter-side forwarded payload.
+ *
+ * Mirrors the JSON body sent by {@link forwardToArbiter}.
+ */
+export interface ParsedForwardedPayload {
+  /** The raw HTTP response body from the resource server (parsed JSON or string). */
+  responseBody: unknown
+  /** Deserialized PaymentInfo with BigInt fields restored. */
+  paymentInfo: PaymentInfo
+  /** CAIP-2 network identifier (e.g. `"eip155:84532"`). */
+  network: string
+  /** Settlement transaction hash. */
+  transaction: string
+}
+
+/**
+ * Parses the JSON body that {@link forwardToArbiter} POSTs to the arbiter's
+ * `/verify` endpoint.
+ *
+ * Extracts `paymentInfo` from `paymentPayload.payload.paymentInfo` and
+ * converts BigInt-serialized fields (`maxAmount`, `salt`) back to native
+ * `bigint` values.
+ *
+ * @example
+ * ```ts
+ * import { parseForwardedPayload } from '@x402r/helpers'
+ *
+ * app.post('/verify', async (req, res) => {
+ *   const { responseBody, paymentInfo, network, transaction } =
+ *     parseForwardedPayload(req.body)
+ *   // paymentInfo.maxAmount is bigint
+ * })
+ * ```
+ */
+export function parseForwardedPayload(body: unknown): ParsedForwardedPayload {
+  if (!body || typeof body !== 'object') {
+    throw new ValidationError('Expected an object as the forwarded payload')
+  }
+
+  const obj = body as Record<string, unknown>
+
+  const transaction = obj.transaction
+  if (typeof transaction !== 'string' || !transaction) {
+    throw new ValidationError(
+      'Missing or invalid "transaction" in forwarded payload',
+    )
+  }
+
+  const paymentPayload = obj.paymentPayload
+  if (!paymentPayload || typeof paymentPayload !== 'object') {
+    throw new ValidationError(
+      'Missing or invalid "paymentPayload" in forwarded payload',
+    )
+  }
+
+  const pp = paymentPayload as Record<string, unknown>
+  const accepted = pp.accepted as Record<string, unknown> | undefined
+  const network =
+    typeof accepted?.network === 'string' ? accepted.network : undefined
+  if (!network) {
+    throw new ValidationError(
+      'Missing "paymentPayload.accepted.network" in forwarded payload',
+    )
+  }
+
+  const payload = pp.payload as Record<string, unknown> | undefined
+  const rawPaymentInfo = payload?.paymentInfo as
+    | SerializedPaymentInfo
+    | undefined
+  if (!rawPaymentInfo || typeof rawPaymentInfo !== 'object') {
+    throw new ValidationError(
+      'Missing "paymentPayload.payload.paymentInfo" in forwarded payload',
+    )
+  }
+
+  const paymentInfo = deserializePaymentInfo(rawPaymentInfo)
+
+  // responseBody is a stringified JSON string; attempt to parse it
+  let responseBody: unknown = obj.responseBody
+  if (typeof responseBody === 'string') {
+    try {
+      responseBody = JSON.parse(responseBody)
+    } catch {
+      // keep as raw string if not valid JSON
+    }
+  }
+
+  return { responseBody, paymentInfo, network, transaction }
+}

--- a/packages/helpers/tests/deploy-context.test.ts
+++ b/packages/helpers/tests/deploy-context.test.ts
@@ -1,0 +1,51 @@
+import { ValidationError } from '@x402r/core'
+import { describe, expect, it } from 'vitest'
+import { parseDeployContext, toDeployContext } from '../src/deploy-context.js'
+
+const VALID_CONTEXT = {
+  operatorAddress: '0x1111111111111111111111111111111111111111',
+  escrowPeriodAddress: '0x2222222222222222222222222222222222222222',
+  arbiterConditionAddress: '0x3333333333333333333333333333333333333333',
+} as const
+
+describe('toDeployContext', () => {
+  it('extracts only the three address fields', () => {
+    const deployment = {
+      ...VALID_CONTEXT,
+      operatorConfig: { some: 'config' },
+      deployments: [],
+      summary: { newCount: 1, existingCount: 0, txHashes: [] },
+    }
+    const ctx = toDeployContext(deployment as any)
+    expect(ctx).toEqual(VALID_CONTEXT)
+    expect(Object.keys(ctx)).toEqual([
+      'operatorAddress',
+      'escrowPeriodAddress',
+      'arbiterConditionAddress',
+    ])
+  })
+
+  it('round-trips through JSON', () => {
+    const ctx = toDeployContext(VALID_CONTEXT)
+    const json = JSON.stringify(ctx)
+    const parsed = parseDeployContext(JSON.parse(json))
+    expect(parsed).toEqual(VALID_CONTEXT)
+  })
+})
+
+describe('parseDeployContext', () => {
+  it('parses a valid context', () => {
+    const ctx = parseDeployContext(VALID_CONTEXT)
+    expect(ctx.operatorAddress).toBe(VALID_CONTEXT.operatorAddress)
+  })
+
+  it('throws on null', () => {
+    expect(() => parseDeployContext(null)).toThrow(ValidationError)
+  })
+
+  it('throws on missing fields', () => {
+    expect(() => parseDeployContext({ operatorAddress: '0x1' })).toThrow(
+      /missing required address fields/,
+    )
+  })
+})

--- a/packages/helpers/tests/parse-forwarded-payload.test.ts
+++ b/packages/helpers/tests/parse-forwarded-payload.test.ts
@@ -1,0 +1,87 @@
+import { ValidationError } from '@x402r/core'
+import { describe, expect, it } from 'vitest'
+import { parseForwardedPayload } from '../src/parse-forwarded-payload.js'
+
+const VALID_BODY = {
+  responseBody: '{"temp": 72}',
+  transaction: '0xabc',
+  paymentPayload: {
+    x402Version: 2,
+    accepted: { scheme: 'commerce', network: 'eip155:84532' },
+    payload: {
+      paymentInfo: {
+        operator: '0x1111111111111111111111111111111111111111',
+        payer: '0x2222222222222222222222222222222222222222',
+        receiver: '0x3333333333333333333333333333333333333333',
+        token: '0x4444444444444444444444444444444444444444',
+        maxAmount: '1000000',
+        preApprovalExpiry: 0,
+        authorizationExpiry: 1700000000,
+        refundExpiry: 1700086400,
+        minFeeBps: 100,
+        maxFeeBps: 500,
+        feeReceiver: '0x5555555555555555555555555555555555555555',
+        salt: '999',
+      },
+    },
+  },
+}
+
+describe('parseForwardedPayload', () => {
+  it('parses a valid forwarded payload', () => {
+    const result = parseForwardedPayload(VALID_BODY)
+
+    expect(result.network).toBe('eip155:84532')
+    expect(result.transaction).toBe('0xabc')
+    expect(result.responseBody).toEqual({ temp: 72 })
+    expect(result.paymentInfo.maxAmount).toBe(1000000n)
+    expect(result.paymentInfo.salt).toBe(999n)
+    expect(result.paymentInfo.operator).toBe(
+      '0x1111111111111111111111111111111111111111',
+    )
+  })
+
+  it('keeps responseBody as string if not valid JSON', () => {
+    const body = { ...VALID_BODY, responseBody: 'not json' }
+    const result = parseForwardedPayload(body)
+    expect(result.responseBody).toBe('not json')
+  })
+
+  it('throws on null body', () => {
+    expect(() => parseForwardedPayload(null)).toThrow(ValidationError)
+  })
+
+  it('throws on missing transaction', () => {
+    const { transaction: _, ...body } = VALID_BODY
+    expect(() => parseForwardedPayload(body)).toThrow(/transaction/)
+  })
+
+  it('throws on missing paymentPayload', () => {
+    const { paymentPayload: _, ...body } = VALID_BODY
+    expect(() =>
+      parseForwardedPayload({ ...body, transaction: '0xabc' }),
+    ).toThrow(/paymentPayload/)
+  })
+
+  it('throws on missing network in accepted', () => {
+    const body = {
+      ...VALID_BODY,
+      paymentPayload: {
+        ...VALID_BODY.paymentPayload,
+        accepted: { scheme: 'commerce' },
+      },
+    }
+    expect(() => parseForwardedPayload(body)).toThrow(/network/)
+  })
+
+  it('throws on missing paymentInfo', () => {
+    const body = {
+      ...VALID_BODY,
+      paymentPayload: {
+        ...VALID_BODY.paymentPayload,
+        payload: {},
+      },
+    }
+    expect(() => parseForwardedPayload(body)).toThrow(/paymentInfo/)
+  })
+})

--- a/packages/sdk/src/actions/payment.ts
+++ b/packages/sdk/src/actions/payment.ts
@@ -9,6 +9,7 @@ import {
   release as coreRelease,
   getPaymentAmounts,
   getPaymentState,
+  receiverRefundCollector,
 } from '@x402r/core'
 import type { Address, Hash, Hex } from 'viem'
 import type { PaymentActions, ResolvedConfig } from '../types.js'
@@ -96,7 +97,7 @@ export function createPaymentActions(config: ResolvedConfig): PaymentActions {
       const wallet = requireWallet(config)
       return coreApprovePostEscrowRefund(wallet, {
         token,
-        collectorAddress: config.chainConfig.receiverRefundCollector,
+        collectorAddress: receiverRefundCollector,
         amount,
       })
     },
@@ -107,7 +108,7 @@ export function createPaymentActions(config: ResolvedConfig): PaymentActions {
       return coreGetPostEscrowRefundAllowance(config.publicClient, {
         token,
         owner,
-        collectorAddress: config.chainConfig.receiverRefundCollector,
+        collectorAddress: receiverRefundCollector,
       })
     },
     async getState(paymentInfo: PaymentInfo) {

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -78,7 +78,7 @@ export function createX402r(config: X402rConfig): X402r {
 
 export function resolveConfig(config: X402rConfig): ResolvedConfig {
   const chainId = resolveChainId(config)
-  const chainConfig = getChainConfig(chainId)
+  const { usdc } = getChainConfig(chainId)
   const refundRequestEvidenceAddress = config.refundRequestEvidenceAddress
 
   if (refundRequestEvidenceAddress && !config.refundRequestAddress) {
@@ -92,7 +92,7 @@ export function resolveConfig(config: X402rConfig): ResolvedConfig {
     walletClient: config.walletClient,
     operatorAddress: config.operatorAddress,
     chainId,
-    chainConfig,
+    usdc,
     refundRequestAddress: config.refundRequestAddress ?? undefined,
     refundRequestEvidenceAddress,
     escrowPeriodAddress: config.escrowPeriodAddress,

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -13,7 +13,6 @@ import type {
   PaymentInfo,
   RefundRequestData,
   RefundRequestStatus,
-  X402rChainConfig,
 } from '@x402r/core'
 import type { Address, Hash, Hex, PublicClient, WalletClient } from 'viem'
 import type { PaymentStore } from './store/types.js'
@@ -58,7 +57,7 @@ export interface ResolvedConfig {
   walletClient: WalletClient | undefined
   operatorAddress: Address
   chainId: number
-  chainConfig: X402rChainConfig
+  usdc: Address
   refundRequestAddress: Address | undefined
   refundRequestEvidenceAddress: Address | undefined
   escrowPeriodAddress: Address | undefined

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -332,7 +332,7 @@ export interface ArbiterClient {
   readonly config: ResolvedWriteConfig
   readonly payment: Pick<
     PaymentActions,
-    'getState' | 'getAmounts' | 'refundInEscrow'
+    'getState' | 'getAmounts' | 'release' | 'refundInEscrow'
   >
   readonly escrow:
     | Pick<


### PR DESCRIPTION
## Summary

- **#98** `serializePaymentInfo()` / `deserializePaymentInfo()` in `@x402r/core` for BigInt-safe JSON round-trips
- **#96** `parseForwardedPayload()` in `@x402r/helpers` -- arbiter-side counterpart to `forwardToArbiter()`, extracts typed PaymentInfo with BigInt restoration
- **#97** Added `payment.release()` to `ArbiterClient` type -- releasing escrowed funds is the primary arbiter action
- **#99** `toDeployContext()` / `parseDeployContext()` in `@x402r/helpers` -- eliminates ~40 lines of save/load boilerplate per example
- **#101** Slimmed `ResolvedConfig`: replaced `chainConfig` with `usdc`, import `receiverRefundCollector` directly from `@x402r/core`, removed dead `hasFactories`/`hasConditionSingletons`

## Breaking Changes

- `ResolvedConfig.chainConfig` removed. Consumers must migrate:
  - Universal addresses: `import { receiverRefundCollector } from '@x402r/core'`
  - USDC address: `client.config.usdc`
  - Full chain config: `getChainConfig(chainId)` still works
- `hasFactories()` and `hasConditionSingletons()` removed (zero callers)

## Test plan

- [x] `pnpm build` passes all 3 packages (core, helpers, sdk)
- [x] `pnpm typecheck` passes all packages
- [x] `pnpm --filter @x402r/core test` -- 275 unit tests pass (5 pre-existing fork test failures)
- [x] `pnpm --filter @x402r/sdk test` -- 135 tests pass
- [x] `pnpm --filter @x402r/helpers test` -- 19 tests pass (includes new tests for parseForwardedPayload and deploy context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)