### PR TITLE
feat(core): marketplace PaymentIndexRecorder + block charge() in delivery-protection preset

### DIFF
--- a/.changeset/core-delivery-protection-block-charge.md
+++ b/.changeset/core-delivery-protection-block-charge.md
@@ -1,0 +1,15 @@
+---
+"@x402r/core": minor
+---
+
+Delivery-protection operator preset now blocks the immediate-charge path.
+
+`previewDeliveryProtectionOperator` / `deployDeliveryProtectionOperator` wire
+`chargeCondition` to a `NotCondition(AlwaysTrue)` (always returns false) instead
+of `zeroAddress`. In `PaymentOperator`, a `zeroAddress` condition means "always
+allow", so leaving the charge slot empty let anyone call `charge()` to settle a
+delivery-protected payment immediately and skip the escrow hold — defeating the
+protection. Payments must now go through `authorize` -> `release`/`refund`.
+
+Note: this changes the deterministic address of delivery-protection operators,
+and the preset now deploys one additional contract (the `NotCondition`).

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,4 +1,4 @@
-import { type Address, zeroAddress } from 'viem'
+import { type Address, type Hex, pad, zeroAddress } from 'viem'
 import { ConfigError } from '../errors/index.js'
 
 // ---------------------------------------------------------------------------
@@ -26,6 +26,11 @@ export interface ConditionSingletonAddresses {
   alwaysTrue: Address
 }
 
+export interface RecorderSingletonAddresses {
+  /** PaymentIndexRecorder(escrow, recorderCombinatorCodehash) — deploy once, share across operators */
+  paymentIndexRecorder: Address
+}
+
 export interface X402rChainConfig {
   name: string
   chainId: number
@@ -38,6 +43,9 @@ export interface X402rChainConfig {
   usdc: Address
   factories: FactoryAddresses
   conditions: ConditionSingletonAddresses
+  recorders: RecorderSingletonAddresses
+  /** Runtime codehash of RecorderCombinator contract (same for all instances) */
+  recorderCombinatorCodehash: Hex
 }
 
 // ---------------------------------------------------------------------------
@@ -80,6 +88,23 @@ export const conditions = {
   alwaysTrue: '0xA367323189f20706488A1D83430eda82a2eA5320',
 } as const satisfies ConditionSingletonAddresses
 
+/** Chain-invariant CREATE3 recorder singleton addresses. Same as `getChainConfig(chainId).recorders`. */
+export const recorders = {
+  // TODO: Deploy PaymentIndexRecorder via CREATE3 and set address here.
+  // Until deployed, delivery protection preset falls back to EscrowPeriod-only recorder.
+  paymentIndexRecorder: zeroAddress,
+} as const satisfies RecorderSingletonAddresses
+
+/**
+ * Runtime codehash of RecorderCombinator contract.
+ * All RecorderCombinator instances share identical runtime bytecode —
+ * constructor args affect storage, not deployed code.
+ *
+ * TODO: Compute from x402r-contracts build artifacts and set here.
+ * Until set, delivery protection preset uses pad('0x00') (operator-only mode).
+ */
+export const recorderCombinatorCodehash: Hex = pad('0x00')
+
 const PROTOCOL_ADDRESSES = {
   authCaptureEscrow,
   tokenCollector,
@@ -89,6 +114,8 @@ const PROTOCOL_ADDRESSES = {
   usdcTvlLimit,
   factories,
   conditions,
+  recorders,
+  recorderCombinatorCodehash,
 } as const
 
 /** Build a chain config by spreading unified protocol addresses + chain-specific USDC */
@@ -245,6 +272,13 @@ export function getConditionSingletons(
     )
   }
   return config.conditions
+}
+
+export function getRecorderSingletons(
+  chainId: number,
+): RecorderSingletonAddresses {
+  const config = getChainConfig(chainId)
+  return config.recorders
 }
 
 export function hasFactories(chainId: number): boolean {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,4 +1,4 @@
-import { type Address, type Hex, pad, zeroAddress } from 'viem'
+import { type Address, type Hex, zeroAddress } from 'viem'
 import { ConfigError } from '../errors/index.js'
 
 // ---------------------------------------------------------------------------
@@ -90,20 +90,18 @@ export const conditions = {
 
 /** Chain-invariant CREATE3 recorder singleton addresses. Same as `getChainConfig(chainId).recorders`. */
 export const recorders = {
-  // TODO: Deploy PaymentIndexRecorder via CREATE3 and set address here.
-  // Until deployed, delivery protection preset falls back to EscrowPeriod-only recorder.
-  paymentIndexRecorder: zeroAddress,
+  paymentIndexRecorder:
+    '0x3134920b77565767adf9559E747bED01918B0763' as const satisfies Address,
 } as const satisfies RecorderSingletonAddresses
 
 /**
  * Runtime codehash of RecorderCombinator contract.
  * All RecorderCombinator instances share identical runtime bytecode —
  * constructor args affect storage, not deployed code.
- *
- * TODO: Compute from x402r-contracts build artifacts and set here.
- * Until set, delivery protection preset uses pad('0x00') (operator-only mode).
+ * Computed via: forge script script/ComputeCodehash.s.sol
  */
-export const recorderCombinatorCodehash: Hex = pad('0x00')
+export const recorderCombinatorCodehash: Hex =
+  '0x489c83194f171a41ed97057e542ffb877d7a787f7888341ee379288f4f02691e'
 
 const PROTOCOL_ADDRESSES = {
   authCaptureEscrow,

--- a/packages/core/src/deploy/presets.ts
+++ b/packages/core/src/deploy/presets.ts
@@ -1,5 +1,5 @@
 import type { Address, Hex, PublicClient, WalletClient } from 'viem'
-import { encodeFunctionData, pad, zeroAddress } from 'viem'
+import { encodeFunctionData, zeroAddress } from 'viem'
 import {
   andConditionFactoryAbi,
   escrowPeriodFactoryAbi,
@@ -272,8 +272,9 @@ function resolveOptions(options: MarketplaceOperatorOptions) {
 
   const factories = getFactoryAddresses(options.chainId)
   const singletons = getConditionSingletons(options.chainId)
-  // bytes32(0) = no authorized codehash restriction (operator-only recording)
-  const authorizedCodehash = options.authorizedCodehash ?? pad('0x00')
+  const recorderSingletons = getRecorderSingletons(options.chainId)
+  const authorizedCodehash =
+    options.authorizedCodehash ?? config.recorderCombinatorCodehash
   const freezeDurationSeconds = options.freezeDurationSeconds ?? 0n
   const operatorFeeBps = options.operatorFeeBps ?? 0n
 
@@ -281,6 +282,7 @@ function resolveOptions(options: MarketplaceOperatorOptions) {
     config,
     factories,
     singletons,
+    recorderSingletons,
     authorizedCodehash,
     freezeDurationSeconds,
     operatorFeeBps,
@@ -299,6 +301,7 @@ export async function previewMarketplaceOperator(
     config,
     factories,
     singletons,
+    recorderSingletons,
     authorizedCodehash,
     freezeDurationSeconds,
     operatorFeeBps,
@@ -370,12 +373,22 @@ export async function previewMarketplaceOperator(
   const releaseConditionAddress: Address =
     andConditionAddress ?? escrowPeriodAddress
 
+  // Batch 3b: RecorderCombinator for authorize (if PaymentIndexRecorder available)
+  const paymentIndexRecorderAddress = recorderSingletons.paymentIndexRecorder
+  const hasPaymentIndexRecorder = paymentIndexRecorderAddress !== zeroAddress
+  const authorizeRecorderAddress: Address = hasPaymentIndexRecorder
+    ? await computeRecorderCombinatorAddress(publicClient, {
+        factoryAddress: factories.recorderCombinator,
+        recorders: [escrowPeriodAddress, paymentIndexRecorderAddress],
+      })
+    : escrowPeriodAddress
+
   // Batch 4: operator (depends on everything)
   const operatorConfig: OperatorConfig = {
     feeRecipient: options.feeRecipient,
     feeCalculator: feeCalculatorAddress ?? zeroAddress,
     authorizeCondition: config.usdcTvlLimit,
-    authorizeRecorder: escrowPeriodAddress,
+    authorizeRecorder: authorizeRecorderAddress,
     chargeCondition: zeroAddress,
     chargeRecorder: zeroAddress,
     releaseCondition: releaseConditionAddress,

--- a/packages/core/src/deploy/presets.ts
+++ b/packages/core/src/deploy/presets.ts
@@ -4,6 +4,7 @@ import {
   andConditionFactoryAbi,
   escrowPeriodFactoryAbi,
   freezeFactoryAbi,
+  notConditionFactoryAbi,
   orConditionFactoryAbi,
   paymentOperatorFactoryAbi,
   recorderCombinatorFactoryAbi,
@@ -26,6 +27,7 @@ import {
   computeEscrowPeriodAddress,
   computeFeeCalculatorAddress,
   computeFreezeAddress,
+  computeNotConditionAddress,
   computeOperatorAddress,
   computeOrConditionAddress,
   computeRecorderCombinatorAddress,
@@ -1078,6 +1080,8 @@ export interface DeliveryProtectionOperatorPreview {
   operatorAddress: Address
   escrowPeriodAddress: Address
   arbiterConditionAddress: Address
+  /** NotCondition(AlwaysTrue) wired into chargeCondition to block the immediate-charge bypass */
+  chargeBlockConditionAddress: Address
   releaseConditionAddress: Address
   refundInEscrowConditionAddress: Address
   authorizeRecorderAddress: Address
@@ -1089,6 +1093,8 @@ export interface DeliveryProtectionOperatorDeployment {
   operatorAddress: Address
   escrowPeriodAddress: Address
   arbiterConditionAddress: Address
+  /** NotCondition(AlwaysTrue) wired into chargeCondition to block the immediate-charge bypass */
+  chargeBlockConditionAddress: Address
   releaseConditionAddress: Address
   refundInEscrowConditionAddress: Address
   authorizeRecorderAddress: Address
@@ -1123,7 +1129,11 @@ export async function previewDeliveryProtectionOperator(
   const hasPaymentIndexRecorder = paymentIndexRecorderAddress !== zeroAddress
 
   // Batch 1 (parallel, no dependencies)
-  const [escrowPeriodAddress, arbiterConditionAddress] = await Promise.all([
+  const [
+    escrowPeriodAddress,
+    arbiterConditionAddress,
+    chargeBlockConditionAddress,
+  ] = await Promise.all([
     computeEscrowPeriodAddress(publicClient, {
       factoryAddress: factoryAddrs.escrowPeriod,
       escrowPeriod: options.escrowPeriodSeconds,
@@ -1132,6 +1142,14 @@ export async function previewDeliveryProtectionOperator(
     computeStaticAddressConditionAddress(publicClient, {
       factoryAddress: factoryAddrs.staticAddressCondition,
       designatedAddress: options.arbiter,
+    }),
+    // NotCondition(AlwaysTrue) — always returns false. Wired into chargeCondition
+    // so charge() is blocked: a zeroAddress chargeCondition means "always allow",
+    // which would let anyone settle a delivery-protected payment immediately and
+    // skip the escrow hold. Forcing payments through authorize -> release/refund.
+    computeNotConditionAddress(publicClient, {
+      factoryAddress: factoryAddrs.notCondition,
+      condition: singletons.alwaysTrue,
     }),
   ])
 
@@ -1173,7 +1191,7 @@ export async function previewDeliveryProtectionOperator(
     feeCalculator: zeroAddress,
     authorizeCondition: config.usdcTvlLimit,
     authorizeRecorder: authorizeRecorderAddress,
-    chargeCondition: zeroAddress,
+    chargeCondition: chargeBlockConditionAddress,
     chargeRecorder: zeroAddress,
     releaseCondition: releaseConditionAddress,
     releaseRecorder: zeroAddress,
@@ -1192,6 +1210,7 @@ export async function previewDeliveryProtectionOperator(
     operatorAddress,
     escrowPeriodAddress,
     arbiterConditionAddress,
+    chargeBlockConditionAddress,
     releaseConditionAddress,
     refundInEscrowConditionAddress,
     authorizeRecorderAddress,
@@ -1204,6 +1223,10 @@ export async function previewDeliveryProtectionOperator(
 // deployDeliveryProtectionOperator — single-tx via Multicall3
 //
 // Deploys a PaymentOperator where:
+// - Charge: NotCondition(AlwaysTrue) — always false, so the immediate-charge
+//   path is blocked. Payments must go authorize -> release/refund, otherwise a
+//   zeroAddress chargeCondition ("always allow") would let anyone settle a
+//   delivery-protected payment immediately and skip the escrow hold.
 // - Release: OrCondition([SAC(arbiter), PayerCondition]) — arbiter or payer
 // - RefundInEscrow: OrCondition([EscrowPeriod, ReceiverCondition, SAC(arbiter)])
 //   — after escrow window, or receiver, or arbiter
@@ -1227,6 +1250,7 @@ export async function deployDeliveryProtectionOperator(
   const {
     escrowPeriodAddress,
     arbiterConditionAddress,
+    chargeBlockConditionAddress,
     releaseConditionAddress,
     refundInEscrowConditionAddress,
     authorizeRecorderAddress,
@@ -1252,6 +1276,12 @@ export async function deployDeliveryProtectionOperator(
       abi: staticAddressConditionFactoryAbi,
       functionName: 'getDeployed',
       args: [options.arbiter],
+    },
+    {
+      address: factoryAddrs.notCondition,
+      abi: notConditionFactoryAbi,
+      functionName: 'getDeployed',
+      args: [getConditionSingletons(options.chainId).alwaysTrue],
     },
     {
       address: factoryAddrs.orCondition,
@@ -1303,6 +1333,7 @@ export async function deployDeliveryProtectionOperator(
   let idx = 0
   const escrowPeriodExists = existenceResults[idx++].result !== zeroAddress
   const arbiterCondExists = existenceResults[idx++].result !== zeroAddress
+  const chargeBlockCondExists = existenceResults[idx++].result !== zeroAddress
   const releaseCondExists = existenceResults[idx++].result !== zeroAddress
   const refundCondExists = existenceResults[idx++].result !== zeroAddress
   const combinatorExists = hasCombinator
@@ -1310,13 +1341,14 @@ export async function deployDeliveryProtectionOperator(
     : true // no combinator needed
   const operatorExists = existenceResults[idx++].result !== zeroAddress
 
-  const totalContracts = hasCombinator ? 6 : 5
+  const totalContracts = hasCombinator ? 7 : 6
 
   // If operator already deployed, return immediately
   if (operatorExists) {
     const existingDeployments: DeployResult[] = [
       { address: escrowPeriodAddress, hash: null, isNew: false },
       { address: arbiterConditionAddress, hash: null, isNew: false },
+      { address: chargeBlockConditionAddress, hash: null, isNew: false },
       { address: releaseConditionAddress, hash: null, isNew: false },
       { address: refundInEscrowConditionAddress, hash: null, isNew: false },
       ...(hasCombinator
@@ -1328,6 +1360,7 @@ export async function deployDeliveryProtectionOperator(
       operatorAddress,
       escrowPeriodAddress,
       arbiterConditionAddress,
+      chargeBlockConditionAddress,
       releaseConditionAddress,
       refundInEscrowConditionAddress,
       authorizeRecorderAddress,
@@ -1387,7 +1420,17 @@ export async function deployDeliveryProtectionOperator(
     [options.arbiter],
   )
 
-  // 3. OrCondition for release: arbiter OR payer
+  // 3. NotCondition(AlwaysTrue) — wired into chargeCondition to block charge()
+  trackDeploy(
+    chargeBlockConditionAddress,
+    chargeBlockCondExists,
+    factoryAddrs.notCondition,
+    notConditionFactoryAbi,
+    'deploy',
+    [singletons.alwaysTrue],
+  )
+
+  // 4. OrCondition for release: arbiter OR payer
   trackDeploy(
     releaseConditionAddress,
     releaseCondExists,
@@ -1397,7 +1440,7 @@ export async function deployDeliveryProtectionOperator(
     [[arbiterConditionAddress, singletons.payer]],
   )
 
-  // 4. OrCondition for refundInEscrow: escrow period OR receiver OR arbiter
+  // 5. OrCondition for refundInEscrow: escrow period OR receiver OR arbiter
   trackDeploy(
     refundInEscrowConditionAddress,
     refundCondExists,
@@ -1407,7 +1450,7 @@ export async function deployDeliveryProtectionOperator(
     [[escrowPeriodAddress, singletons.receiver, arbiterConditionAddress]],
   )
 
-  // 5. RecorderCombinator (if PaymentIndexRecorder available)
+  // 6. RecorderCombinator (if PaymentIndexRecorder available)
   if (hasCombinator) {
     trackDeploy(
       authorizeRecorderAddress,
@@ -1419,7 +1462,7 @@ export async function deployDeliveryProtectionOperator(
     )
   }
 
-  // 6. Operator (always included, never allowFailure)
+  // 7. Operator (always included, never allowFailure)
   calls.push({
     target: factoryAddrs.paymentOperator,
     allowFailure: false,
@@ -1443,6 +1486,7 @@ export async function deployDeliveryProtectionOperator(
     operatorAddress,
     escrowPeriodAddress,
     arbiterConditionAddress,
+    chargeBlockConditionAddress,
     releaseConditionAddress,
     refundInEscrowConditionAddress,
     authorizeRecorderAddress,

--- a/packages/core/src/deploy/presets.ts
+++ b/packages/core/src/deploy/presets.ts
@@ -231,6 +231,8 @@ export interface MarketplaceOperatorPreview {
   refundRequestEvidenceAddress: Address
   refundInEscrowConditionAddress: Address
   feeCalculatorAddress: Address | null
+  authorizeRecorderAddress: Address
+  paymentIndexRecorderAddress: Address
   operatorConfig: OperatorConfig
 }
 
@@ -242,6 +244,8 @@ export interface MarketplaceOperatorDeployment {
   refundRequestEvidenceAddress: Address
   refundInEscrowConditionAddress: Address
   feeCalculatorAddress: Address | null
+  authorizeRecorderAddress: Address
+  paymentIndexRecorderAddress: Address
   operatorConfig: OperatorConfig
   deployments: DeployResult[]
   summary: {
@@ -272,6 +276,7 @@ function resolveOptions(options: MarketplaceOperatorOptions) {
 
   const factories = getFactoryAddresses(options.chainId)
   const singletons = getConditionSingletons(options.chainId)
+  const recorderSingletons = getRecorderSingletons(options.chainId)
   const authorizedCodehash =
     options.authorizedCodehash ?? config.recorderCombinatorCodehash
   const freezeDurationSeconds = options.freezeDurationSeconds ?? 0n
@@ -281,6 +286,7 @@ function resolveOptions(options: MarketplaceOperatorOptions) {
     config,
     factories,
     singletons,
+    recorderSingletons,
     authorizedCodehash,
     freezeDurationSeconds,
     operatorFeeBps,
@@ -299,6 +305,7 @@ export async function previewMarketplaceOperator(
     config,
     factories,
     singletons,
+    recorderSingletons,
     authorizedCodehash,
     freezeDurationSeconds,
     operatorFeeBps,
@@ -370,12 +377,22 @@ export async function previewMarketplaceOperator(
   const releaseConditionAddress: Address =
     andConditionAddress ?? escrowPeriodAddress
 
+  // Batch 3b: RecorderCombinator for authorize (if PaymentIndexRecorder available)
+  const paymentIndexRecorderAddress = recorderSingletons.paymentIndexRecorder
+  const hasPaymentIndexRecorder = paymentIndexRecorderAddress !== zeroAddress
+  const authorizeRecorderAddress: Address = hasPaymentIndexRecorder
+    ? await computeRecorderCombinatorAddress(publicClient, {
+        factoryAddress: factories.recorderCombinator,
+        recorders: [escrowPeriodAddress, paymentIndexRecorderAddress],
+      })
+    : escrowPeriodAddress
+
   // Batch 4: operator (depends on everything)
   const operatorConfig: OperatorConfig = {
     feeRecipient: options.feeRecipient,
     feeCalculator: feeCalculatorAddress ?? zeroAddress,
     authorizeCondition: config.usdcTvlLimit,
-    authorizeRecorder: escrowPeriodAddress,
+    authorizeRecorder: authorizeRecorderAddress,
     chargeCondition: zeroAddress,
     chargeRecorder: zeroAddress,
     releaseCondition: releaseConditionAddress,
@@ -399,6 +416,8 @@ export async function previewMarketplaceOperator(
     refundRequestEvidenceAddress,
     refundInEscrowConditionAddress,
     feeCalculatorAddress,
+    authorizeRecorderAddress,
+    paymentIndexRecorderAddress,
     operatorConfig,
   }
 }
@@ -443,12 +462,17 @@ export async function deployMarketplaceOperator(
     refundRequestAddress,
     refundRequestEvidenceAddress,
     refundInEscrowConditionAddress,
+    authorizeRecorderAddress,
+    paymentIndexRecorderAddress,
     operatorAddress,
     operatorConfig,
   } = preview
 
   const hasFee = operatorFeeBps > 0n
   const hasFreeze = freezeDurationSeconds > 0n
+  const hasPaymentIndexRecorder = paymentIndexRecorderAddress !== zeroAddress
+  const hasCombinator =
+    hasPaymentIndexRecorder && authorizeRecorderAddress !== escrowPeriodAddress
 
   // SAC(arbiter) is always needed: used for refundInEscrow OrCondition + freeze unfreeze gate.
   const staticAddrCondArbiterAddr = await computeStaticAddressConditionAddress(
@@ -568,6 +592,17 @@ export async function deployMarketplaceOperator(
       },
     })
   }
+  if (hasCombinator) {
+    existenceEntries.push({
+      name: 'recorderCombinator',
+      contract: {
+        address: factories.recorderCombinator,
+        abi: recorderCombinatorFactoryAbi,
+        functionName: 'getDeployed',
+        args: [[escrowPeriodAddress, paymentIndexRecorderAddress]],
+      },
+    })
+  }
 
   const existenceResults = await publicClient.multicall({
     contracts: existenceEntries.map((e) => e.contract) as Parameters<
@@ -594,6 +629,7 @@ export async function deployMarketplaceOperator(
     freeze: existsMap.get('freeze') ?? false,
     andCondition: existsMap.get('andCondition') ?? false,
     feeCalculator: existsMap.get('feeCalculator') ?? !hasFee,
+    recorderCombinator: existsMap.get('recorderCombinator') ?? !hasCombinator,
   }
 
   // If operator already deployed, return immediately
@@ -624,6 +660,13 @@ export async function deployMarketplaceOperator(
         isNew: false,
       })
     }
+    if (hasCombinator) {
+      existingDeployments.push({
+        address: authorizeRecorderAddress,
+        hash: null,
+        isNew: false,
+      })
+    }
     existingDeployments.push({
       address: operatorAddress,
       hash: null,
@@ -637,6 +680,8 @@ export async function deployMarketplaceOperator(
       refundRequestEvidenceAddress,
       refundInEscrowConditionAddress,
       feeCalculatorAddress,
+      authorizeRecorderAddress,
+      paymentIndexRecorderAddress,
       operatorConfig,
       deployments: existingDeployments,
       summary: {
@@ -745,6 +790,16 @@ export async function deployMarketplaceOperator(
       [operatorFeeBps],
     )
   }
+  if (hasCombinator) {
+    trackDeploy(
+      authorizeRecorderAddress,
+      exists.recorderCombinator,
+      factories.recorderCombinator,
+      recorderCombinatorFactoryAbi,
+      'deploy',
+      [[escrowPeriodAddress, paymentIndexRecorderAddress]],
+    )
+  }
 
   // Operator deploy is always included (we checked it doesn't exist above)
   calls.push({
@@ -774,6 +829,8 @@ export async function deployMarketplaceOperator(
     refundRequestEvidenceAddress,
     refundInEscrowConditionAddress,
     feeCalculatorAddress,
+    authorizeRecorderAddress,
+    paymentIndexRecorderAddress,
     operatorConfig,
     deployments,
     summary: { newCount, existingCount, txHashes },

--- a/packages/core/src/deploy/presets.ts
+++ b/packages/core/src/deploy/presets.ts
@@ -231,8 +231,6 @@ export interface MarketplaceOperatorPreview {
   refundRequestEvidenceAddress: Address
   refundInEscrowConditionAddress: Address
   feeCalculatorAddress: Address | null
-  authorizeRecorderAddress: Address
-  paymentIndexRecorderAddress: Address
   operatorConfig: OperatorConfig
 }
 
@@ -244,8 +242,6 @@ export interface MarketplaceOperatorDeployment {
   refundRequestEvidenceAddress: Address
   refundInEscrowConditionAddress: Address
   feeCalculatorAddress: Address | null
-  authorizeRecorderAddress: Address
-  paymentIndexRecorderAddress: Address
   operatorConfig: OperatorConfig
   deployments: DeployResult[]
   summary: {
@@ -416,8 +412,6 @@ export async function previewMarketplaceOperator(
     refundRequestEvidenceAddress,
     refundInEscrowConditionAddress,
     feeCalculatorAddress,
-    authorizeRecorderAddress,
-    paymentIndexRecorderAddress,
     operatorConfig,
   }
 }
@@ -462,15 +456,9 @@ export async function deployMarketplaceOperator(
     refundRequestAddress,
     refundRequestEvidenceAddress,
     refundInEscrowConditionAddress,
-    authorizeRecorderAddress,
-    paymentIndexRecorderAddress,
     operatorAddress,
     operatorConfig,
   } = preview
-
-  const hasPaymentIndexRecorder = paymentIndexRecorderAddress !== zeroAddress
-  const hasCombinator =
-    hasPaymentIndexRecorder && authorizeRecorderAddress !== escrowPeriodAddress
 
   const hasFee = operatorFeeBps > 0n
   const hasFreeze = freezeDurationSeconds > 0n
@@ -593,17 +581,6 @@ export async function deployMarketplaceOperator(
       },
     })
   }
-  if (hasCombinator) {
-    existenceEntries.push({
-      name: 'recorderCombinator',
-      contract: {
-        address: factories.recorderCombinator,
-        abi: recorderCombinatorFactoryAbi,
-        functionName: 'getDeployed',
-        args: [[escrowPeriodAddress, paymentIndexRecorderAddress]],
-      },
-    })
-  }
 
   const existenceResults = await publicClient.multicall({
     contracts: existenceEntries.map((e) => e.contract) as Parameters<
@@ -630,7 +607,6 @@ export async function deployMarketplaceOperator(
     freeze: existsMap.get('freeze') ?? false,
     andCondition: existsMap.get('andCondition') ?? false,
     feeCalculator: existsMap.get('feeCalculator') ?? !hasFee,
-    recorderCombinator: existsMap.get('recorderCombinator') ?? !hasCombinator,
   }
 
   // If operator already deployed, return immediately
@@ -661,13 +637,6 @@ export async function deployMarketplaceOperator(
         isNew: false,
       })
     }
-    if (hasCombinator) {
-      existingDeployments.push({
-        address: authorizeRecorderAddress,
-        hash: null,
-        isNew: false,
-      })
-    }
     existingDeployments.push({
       address: operatorAddress,
       hash: null,
@@ -681,8 +650,6 @@ export async function deployMarketplaceOperator(
       refundRequestEvidenceAddress,
       refundInEscrowConditionAddress,
       feeCalculatorAddress,
-      authorizeRecorderAddress,
-      paymentIndexRecorderAddress,
       operatorConfig,
       deployments: existingDeployments,
       summary: {
@@ -791,16 +758,6 @@ export async function deployMarketplaceOperator(
       [operatorFeeBps],
     )
   }
-  if (hasCombinator) {
-    trackDeploy(
-      authorizeRecorderAddress,
-      exists.recorderCombinator,
-      factories.recorderCombinator,
-      recorderCombinatorFactoryAbi,
-      'deploy',
-      [[escrowPeriodAddress, paymentIndexRecorderAddress]],
-    )
-  }
 
   // Operator deploy is always included (we checked it doesn't exist above)
   calls.push({
@@ -830,8 +787,6 @@ export async function deployMarketplaceOperator(
     refundRequestEvidenceAddress,
     refundInEscrowConditionAddress,
     feeCalculatorAddress,
-    authorizeRecorderAddress,
-    paymentIndexRecorderAddress,
     operatorConfig,
     deployments,
     summary: { newCount, existingCount, txHashes },

--- a/packages/core/src/deploy/presets.ts
+++ b/packages/core/src/deploy/presets.ts
@@ -6,6 +6,7 @@ import {
   freezeFactoryAbi,
   orConditionFactoryAbi,
   paymentOperatorFactoryAbi,
+  recorderCombinatorFactoryAbi,
   refundRequestEvidenceFactoryAbi,
   refundRequestFactoryAbi,
   signatureConditionFactoryAbi,
@@ -16,6 +17,7 @@ import {
   getChainConfig,
   getConditionSingletons,
   getFactoryAddresses,
+  getRecorderSingletons,
 } from '../config/index.js'
 import { ConfigError } from '../errors/index.js'
 import type { OperatorConfig } from '../types/index.js'
@@ -26,6 +28,7 @@ import {
   computeFreezeAddress,
   computeOperatorAddress,
   computeOrConditionAddress,
+  computeRecorderCombinatorAddress,
   computeRefundRequestAddress,
   computeRefundRequestEvidenceAddress,
   computeSignatureConditionAddress,
@@ -1008,13 +1011,20 @@ export interface DeliveryProtectionOperatorOptions {
   arbiter: Address
   feeRecipient: Address
   escrowPeriodSeconds: bigint
+  /** Override default authorizedCodehash (default: recorderCombinatorCodehash from config) */
   authorizedCodehash?: Hex
+  /** Override PaymentIndexRecorder address (default: from config, zeroAddress = skip) */
+  paymentIndexRecorderAddress?: Address
 }
 
 export interface DeliveryProtectionOperatorPreview {
   operatorAddress: Address
   escrowPeriodAddress: Address
   arbiterConditionAddress: Address
+  releaseConditionAddress: Address
+  refundInEscrowConditionAddress: Address
+  authorizeRecorderAddress: Address
+  paymentIndexRecorderAddress: Address
   operatorConfig: OperatorConfig
 }
 
@@ -1022,6 +1032,10 @@ export interface DeliveryProtectionOperatorDeployment {
   operatorAddress: Address
   escrowPeriodAddress: Address
   arbiterConditionAddress: Address
+  releaseConditionAddress: Address
+  refundInEscrowConditionAddress: Address
+  authorizeRecorderAddress: Address
+  paymentIndexRecorderAddress: Address
   operatorConfig: OperatorConfig
   deployments: DeployResult[]
   summary: {
@@ -1040,26 +1054,59 @@ export async function previewDeliveryProtectionOperator(
   options: DeliveryProtectionOperatorOptions,
 ): Promise<DeliveryProtectionOperatorPreview> {
   const config = getChainConfig(options.chainId)
-  const factories = getFactoryAddresses(options.chainId)
+  const factoryAddrs = getFactoryAddresses(options.chainId)
   const singletons = getConditionSingletons(options.chainId)
-  const authorizedCodehash = options.authorizedCodehash ?? pad('0x00')
+  const recorderSingletons = getRecorderSingletons(options.chainId)
 
+  const authorizedCodehash =
+    options.authorizedCodehash ?? config.recorderCombinatorCodehash
+  const paymentIndexRecorderAddress =
+    options.paymentIndexRecorderAddress ??
+    recorderSingletons.paymentIndexRecorder
+  const hasPaymentIndexRecorder = paymentIndexRecorderAddress !== zeroAddress
+
+  // Batch 1 (parallel, no dependencies)
   const [escrowPeriodAddress, arbiterConditionAddress] = await Promise.all([
     computeEscrowPeriodAddress(publicClient, {
-      factoryAddress: factories.escrowPeriod,
+      factoryAddress: factoryAddrs.escrowPeriod,
       escrowPeriod: options.escrowPeriodSeconds,
       authorizedCodehash,
     }),
     computeStaticAddressConditionAddress(publicClient, {
-      factoryAddress: factories.staticAddressCondition,
+      factoryAddress: factoryAddrs.staticAddressCondition,
       designatedAddress: options.arbiter,
     }),
   ])
 
-  // Release: only arbiter can call (StaticAddressCondition)
-  // Authorize recorder: EscrowPeriod (tracks auth time)
-  // Refund in escrow: EscrowPeriod (anyone can refund after window expires)
-  // Refund post escrow: receiver only
+  // Batch 2 (parallel, depends on batch 1)
+  const [
+    releaseConditionAddress,
+    refundInEscrowConditionAddress,
+    authorizeRecorderAddress,
+  ] = await Promise.all([
+    // Release: arbiter OR payer
+    computeOrConditionAddress(publicClient, {
+      factoryAddress: factoryAddrs.orCondition,
+      conditions: [arbiterConditionAddress, singletons.payer],
+    }),
+    // RefundInEscrow: escrow period expired OR receiver OR arbiter
+    computeOrConditionAddress(publicClient, {
+      factoryAddress: factoryAddrs.orCondition,
+      conditions: [
+        escrowPeriodAddress,
+        singletons.receiver,
+        arbiterConditionAddress,
+      ],
+    }),
+    // AuthorizeRecorder: EscrowPeriod + PaymentIndexRecorder (if available)
+    hasPaymentIndexRecorder
+      ? computeRecorderCombinatorAddress(publicClient, {
+          factoryAddress: factoryAddrs.recorderCombinator,
+          recorders: [escrowPeriodAddress, paymentIndexRecorderAddress],
+        })
+      : Promise.resolve(escrowPeriodAddress),
+  ])
+
   // feeCalculator is zeroAddress (no fees charged) but feeRecipient is still
   // required by the factory's non-zero validation. This future-proofs the
   // operator: when a fee calculator is added later, the recipient is already
@@ -1068,19 +1115,19 @@ export async function previewDeliveryProtectionOperator(
     feeRecipient: options.feeRecipient,
     feeCalculator: zeroAddress,
     authorizeCondition: config.usdcTvlLimit,
-    authorizeRecorder: escrowPeriodAddress,
+    authorizeRecorder: authorizeRecorderAddress,
     chargeCondition: zeroAddress,
     chargeRecorder: zeroAddress,
-    releaseCondition: arbiterConditionAddress,
+    releaseCondition: releaseConditionAddress,
     releaseRecorder: zeroAddress,
-    refundInEscrowCondition: escrowPeriodAddress,
+    refundInEscrowCondition: refundInEscrowConditionAddress,
     refundInEscrowRecorder: zeroAddress,
     refundPostEscrowCondition: singletons.receiver,
     refundPostEscrowRecorder: zeroAddress,
   }
 
   const operatorAddress = await computeOperatorAddress(publicClient, {
-    factoryAddress: factories.paymentOperator,
+    factoryAddress: factoryAddrs.paymentOperator,
     config: operatorConfig,
   })
 
@@ -1088,6 +1135,10 @@ export async function previewDeliveryProtectionOperator(
     operatorAddress,
     escrowPeriodAddress,
     arbiterConditionAddress,
+    releaseConditionAddress,
+    refundInEscrowConditionAddress,
+    authorizeRecorderAddress,
+    paymentIndexRecorderAddress,
     operatorConfig,
   }
 }
@@ -1096,10 +1147,12 @@ export async function previewDeliveryProtectionOperator(
 // deployDeliveryProtectionOperator — single-tx via Multicall3
 //
 // Deploys a PaymentOperator where:
-// - Release is gated by StaticAddressCondition(arbiter) — arbiter calls
-//   release() directly when content passes garbage detection
-// - Refund in escrow uses EscrowPeriod — if arbiter does nothing, escrow
-//   window expires and anyone can call refundInEscrow() for auto-refund
+// - Release: OrCondition([SAC(arbiter), PayerCondition]) — arbiter or payer
+// - RefundInEscrow: OrCondition([EscrowPeriod, ReceiverCondition, SAC(arbiter)])
+//   — after escrow window, or receiver, or arbiter
+// - AuthorizeRecorder: RecorderCombinator([EscrowPeriod, PaymentIndexRecorder])
+//   — records auth time + indexes payments (falls back to EscrowPeriod-only
+//   if PaymentIndexRecorder is not deployed)
 // ---------------------------------------------------------------------------
 
 export async function deployDeliveryProtectionOperator(
@@ -1107,34 +1160,77 @@ export async function deployDeliveryProtectionOperator(
   publicClient: PublicClient,
   options: DeliveryProtectionOperatorOptions,
 ): Promise<DeliveryProtectionOperatorDeployment> {
-  const factories = getFactoryAddresses(options.chainId)
-  const authorizedCodehash = options.authorizedCodehash ?? pad('0x00')
+  const factoryAddrs = getFactoryAddresses(options.chainId)
+  const config = getChainConfig(options.chainId)
+  const authorizedCodehash =
+    options.authorizedCodehash ?? config.recorderCombinatorCodehash
 
   // Phase 1: Compute all deterministic addresses
   const preview = await previewDeliveryProtectionOperator(publicClient, options)
   const {
     escrowPeriodAddress,
     arbiterConditionAddress,
+    releaseConditionAddress,
+    refundInEscrowConditionAddress,
+    authorizeRecorderAddress,
+    paymentIndexRecorderAddress,
     operatorAddress,
     operatorConfig,
   } = preview
 
+  const hasPaymentIndexRecorder = paymentIndexRecorderAddress !== zeroAddress
+  const hasCombinator =
+    hasPaymentIndexRecorder && authorizeRecorderAddress !== escrowPeriodAddress
+
   // Phase 2: Batch-check which contracts already exist
   const existenceEntries: MulticallContract[] = [
     {
-      address: factories.escrowPeriod,
+      address: factoryAddrs.escrowPeriod,
       abi: escrowPeriodFactoryAbi,
       functionName: 'getDeployed',
       args: [options.escrowPeriodSeconds, authorizedCodehash],
     },
     {
-      address: factories.staticAddressCondition,
+      address: factoryAddrs.staticAddressCondition,
       abi: staticAddressConditionFactoryAbi,
       functionName: 'getDeployed',
       args: [options.arbiter],
     },
     {
-      address: factories.paymentOperator,
+      address: factoryAddrs.orCondition,
+      abi: orConditionFactoryAbi,
+      functionName: 'getDeployed',
+      args: [
+        [
+          arbiterConditionAddress,
+          getConditionSingletons(options.chainId).payer,
+        ],
+      ],
+    },
+    {
+      address: factoryAddrs.orCondition,
+      abi: orConditionFactoryAbi,
+      functionName: 'getDeployed',
+      args: [
+        [
+          escrowPeriodAddress,
+          getConditionSingletons(options.chainId).receiver,
+          arbiterConditionAddress,
+        ],
+      ],
+    },
+    ...(hasCombinator
+      ? [
+          {
+            address: factoryAddrs.recorderCombinator,
+            abi: recorderCombinatorFactoryAbi,
+            functionName: 'getDeployed',
+            args: [[escrowPeriodAddress, paymentIndexRecorderAddress]],
+          },
+        ]
+      : []),
+    {
+      address: factoryAddrs.paymentOperator,
       abi: paymentOperatorFactoryAbi,
       functionName: 'getOperator',
       args: [operatorConfig],
@@ -1147,29 +1243,52 @@ export async function deployDeliveryProtectionOperator(
     >[0]['contracts'],
   })
 
-  const escrowPeriodExists = existenceResults[0].result !== zeroAddress
-  const arbiterCondExists = existenceResults[1].result !== zeroAddress
-  const operatorExists = existenceResults[2].result !== zeroAddress
+  let idx = 0
+  const escrowPeriodExists = existenceResults[idx++].result !== zeroAddress
+  const arbiterCondExists = existenceResults[idx++].result !== zeroAddress
+  const releaseCondExists = existenceResults[idx++].result !== zeroAddress
+  const refundCondExists = existenceResults[idx++].result !== zeroAddress
+  const combinatorExists = hasCombinator
+    ? existenceResults[idx++].result !== zeroAddress
+    : true // no combinator needed
+  const operatorExists = existenceResults[idx++].result !== zeroAddress
+
+  const totalContracts = hasCombinator ? 6 : 5
 
   // If operator already deployed, return immediately
   if (operatorExists) {
+    const existingDeployments: DeployResult[] = [
+      { address: escrowPeriodAddress, hash: null, isNew: false },
+      { address: arbiterConditionAddress, hash: null, isNew: false },
+      { address: releaseConditionAddress, hash: null, isNew: false },
+      { address: refundInEscrowConditionAddress, hash: null, isNew: false },
+      ...(hasCombinator
+        ? [{ address: authorizeRecorderAddress, hash: null, isNew: false }]
+        : []),
+      { address: operatorAddress, hash: null, isNew: false },
+    ]
     return {
       operatorAddress,
       escrowPeriodAddress,
       arbiterConditionAddress,
+      releaseConditionAddress,
+      refundInEscrowConditionAddress,
+      authorizeRecorderAddress,
+      paymentIndexRecorderAddress,
       operatorConfig,
-      deployments: [
-        { address: escrowPeriodAddress, hash: null, isNew: false },
-        { address: arbiterConditionAddress, hash: null, isNew: false },
-        { address: operatorAddress, hash: null, isNew: false },
-      ],
-      summary: { newCount: 0, existingCount: 3, txHashes: [] },
+      deployments: existingDeployments,
+      summary: {
+        newCount: 0,
+        existingCount: totalContracts,
+        txHashes: [],
+      },
     }
   }
 
   // Phase 3: Build deploy calls for missing contracts
   const calls: Multicall3Call[] = []
   const deployments: DeployResult[] = []
+  const singletons = getConditionSingletons(options.chainId)
 
   function trackDeploy(
     address: Address,
@@ -1191,26 +1310,61 @@ export async function deployDeliveryProtectionOperator(
     }
   }
 
+  // 1. EscrowPeriod
   trackDeploy(
     escrowPeriodAddress,
     escrowPeriodExists,
-    factories.escrowPeriod,
+    factoryAddrs.escrowPeriod,
     escrowPeriodFactoryAbi,
     'deploy',
     [options.escrowPeriodSeconds, authorizedCodehash],
   )
+
+  // 2. StaticAddressCondition(arbiter)
   trackDeploy(
     arbiterConditionAddress,
     arbiterCondExists,
-    factories.staticAddressCondition,
+    factoryAddrs.staticAddressCondition,
     staticAddressConditionFactoryAbi,
     'deploy',
     [options.arbiter],
   )
 
-  // Operator deploy is always included
+  // 3. OrCondition for release: arbiter OR payer
+  trackDeploy(
+    releaseConditionAddress,
+    releaseCondExists,
+    factoryAddrs.orCondition,
+    orConditionFactoryAbi,
+    'deploy',
+    [[arbiterConditionAddress, singletons.payer]],
+  )
+
+  // 4. OrCondition for refundInEscrow: escrow period OR receiver OR arbiter
+  trackDeploy(
+    refundInEscrowConditionAddress,
+    refundCondExists,
+    factoryAddrs.orCondition,
+    orConditionFactoryAbi,
+    'deploy',
+    [[escrowPeriodAddress, singletons.receiver, arbiterConditionAddress]],
+  )
+
+  // 5. RecorderCombinator (if PaymentIndexRecorder available)
+  if (hasCombinator) {
+    trackDeploy(
+      authorizeRecorderAddress,
+      combinatorExists,
+      factoryAddrs.recorderCombinator,
+      recorderCombinatorFactoryAbi,
+      'deploy',
+      [[escrowPeriodAddress, paymentIndexRecorderAddress]],
+    )
+  }
+
+  // 6. Operator (always included, never allowFailure)
   calls.push({
-    target: factories.paymentOperator,
+    target: factoryAddrs.paymentOperator,
     allowFailure: false,
     callData: encodeFunctionData({
       abi: paymentOperatorFactoryAbi,
@@ -1232,6 +1386,10 @@ export async function deployDeliveryProtectionOperator(
     operatorAddress,
     escrowPeriodAddress,
     arbiterConditionAddress,
+    releaseConditionAddress,
+    refundInEscrowConditionAddress,
+    authorizeRecorderAddress,
+    paymentIndexRecorderAddress,
     operatorConfig,
     deployments,
     summary: { newCount, existingCount, txHashes },

--- a/packages/core/src/deploy/presets.ts
+++ b/packages/core/src/deploy/presets.ts
@@ -231,6 +231,8 @@ export interface MarketplaceOperatorPreview {
   refundRequestEvidenceAddress: Address
   refundInEscrowConditionAddress: Address
   feeCalculatorAddress: Address | null
+  authorizeRecorderAddress: Address
+  paymentIndexRecorderAddress: Address
   operatorConfig: OperatorConfig
 }
 
@@ -242,6 +244,8 @@ export interface MarketplaceOperatorDeployment {
   refundRequestEvidenceAddress: Address
   refundInEscrowConditionAddress: Address
   feeCalculatorAddress: Address | null
+  authorizeRecorderAddress: Address
+  paymentIndexRecorderAddress: Address
   operatorConfig: OperatorConfig
   deployments: DeployResult[]
   summary: {
@@ -412,6 +416,8 @@ export async function previewMarketplaceOperator(
     refundRequestEvidenceAddress,
     refundInEscrowConditionAddress,
     feeCalculatorAddress,
+    authorizeRecorderAddress,
+    paymentIndexRecorderAddress,
     operatorConfig,
   }
 }
@@ -456,9 +462,15 @@ export async function deployMarketplaceOperator(
     refundRequestAddress,
     refundRequestEvidenceAddress,
     refundInEscrowConditionAddress,
+    authorizeRecorderAddress,
+    paymentIndexRecorderAddress,
     operatorAddress,
     operatorConfig,
   } = preview
+
+  const hasPaymentIndexRecorder = paymentIndexRecorderAddress !== zeroAddress
+  const hasCombinator =
+    hasPaymentIndexRecorder && authorizeRecorderAddress !== escrowPeriodAddress
 
   const hasFee = operatorFeeBps > 0n
   const hasFreeze = freezeDurationSeconds > 0n
@@ -581,6 +593,17 @@ export async function deployMarketplaceOperator(
       },
     })
   }
+  if (hasCombinator) {
+    existenceEntries.push({
+      name: 'recorderCombinator',
+      contract: {
+        address: factories.recorderCombinator,
+        abi: recorderCombinatorFactoryAbi,
+        functionName: 'getDeployed',
+        args: [[escrowPeriodAddress, paymentIndexRecorderAddress]],
+      },
+    })
+  }
 
   const existenceResults = await publicClient.multicall({
     contracts: existenceEntries.map((e) => e.contract) as Parameters<
@@ -607,6 +630,7 @@ export async function deployMarketplaceOperator(
     freeze: existsMap.get('freeze') ?? false,
     andCondition: existsMap.get('andCondition') ?? false,
     feeCalculator: existsMap.get('feeCalculator') ?? !hasFee,
+    recorderCombinator: existsMap.get('recorderCombinator') ?? !hasCombinator,
   }
 
   // If operator already deployed, return immediately
@@ -637,6 +661,13 @@ export async function deployMarketplaceOperator(
         isNew: false,
       })
     }
+    if (hasCombinator) {
+      existingDeployments.push({
+        address: authorizeRecorderAddress,
+        hash: null,
+        isNew: false,
+      })
+    }
     existingDeployments.push({
       address: operatorAddress,
       hash: null,
@@ -650,6 +681,8 @@ export async function deployMarketplaceOperator(
       refundRequestEvidenceAddress,
       refundInEscrowConditionAddress,
       feeCalculatorAddress,
+      authorizeRecorderAddress,
+      paymentIndexRecorderAddress,
       operatorConfig,
       deployments: existingDeployments,
       summary: {
@@ -758,6 +791,16 @@ export async function deployMarketplaceOperator(
       [operatorFeeBps],
     )
   }
+  if (hasCombinator) {
+    trackDeploy(
+      authorizeRecorderAddress,
+      exists.recorderCombinator,
+      factories.recorderCombinator,
+      recorderCombinatorFactoryAbi,
+      'deploy',
+      [[escrowPeriodAddress, paymentIndexRecorderAddress]],
+    )
+  }
 
   // Operator deploy is always included (we checked it doesn't exist above)
   calls.push({
@@ -787,6 +830,8 @@ export async function deployMarketplaceOperator(
     refundRequestEvidenceAddress,
     refundInEscrowConditionAddress,
     feeCalculatorAddress,
+    authorizeRecorderAddress,
+    paymentIndexRecorderAddress,
     operatorConfig,
     deployments,
     summary: { newCount, existingCount, txHashes },

--- a/packages/core/src/deploy/presets.ts
+++ b/packages/core/src/deploy/presets.ts
@@ -272,7 +272,6 @@ function resolveOptions(options: MarketplaceOperatorOptions) {
 
   const factories = getFactoryAddresses(options.chainId)
   const singletons = getConditionSingletons(options.chainId)
-  const recorderSingletons = getRecorderSingletons(options.chainId)
   const authorizedCodehash =
     options.authorizedCodehash ?? config.recorderCombinatorCodehash
   const freezeDurationSeconds = options.freezeDurationSeconds ?? 0n
@@ -282,7 +281,6 @@ function resolveOptions(options: MarketplaceOperatorOptions) {
     config,
     factories,
     singletons,
-    recorderSingletons,
     authorizedCodehash,
     freezeDurationSeconds,
     operatorFeeBps,
@@ -301,7 +299,6 @@ export async function previewMarketplaceOperator(
     config,
     factories,
     singletons,
-    recorderSingletons,
     authorizedCodehash,
     freezeDurationSeconds,
     operatorFeeBps,
@@ -373,22 +370,12 @@ export async function previewMarketplaceOperator(
   const releaseConditionAddress: Address =
     andConditionAddress ?? escrowPeriodAddress
 
-  // Batch 3b: RecorderCombinator for authorize (if PaymentIndexRecorder available)
-  const paymentIndexRecorderAddress = recorderSingletons.paymentIndexRecorder
-  const hasPaymentIndexRecorder = paymentIndexRecorderAddress !== zeroAddress
-  const authorizeRecorderAddress: Address = hasPaymentIndexRecorder
-    ? await computeRecorderCombinatorAddress(publicClient, {
-        factoryAddress: factories.recorderCombinator,
-        recorders: [escrowPeriodAddress, paymentIndexRecorderAddress],
-      })
-    : escrowPeriodAddress
-
   // Batch 4: operator (depends on everything)
   const operatorConfig: OperatorConfig = {
     feeRecipient: options.feeRecipient,
     feeCalculator: feeCalculatorAddress ?? zeroAddress,
     authorizeCondition: config.usdcTvlLimit,
-    authorizeRecorder: authorizeRecorderAddress,
+    authorizeRecorder: escrowPeriodAddress,
     chargeCondition: zeroAddress,
     chargeRecorder: zeroAddress,
     releaseCondition: releaseConditionAddress,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -209,6 +209,7 @@ export {
 export type {
   ConditionSingletonAddresses,
   FactoryAddresses,
+  RecorderSingletonAddresses,
   SupportedChainId,
   X402rChainConfig,
 } from './config/index.js'
@@ -222,11 +223,14 @@ export {
   getConditionSingletons,
   getFactoryAddress,
   getFactoryAddresses,
+  getRecorderSingletons,
   hasConditionSingletons,
   hasFactories,
   isSupportedChain,
   protocolFeeConfig,
   receiverRefundCollector,
+  recorderCombinatorCodehash,
+  recorders,
   supportedChainIds,
   tokenCollector,
   toNetworkId,

--- a/packages/core/tests/deploy/presets.test.ts
+++ b/packages/core/tests/deploy/presets.test.ts
@@ -726,6 +726,10 @@ function makeDeliveryProtectionOptions(
     arbiter: '0x15d34AAf54267DB7D7c367839AAf71A00a2C6A65',
     feeRecipient: '0x5678901234567890123456789012345678901234',
     escrowPeriodSeconds: 86400n,
+    // Exercise the no-combinator path explicitly. The config default for 84532
+    // is now a real PaymentIndexRecorder; passing zeroAddress skips it so these
+    // tests cover the RecorderCombinator-free branch.
+    paymentIndexRecorderAddress: zeroAddress,
     ...overrides,
   }
 }
@@ -745,11 +749,13 @@ describe('previewDeliveryProtectionOperator', () => {
     const escrowAddr = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa' as Address
     const arbiterCondAddr =
       '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' as Address
-    const orCondAddr = '0xdDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd' as Address
+    const orCondAddr = '0xdd22dd22dd22dd22dd22dd22dd22dd22dd22dd22' as Address
+    const notCondAddr = '0xee11ee11ee11ee11ee11ee11ee11ee11ee11ee11' as Address
     const operatorAddr = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC' as Address
     const publicClient = createMockPublicClient({
       [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
       [`${F.staticAddressCondition}:computeAddress`]: arbiterCondAddr,
+      [`${F.notCondition}:computeAddress`]: notCondAddr,
       [`${F.orCondition}:computeAddress`]: orCondAddr,
       [`${F.paymentOperator}:computeAddress`]: operatorAddr,
     })
@@ -761,10 +767,15 @@ describe('previewDeliveryProtectionOperator', () => {
 
     expect(result.escrowPeriodAddress).toBe(escrowAddr)
     expect(result.arbiterConditionAddress).toBe(arbiterCondAddr)
+    expect(result.chargeBlockConditionAddress).toBe(notCondAddr)
     expect(result.releaseConditionAddress).toBe(orCondAddr)
     expect(result.refundInEscrowConditionAddress).toBe(orCondAddr)
     // Without PaymentIndexRecorder, authorizeRecorder falls back to escrowPeriod
     expect(result.authorizeRecorderAddress).toBe(escrowAddr)
+    // charge is blocked via NotCondition(AlwaysTrue), never left as zeroAddress
+    // (zeroAddress would mean "always allow" and defeat the escrow hold)
+    expect(result.operatorConfig.chargeCondition).toBe(notCondAddr)
+    expect(result.operatorConfig.chargeCondition).not.toBe(zeroAddress)
     expect(result.operatorConfig.releaseCondition).toBe(orCondAddr)
     expect(result.operatorConfig.refundInEscrowCondition).toBe(orCondAddr)
     expect(result.operatorConfig.feeCalculator).toBe(zeroAddress)
@@ -792,19 +803,23 @@ describe('previewDeliveryProtectionOperator', () => {
 })
 
 describe('deployDeliveryProtectionOperator', () => {
-  // Without PaymentIndexRecorder (zeroAddress in config), deploys 5 contracts:
-  // escrowPeriod, arbiterCondition, orCondition(release), orCondition(refund), operator
-  it('deploys 5 contracts without PaymentIndexRecorder', async () => {
+  // Without PaymentIndexRecorder (zeroAddress in config), deploys 6 contracts:
+  // escrowPeriod, arbiterCondition, notCondition(charge-block), orCondition(release),
+  // orCondition(refund), operator
+  it('deploys 6 contracts without PaymentIndexRecorder', async () => {
     const escrowAddr = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa' as Address
     const arbiterCondAddr =
       '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' as Address
-    const orCondAddr = '0xdDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd' as Address
+    const orCondAddr = '0xdd22dd22dd22dd22dd22dd22dd22dd22dd22dd22' as Address
+    const notCondAddr = '0xee11ee11ee11ee11ee11ee11ee11ee11ee11ee11' as Address
     const operatorAddr = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC' as Address
     const publicClient = createMockPublicClient({
       [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
       [`${F.escrowPeriod}:getDeployed`]: zeroAddress,
       [`${F.staticAddressCondition}:computeAddress`]: arbiterCondAddr,
       [`${F.staticAddressCondition}:getDeployed`]: zeroAddress,
+      [`${F.notCondition}:computeAddress`]: notCondAddr,
+      [`${F.notCondition}:getDeployed`]: zeroAddress,
       [`${F.orCondition}:computeAddress`]: orCondAddr,
       [`${F.orCondition}:getDeployed`]: zeroAddress,
       [`${F.paymentOperator}:computeAddress`]: operatorAddr,
@@ -818,15 +833,17 @@ describe('deployDeliveryProtectionOperator', () => {
       makeDeliveryProtectionOptions(),
     )
 
-    expect(result.deployments).toHaveLength(5)
+    expect(result.deployments).toHaveLength(6)
     expect(result.escrowPeriodAddress).toBe(escrowAddr)
     expect(result.arbiterConditionAddress).toBe(arbiterCondAddr)
+    expect(result.chargeBlockConditionAddress).toBe(notCondAddr)
     expect(result.releaseConditionAddress).toBe(orCondAddr)
     expect(result.refundInEscrowConditionAddress).toBe(orCondAddr)
     expect(result.operatorAddress).toBe(operatorAddr)
-    expect(result.summary.newCount).toBe(5)
+    expect(result.summary.newCount).toBe(6)
     expect(result.summary.existingCount).toBe(0)
     expect(result.summary.txHashes).toHaveLength(1)
+    expect(result.operatorConfig.chargeCondition).toBe(notCondAddr)
     expect(result.operatorConfig.releaseCondition).toBe(orCondAddr)
     expect(result.operatorConfig.refundInEscrowCondition).toBe(orCondAddr)
     expect(result.operatorConfig.feeCalculator).toBe(zeroAddress)
@@ -836,13 +853,16 @@ describe('deployDeliveryProtectionOperator', () => {
     const escrowAddr = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa' as Address
     const arbiterCondAddr =
       '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' as Address
-    const orCondAddr = '0xdDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd' as Address
+    const orCondAddr = '0xdd22dd22dd22dd22dd22dd22dd22dd22dd22dd22' as Address
     const operatorAddr = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC' as Address
+    const notCondAddr = '0xee11ee11ee11ee11ee11ee11ee11ee11ee11ee11' as Address
     const publicClient = createMockPublicClient({
       [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
       [`${F.escrowPeriod}:getDeployed`]: escrowAddr,
       [`${F.staticAddressCondition}:computeAddress`]: arbiterCondAddr,
       [`${F.staticAddressCondition}:getDeployed`]: arbiterCondAddr,
+      [`${F.notCondition}:computeAddress`]: notCondAddr,
+      [`${F.notCondition}:getDeployed`]: notCondAddr,
       [`${F.orCondition}:computeAddress`]: orCondAddr,
       [`${F.orCondition}:getDeployed`]: orCondAddr,
       [`${F.paymentOperator}:computeAddress`]: operatorAddr,
@@ -856,9 +876,9 @@ describe('deployDeliveryProtectionOperator', () => {
       makeDeliveryProtectionOptions(),
     )
 
-    expect(result.deployments).toHaveLength(5)
+    expect(result.deployments).toHaveLength(6)
     expect(result.summary.newCount).toBe(0)
-    expect(result.summary.existingCount).toBe(5)
+    expect(result.summary.existingCount).toBe(6)
     expect(result.summary.txHashes).toHaveLength(0)
     for (const d of result.deployments) {
       expect(d.isNew).toBe(false)
@@ -870,14 +890,17 @@ describe('deployDeliveryProtectionOperator', () => {
     const escrowAddr = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa' as Address
     const arbiterCondAddr =
       '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' as Address
-    const orCondAddr = '0xdDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd' as Address
+    const orCondAddr = '0xdd22dd22dd22dd22dd22dd22dd22dd22dd22dd22' as Address
     const operatorAddr = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC' as Address
+    const notCondAddr = '0xee11ee11ee11ee11ee11ee11ee11ee11ee11ee11' as Address
     // escrowPeriod exists, everything else is new
     const publicClient = createMockPublicClient({
       [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
       [`${F.escrowPeriod}:getDeployed`]: escrowAddr,
       [`${F.staticAddressCondition}:computeAddress`]: arbiterCondAddr,
       [`${F.staticAddressCondition}:getDeployed`]: zeroAddress,
+      [`${F.notCondition}:computeAddress`]: notCondAddr,
+      [`${F.notCondition}:getDeployed`]: zeroAddress,
       [`${F.orCondition}:computeAddress`]: orCondAddr,
       [`${F.orCondition}:getDeployed`]: zeroAddress,
       [`${F.paymentOperator}:computeAddress`]: operatorAddr,
@@ -891,12 +914,12 @@ describe('deployDeliveryProtectionOperator', () => {
       makeDeliveryProtectionOptions(),
     )
 
-    expect(result.deployments).toHaveLength(5)
-    expect(result.summary.newCount).toBe(4)
+    expect(result.deployments).toHaveLength(6)
+    expect(result.summary.newCount).toBe(5)
     expect(result.summary.existingCount).toBe(1)
-    expect(result.deployments[0].isNew).toBe(false) // escrowPeriod
+    expect(result.deployments[0].isNew).toBe(false) // escrowPeriod (exists)
     expect(result.deployments[1].isNew).toBe(true) // arbiterCondition
-    expect(result.deployments[2].isNew).toBe(true) // operator
+    expect(result.deployments[2].isNew).toBe(true) // notCondition (charge-block)
   })
 
   it('throws ConfigError when walletClient has no account', async () => {

--- a/packages/core/tests/deploy/presets.test.ts
+++ b/packages/core/tests/deploy/presets.test.ts
@@ -741,14 +741,16 @@ describe('previewDeliveryProtectionOperator', () => {
     ).rejects.toThrow(ConfigError)
   })
 
-  it('computes escrowPeriod, arbiterCondition, and operator addresses', async () => {
+  it('computes all addresses including OrConditions', async () => {
     const escrowAddr = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa' as Address
     const arbiterCondAddr =
       '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' as Address
+    const orCondAddr = '0xdDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd' as Address
     const operatorAddr = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC' as Address
     const publicClient = createMockPublicClient({
       [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
       [`${F.staticAddressCondition}:computeAddress`]: arbiterCondAddr,
+      [`${F.orCondition}:computeAddress`]: orCondAddr,
       [`${F.paymentOperator}:computeAddress`]: operatorAddr,
     })
 
@@ -759,9 +761,12 @@ describe('previewDeliveryProtectionOperator', () => {
 
     expect(result.escrowPeriodAddress).toBe(escrowAddr)
     expect(result.arbiterConditionAddress).toBe(arbiterCondAddr)
-    expect(result.operatorAddress).toBe(operatorAddr)
-    expect(result.operatorConfig.releaseCondition).toBe(arbiterCondAddr)
-    expect(result.operatorConfig.refundInEscrowCondition).toBe(escrowAddr)
+    expect(result.releaseConditionAddress).toBe(orCondAddr)
+    expect(result.refundInEscrowConditionAddress).toBe(orCondAddr)
+    // Without PaymentIndexRecorder, authorizeRecorder falls back to escrowPeriod
+    expect(result.authorizeRecorderAddress).toBe(escrowAddr)
+    expect(result.operatorConfig.releaseCondition).toBe(orCondAddr)
+    expect(result.operatorConfig.refundInEscrowCondition).toBe(orCondAddr)
     expect(result.operatorConfig.feeCalculator).toBe(zeroAddress)
     expect(result.operatorConfig.authorizeCondition).toBe(
       x402rChains[84532].usdcTvlLimit,
@@ -784,50 +789,24 @@ describe('previewDeliveryProtectionOperator', () => {
 
     expect(result.operatorConfig.feeRecipient).toBe(feeRecipient)
   })
-
-  it('uses provided authorizedCodehash in escrowPeriod computation', async () => {
-    const customCodehash =
-      '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef' as `0x${string}`
-    const defaultAddr = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa' as Address
-    const customAddr = '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' as Address
-    const operatorAddr = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC' as Address
-
-    const defaultPublicClient = createMockPublicClient({
-      computeAddress: defaultAddr,
-      [`${F.paymentOperator}:computeAddress`]: operatorAddr,
-    })
-    const customPublicClient = createMockPublicClient({
-      [`${F.escrowPeriod}:computeAddress`]: customAddr,
-      computeAddress: defaultAddr,
-      [`${F.paymentOperator}:computeAddress`]: operatorAddr,
-    })
-
-    const defaultResult = await previewDeliveryProtectionOperator(
-      defaultPublicClient,
-      makeDeliveryProtectionOptions(),
-    )
-    const customResult = await previewDeliveryProtectionOperator(
-      customPublicClient,
-      makeDeliveryProtectionOptions({ authorizedCodehash: customCodehash }),
-    )
-
-    // Different authorizedCodehash should produce different escrowPeriod
-    expect(customResult.escrowPeriodAddress).toBe(customAddr)
-    expect(defaultResult.escrowPeriodAddress).toBe(defaultAddr)
-  })
 })
 
 describe('deployDeliveryProtectionOperator', () => {
-  it('deploys exactly 3 contracts (escrowPeriod + arbiterCondition + operator)', async () => {
+  // Without PaymentIndexRecorder (zeroAddress in config), deploys 5 contracts:
+  // escrowPeriod, arbiterCondition, orCondition(release), orCondition(refund), operator
+  it('deploys 5 contracts without PaymentIndexRecorder', async () => {
     const escrowAddr = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa' as Address
     const arbiterCondAddr =
       '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' as Address
+    const orCondAddr = '0xdDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd' as Address
     const operatorAddr = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC' as Address
     const publicClient = createMockPublicClient({
       [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
       [`${F.escrowPeriod}:getDeployed`]: zeroAddress,
       [`${F.staticAddressCondition}:computeAddress`]: arbiterCondAddr,
       [`${F.staticAddressCondition}:getDeployed`]: zeroAddress,
+      [`${F.orCondition}:computeAddress`]: orCondAddr,
+      [`${F.orCondition}:getDeployed`]: zeroAddress,
       [`${F.paymentOperator}:computeAddress`]: operatorAddr,
       [`${F.paymentOperator}:getOperator`]: zeroAddress,
     })
@@ -839,35 +818,33 @@ describe('deployDeliveryProtectionOperator', () => {
       makeDeliveryProtectionOptions(),
     )
 
-    expect(result.deployments).toHaveLength(3)
+    expect(result.deployments).toHaveLength(5)
     expect(result.escrowPeriodAddress).toBe(escrowAddr)
     expect(result.arbiterConditionAddress).toBe(arbiterCondAddr)
+    expect(result.releaseConditionAddress).toBe(orCondAddr)
+    expect(result.refundInEscrowConditionAddress).toBe(orCondAddr)
     expect(result.operatorAddress).toBe(operatorAddr)
-    expect(result.summary.newCount).toBe(3)
+    expect(result.summary.newCount).toBe(5)
     expect(result.summary.existingCount).toBe(0)
     expect(result.summary.txHashes).toHaveLength(1)
-    // Verify operatorConfig is passed through correctly
-    expect(result.operatorConfig.releaseCondition).toBe(arbiterCondAddr)
-    expect(result.operatorConfig.refundInEscrowCondition).toBe(escrowAddr)
+    expect(result.operatorConfig.releaseCondition).toBe(orCondAddr)
+    expect(result.operatorConfig.refundInEscrowCondition).toBe(orCondAddr)
     expect(result.operatorConfig.feeCalculator).toBe(zeroAddress)
-    expect(result.operatorConfig.authorizeCondition).toBe(
-      x402rChains[84532].usdcTvlLimit,
-    )
-    expect(result.operatorConfig.refundPostEscrowCondition).toBe(
-      x402rChains[84532].conditions!.receiver,
-    )
   })
 
   it('returns all existing when operator already deployed', async () => {
     const escrowAddr = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa' as Address
     const arbiterCondAddr =
       '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' as Address
+    const orCondAddr = '0xdDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd' as Address
     const operatorAddr = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC' as Address
     const publicClient = createMockPublicClient({
       [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
       [`${F.escrowPeriod}:getDeployed`]: escrowAddr,
       [`${F.staticAddressCondition}:computeAddress`]: arbiterCondAddr,
       [`${F.staticAddressCondition}:getDeployed`]: arbiterCondAddr,
+      [`${F.orCondition}:computeAddress`]: orCondAddr,
+      [`${F.orCondition}:getDeployed`]: orCondAddr,
       [`${F.paymentOperator}:computeAddress`]: operatorAddr,
       [`${F.paymentOperator}:getOperator`]: operatorAddr,
     })
@@ -879,9 +856,9 @@ describe('deployDeliveryProtectionOperator', () => {
       makeDeliveryProtectionOptions(),
     )
 
-    expect(result.deployments).toHaveLength(3)
+    expect(result.deployments).toHaveLength(5)
     expect(result.summary.newCount).toBe(0)
-    expect(result.summary.existingCount).toBe(3)
+    expect(result.summary.existingCount).toBe(5)
     expect(result.summary.txHashes).toHaveLength(0)
     for (const d of result.deployments) {
       expect(d.isNew).toBe(false)
@@ -893,13 +870,16 @@ describe('deployDeliveryProtectionOperator', () => {
     const escrowAddr = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa' as Address
     const arbiterCondAddr =
       '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' as Address
+    const orCondAddr = '0xdDdDddDdDdddDDddDDddDDDDdDdDDdDDdDDDDDDd' as Address
     const operatorAddr = '0xCcCCccccCCCCcCCCCCCcCcCccCcCCCcCcccccccC' as Address
-    // escrowPeriod exists, arbiterCondition is new, operator always new
+    // escrowPeriod exists, everything else is new
     const publicClient = createMockPublicClient({
       [`${F.escrowPeriod}:computeAddress`]: escrowAddr,
       [`${F.escrowPeriod}:getDeployed`]: escrowAddr,
       [`${F.staticAddressCondition}:computeAddress`]: arbiterCondAddr,
       [`${F.staticAddressCondition}:getDeployed`]: zeroAddress,
+      [`${F.orCondition}:computeAddress`]: orCondAddr,
+      [`${F.orCondition}:getDeployed`]: zeroAddress,
       [`${F.paymentOperator}:computeAddress`]: operatorAddr,
       [`${F.paymentOperator}:getOperator`]: zeroAddress,
     })
@@ -911,8 +891,8 @@ describe('deployDeliveryProtectionOperator', () => {
       makeDeliveryProtectionOptions(),
     )
 
-    expect(result.deployments).toHaveLength(3)
-    expect(result.summary.newCount).toBe(2)
+    expect(result.deployments).toHaveLength(5)
+    expect(result.summary.newCount).toBe(4)
     expect(result.summary.existingCount).toBe(1)
     expect(result.deployments[0].isNew).toBe(false) // escrowPeriod
     expect(result.deployments[1].isNew).toBe(true) // arbiterCondition

--- a/packages/core/tests/integration/delivery-protection.fork.test.ts
+++ b/packages/core/tests/integration/delivery-protection.fork.test.ts
@@ -114,21 +114,21 @@ describe('Delivery Protection: operator config verification', () => {
       operatorAddress: deployment.operatorAddress,
     })
 
-    // releaseCondition must be the arbiter StaticAddressCondition (not zero)
+    // releaseCondition: OrCondition([SAC(arbiter), PayerCondition])
     expect(config.releaseCondition.toLowerCase()).toBe(
-      deployment.arbiterConditionAddress.toLowerCase(),
+      deployment.releaseConditionAddress.toLowerCase(),
     )
     expect(config.releaseCondition).not.toBe(zeroAddress)
 
-    // refundInEscrowCondition must be the EscrowPeriod (not zero)
+    // refundInEscrowCondition: OrCondition([EscrowPeriod, ReceiverCondition, SAC(arbiter)])
     expect(config.refundInEscrowCondition.toLowerCase()).toBe(
-      deployment.escrowPeriodAddress.toLowerCase(),
+      deployment.refundInEscrowConditionAddress.toLowerCase(),
     )
     expect(config.refundInEscrowCondition).not.toBe(zeroAddress)
 
-    // authorizeRecorder must be the EscrowPeriod (records auth time)
+    // authorizeRecorder: EscrowPeriod (or RecorderCombinator when PaymentIndexRecorder available)
     expect(config.authorizeRecorder.toLowerCase()).toBe(
-      deployment.escrowPeriodAddress.toLowerCase(),
+      deployment.authorizeRecorderAddress.toLowerCase(),
     )
 
     // feeCalculator should be zero (no fees)
@@ -161,8 +161,8 @@ describe('Delivery Protection: arbiter-gated release', () => {
   }, 60_000)
 
   it('arbiter releases funds (no escrow wait required)', async () => {
-    // Arbiter can release immediately — releaseCondition is StaticAddressCondition(arbiter),
-    // not EscrowPeriod, so no time delay is needed.
+    // Arbiter can release immediately — releaseCondition is
+    // OrCondition([SAC(arbiter), PayerCondition]), no time delay needed.
     const hash = await arbiterClient.payment.release(
       paymentInfo,
       DEFAULT_AMOUNT,

--- a/packages/core/tests/integration/delivery-protection.fork.test.ts
+++ b/packages/core/tests/integration/delivery-protection.fork.test.ts
@@ -114,6 +114,13 @@ describe('Delivery Protection: operator config verification', () => {
       operatorAddress: deployment.operatorAddress,
     })
 
+    // chargeCondition: NotCondition(AlwaysTrue) — blocks the immediate-charge
+    // bypass. Must be a real condition, never zeroAddress ("always allow").
+    expect(config.chargeCondition.toLowerCase()).toBe(
+      deployment.chargeBlockConditionAddress.toLowerCase(),
+    )
+    expect(config.chargeCondition).not.toBe(zeroAddress)
+
     // releaseCondition: OrCondition([SAC(arbiter), PayerCondition])
     expect(config.releaseCondition.toLowerCase()).toBe(
       deployment.releaseConditionAddress.toLowerCase(),


### PR DESCRIPTION
## Summary

Two operator-preset changes in `@x402r/core`:

1. **Marketplace** — add `RecorderCombinator([EscrowPeriod, PaymentIndexRecorder])` to the marketplace operator preset, matching the delivery-protection preset.
2. **Delivery protection** — block the immediate-charge bypass. The preset previously left `chargeCondition` as `zeroAddress`, which `PaymentOperator` treats as *"always allow"*. Combined with the fact that `PaymentOperator.charge()` has no caller restriction (only conditions gate it), anyone could call `charge()` on a delivery-protected payment, settle funds immediately to the merchant, and skip the escrow hold — defeating the protection. `chargeCondition` is now wired to `NotCondition(AlwaysTrue)` (always false), forcing payments through `authorize` → `release`/`refund`.

Stacks on #105 (delivery protection v2).

## Changes

### Marketplace PaymentIndexRecorder
- **Preview**: computes RecorderCombinator address when PaymentIndexRecorder available
- **Deploy**: existence check + trackDeploy for RecorderCombinator
- **Interfaces**: `authorizeRecorderAddress` + `paymentIndexRecorderAddress` added to Preview and Deployment types
- Graceful fallback to EscrowPeriod-only when PaymentIndexRecorder not deployed

### Delivery-protection charge gating (commit 140817a)
- **Preview**: computes `chargeBlockConditionAddress` = `NotCondition(AlwaysTrue)` and wires it into `operatorConfig.chargeCondition`
- **Deploy**: existence check + trackDeploy for the `NotCondition`
- **Interfaces**: `chargeBlockConditionAddress` added to Preview and Deployment types
- Unit tests: restored to the no-combinator path explicitly (the 84532 `PaymentIndexRecorder` default is now a real address, which had silently broken the delivery-protection tests by routing through a RecorderCombinator the mocks didn't provide)

⚠️ This **changes the deterministic delivery-protection operator address** (one extra contract deployed, and `chargeCondition` is no longer `zeroAddress`). Any previously-deployed delivery-protection operators have the old, vulnerable config and need redeployment at the new address.

The **marketplace** preset still has `chargeCondition: zeroAddress` — left as a deliberate product decision pending whether marketplaces are meant to support immediate-charge settlement. If marketplaces should also enforce escrow protection, the same fix applies.

## Test plan

- [x] Build passes (ESM build of changed code)
- [x] Typecheck — changed files clean; remaining errors are unrelated WIP
- [x] Unit tests — all `previewDeliveryProtectionOperator` + `deployDeliveryProtectionOperator` tests green (4 previously red went green with this commit)
- [ ] Marketplace unit tests (mock updates needed — pre-existing)
- [ ] Fork integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
