### PR TITLE
feat: default allowArbiterRefund to false (opt-in)

### DIFF
--- a/packages/core/src/deploy/presets.ts
+++ b/packages/core/src/deploy/presets.ts
@@ -1016,7 +1016,7 @@ export interface DeliveryProtectionOperatorOptions {
   authorizedCodehash?: Hex
   /** Override PaymentIndexRecorder address (default: from config, zeroAddress = skip) */
   paymentIndexRecorderAddress?: Address
-  /** Allow arbiter to refund immediately during escrow (default: true). When false, refund requires escrow expiry or receiver action. */
+  /** Allow arbiter to refund immediately during escrow (default: false). When true, arbiter is added to the refundInEscrow OrCondition. */
   allowArbiterRefund?: boolean
 }
 
@@ -1067,7 +1067,7 @@ export async function previewDeliveryProtectionOperator(
     options.paymentIndexRecorderAddress ??
     recorderSingletons.paymentIndexRecorder
   const hasPaymentIndexRecorder = paymentIndexRecorderAddress !== zeroAddress
-  const allowArbiterRefund = options.allowArbiterRefund ?? true
+  const allowArbiterRefund = options.allowArbiterRefund ?? false
 
   // Batch 1 (parallel, no dependencies)
   const [escrowPeriodAddress, arbiterConditionAddress] = await Promise.all([
@@ -1168,7 +1168,7 @@ export async function deployDeliveryProtectionOperator(
   const singletons = getConditionSingletons(options.chainId)
   const authorizedCodehash =
     options.authorizedCodehash ?? recorderCombinatorCodehash
-  const allowArbiterRefund = options.allowArbiterRefund ?? true
+  const allowArbiterRefund = options.allowArbiterRefund ?? false
 
   // Phase 1: Compute all deterministic addresses
   const preview = await previewDeliveryProtectionOperator(publicClient, options)

--- a/packages/core/tests/deploy/presets.test.ts
+++ b/packages/core/tests/deploy/presets.test.ts
@@ -836,7 +836,7 @@ describe('previewDeliveryProtectionOperator', () => {
     expect(result.escrowPeriodAddress).toBe(COMPUTED_ADDR)
   })
 
-  it('excludes arbiter from refundInEscrow OrCondition when allowArbiterRefund is false', async () => {
+  it('includes arbiter in refundInEscrow OrCondition when allowArbiterRefund is true', async () => {
     const escrowAddr = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa' as Address
     const arbiterCondAddr =
       '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' as Address
@@ -854,12 +854,12 @@ describe('previewDeliveryProtectionOperator', () => {
 
     const result = await previewDeliveryProtectionOperator(
       publicClient,
-      makeDeliveryProtectionOptions({ allowArbiterRefund: false }),
+      makeDeliveryProtectionOptions({ allowArbiterRefund: true }),
     )
 
-    // Release still includes arbiter (arbiter OR payer)
+    // Release includes arbiter (arbiter OR payer)
     expect(result.releaseConditionAddress).toBe(orCondAddr)
-    // RefundInEscrow is still an OrCondition (escrow period OR receiver — no arbiter)
+    // RefundInEscrow includes arbiter (escrow period OR receiver OR arbiter)
     expect(result.refundInEscrowConditionAddress).toBe(orCondAddr)
     expect(result.operatorAddress).toBe(operatorAddr)
   })
@@ -1020,7 +1020,7 @@ describe('deployDeliveryProtectionOperator', () => {
     expect(result.summary.existingCount).toBe(0)
   })
 
-  it('deploys 6 contracts with allowArbiterRefund false', async () => {
+  it('deploys 6 contracts with allowArbiterRefund true', async () => {
     const escrowAddr = '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa' as Address
     const arbiterCondAddr =
       '0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB' as Address
@@ -1045,14 +1045,14 @@ describe('deployDeliveryProtectionOperator', () => {
     const result = await deployDeliveryProtectionOperator(
       walletClient,
       publicClient,
-      makeDeliveryProtectionOptions({ allowArbiterRefund: false }),
+      makeDeliveryProtectionOptions({ allowArbiterRefund: true }),
     )
 
     expect(result.deployments).toHaveLength(6)
     expect(result.summary.newCount).toBe(6)
-    // Release still includes arbiter (arbiter OR payer)
+    // Release includes arbiter (arbiter OR payer)
     expect(result.operatorConfig.releaseCondition).toBe(orCondAddr)
-    // RefundInEscrow OrCondition still deployed (escrow period OR receiver — no arbiter)
+    // RefundInEscrow includes arbiter (escrow period OR receiver OR arbiter)
     expect(result.operatorConfig.refundInEscrowCondition).toBe(orCondAddr)
   })
 

--- a/packages/core/tests/integration/delivery-protection.fork.test.ts
+++ b/packages/core/tests/integration/delivery-protection.fork.test.ts
@@ -61,6 +61,7 @@ beforeAll(async () => {
       arbiter: testRoles.arbiter.address,
       feeRecipient: testRoles.operatorFeeRecipient.address,
       escrowPeriodSeconds: ESCROW_PERIOD_SECONDS,
+      allowArbiterRefund: true,
     },
   )
 


### PR DESCRIPTION
## Summary

- Flips `allowArbiterRefund` default from `true` to `false` — arbiter immediate refund is now opt-in
- Deployers must explicitly pass `allowArbiterRefund: true` to grant arbiter refund power during escrow
- Makes the trust surface explicit rather than implicit

Follows up on #105 review feedback (configurability gap).

## Test plan

- [x] 341 unit tests passing
- [x] Typecheck passes
- [x] Biome check passes
- [x] Fork test updated to explicitly opt in (`allowArbiterRefund: true`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)