### PR TITLE
feat(sdk): add ERC-8004 plugin for identity, reputation, and discovery

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@x402r/core": "workspace:*",
+    "@x402r/erc8004": "^0.1.0-alpha.1",
     "viem": "^2.46.3"
   },
   "size-limit": [

--- a/packages/sdk/src/actions/erc8004.ts
+++ b/packages/sdk/src/actions/erc8004.ts
@@ -86,13 +86,13 @@ export function createErc8004ReputationActions(
     async getSummary(
       agentId: bigint,
       reviewers: readonly Address[],
-      opts?: { tag1?: string; tag2?: string },
+      options?: { tag1?: string; tag2?: string },
     ) {
       return coreGetSummary(config.publicClient, {
         agentId,
         clientAddresses: reviewers,
-        tag1: opts?.tag1 ?? tag1,
-        tag2: opts?.tag2 ?? tag2,
+        tag1: options?.tag1 ?? tag1,
+        tag2: options?.tag2 ?? tag2,
         registryAddress,
       })
     },

--- a/packages/sdk/src/actions/erc8004.ts
+++ b/packages/sdk/src/actions/erc8004.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from '@x402r/core'
 import {
   isRegistered as coreIsRegistered,
   resolveAgent as coreResolveAgent,
@@ -67,6 +68,11 @@ export function createErc8004ReputationActions(
   const tag2 = options?.defaultTag2 ?? DEFAULT_FEEDBACK_TAG2
   return {
     async rate(agentId: bigint, score: number): Promise<Hash> {
+      if (score < 0 || score > 100) {
+        throw new ValidationError(
+          `rate() score must be 0–100 (got ${score}). Use giveFeedback() for unconstrained values.`,
+        )
+      }
       const wallet = requireWallet(config)
       return coreGiveFeedback(wallet, {
         agentId,

--- a/packages/sdk/src/actions/erc8004.ts
+++ b/packages/sdk/src/actions/erc8004.ts
@@ -1,0 +1,121 @@
+import {
+  isRegistered as coreIsRegistered,
+  resolveAgent as coreResolveAgent,
+  verifyAgentId as coreVerifyAgentId,
+  registerAgent,
+} from '@x402r/erc8004/identity'
+import { resolveServiceEndpoint as coreResolveServiceEndpoint } from '@x402r/erc8004/registration'
+import {
+  getSummary as coreGetSummary,
+  giveFeedback as coreGiveFeedback,
+} from '@x402r/erc8004/reputation'
+import type { Address, Hash } from 'viem'
+import type {
+  Erc8004DiscoveryActions,
+  Erc8004GiveFeedbackParams,
+  Erc8004IdentityActions,
+  Erc8004PluginOptions,
+  Erc8004ReputationActions,
+  ResolvedConfig,
+} from '../types.js'
+import { requireWallet } from './utils.js'
+
+export const DEFAULT_FEEDBACK_TAG1 = 'starred'
+export const DEFAULT_FEEDBACK_TAG2 = 'x402'
+
+export function createErc8004IdentityActions(
+  config: ResolvedConfig,
+  options?: Erc8004PluginOptions,
+): Erc8004IdentityActions {
+  const registryAddress = options?.registryAddress
+  return {
+    async register(agentURI?: string): Promise<Hash> {
+      const wallet = requireWallet(config)
+      return registerAgent(wallet, { agentURI, registryAddress })
+    },
+    async verifyAgentId(
+      agentId: bigint,
+      claimedAddress: Address,
+    ): Promise<boolean> {
+      return coreVerifyAgentId(config.publicClient, {
+        agentId,
+        claimedAddress,
+        registryAddress,
+      })
+    },
+    async resolveAgent(agentId: bigint) {
+      return coreResolveAgent(config.publicClient, {
+        agentId,
+        registryAddress,
+      })
+    },
+    async isRegistered(address: Address): Promise<boolean> {
+      return coreIsRegistered(config.publicClient, {
+        address,
+        registryAddress,
+      })
+    },
+  }
+}
+
+export function createErc8004ReputationActions(
+  config: ResolvedConfig,
+  options?: Erc8004PluginOptions,
+): Erc8004ReputationActions {
+  const registryAddress = options?.reputationRegistryAddress
+  const tag1 = options?.defaultTag1 ?? DEFAULT_FEEDBACK_TAG1
+  const tag2 = options?.defaultTag2 ?? DEFAULT_FEEDBACK_TAG2
+  return {
+    async rate(agentId: bigint, score: number): Promise<Hash> {
+      const wallet = requireWallet(config)
+      return coreGiveFeedback(wallet, {
+        agentId,
+        value: BigInt(score),
+        valueDecimals: 0,
+        tag1,
+        tag2,
+        registryAddress,
+      })
+    },
+    async getSummary(
+      agentId: bigint,
+      reviewers: readonly Address[],
+      opts?: { tag1?: string; tag2?: string },
+    ) {
+      return coreGetSummary(config.publicClient, {
+        agentId,
+        clientAddresses: reviewers,
+        tag1: opts?.tag1 ?? tag1,
+        tag2: opts?.tag2 ?? tag2,
+        registryAddress,
+      })
+    },
+    async giveFeedback(
+      agentId: bigint,
+      params: Erc8004GiveFeedbackParams,
+    ): Promise<Hash> {
+      const wallet = requireWallet(config)
+      return coreGiveFeedback(wallet, {
+        agentId,
+        ...params,
+        registryAddress,
+      })
+    },
+  }
+}
+
+export function createErc8004DiscoveryActions(
+  config: ResolvedConfig,
+  options?: Erc8004PluginOptions,
+): Erc8004DiscoveryActions {
+  const registryAddress = options?.registryAddress
+  return {
+    async resolveServiceEndpoint(agentId: bigint, serviceName: string) {
+      return coreResolveServiceEndpoint(config.publicClient, {
+        agentId,
+        serviceName,
+        registryAddress,
+      })
+    },
+  }
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -41,8 +41,15 @@ export {
   validatePaymentInfo,
   X402rError,
 } from '@x402r/core'
+export type { ResolvedAgent } from '@x402r/erc8004/identity'
+export type { ResolvedServiceEndpoint } from '@x402r/erc8004/registration'
+export type { ReputationSummary } from '@x402r/erc8004/reputation'
+export {
+  DEFAULT_FEEDBACK_TAG1,
+  DEFAULT_FEEDBACK_TAG2,
+} from './actions/erc8004.js'
 export { createX402r } from './client.js'
-export { queryActions } from './plugins/index.js'
+export { erc8004Actions, queryActions } from './plugins/index.js'
 export {
   createArbiterClient,
   createMerchantClient,
@@ -52,6 +59,11 @@ export { createMemoryStore } from './store/index.js'
 export type { PaymentStore } from './store/types.js'
 export type {
   ArbiterClient,
+  Erc8004DiscoveryActions,
+  Erc8004GiveFeedbackParams,
+  Erc8004IdentityActions,
+  Erc8004PluginOptions,
+  Erc8004ReputationActions,
   EscrowActions,
   EvidenceActions,
   FreezeActions,

--- a/packages/sdk/src/plugins/index.ts
+++ b/packages/sdk/src/plugins/index.ts
@@ -1,3 +1,4 @@
+import { getErc8004Addresses } from '@x402r/erc8004'
 import type { Address } from 'viem'
 import {
   createErc8004DiscoveryActions,
@@ -12,11 +13,20 @@ import type { Erc8004PluginOptions, X402r } from '../types.js'
 
 /** Extend plugin — attaches ERC-8004 identity, reputation, and discovery actions. */
 export function erc8004Actions(options?: Erc8004PluginOptions) {
-  return (client: X402r) => ({
-    identity: createErc8004IdentityActions(client.config, options),
-    reputation: createErc8004ReputationActions(client.config, options),
-    discovery: createErc8004DiscoveryActions(client.config, options),
-  })
+  return (client: X402r) => {
+    const addresses = getErc8004Addresses(client.config.chainId)
+    const resolved: Erc8004PluginOptions = {
+      ...options,
+      registryAddress: options?.registryAddress ?? addresses.identityRegistry,
+      reputationRegistryAddress:
+        options?.reputationRegistryAddress ?? addresses.reputationRegistry,
+    }
+    return {
+      identity: createErc8004IdentityActions(client.config, resolved),
+      reputation: createErc8004ReputationActions(client.config, resolved),
+      discovery: createErc8004DiscoveryActions(client.config, resolved),
+    }
+  }
 }
 
 /** Extend plugin — attaches escrow actions for the given EscrowPeriod address. */

--- a/packages/sdk/src/plugins/index.ts
+++ b/packages/sdk/src/plugins/index.ts
@@ -1,9 +1,23 @@
 import type { Address } from 'viem'
+import {
+  createErc8004DiscoveryActions,
+  createErc8004IdentityActions,
+  createErc8004ReputationActions,
+} from '../actions/erc8004.js'
 import { createEscrowActions } from '../actions/escrow.js'
 import { createFreezeActions } from '../actions/freeze.js'
 import { createQueryActions } from '../actions/query.js'
 import type { PaymentStore } from '../store/types.js'
-import type { X402r } from '../types.js'
+import type { Erc8004PluginOptions, X402r } from '../types.js'
+
+/** Extend plugin — attaches ERC-8004 identity, reputation, and discovery actions. */
+export function erc8004Actions(options?: Erc8004PluginOptions) {
+  return (client: X402r) => ({
+    identity: createErc8004IdentityActions(client.config, options),
+    reputation: createErc8004ReputationActions(client.config, options),
+    discovery: createErc8004DiscoveryActions(client.config, options),
+  })
+}
 
 /** Extend plugin — attaches escrow actions for the given EscrowPeriod address. */
 export function escrowPeriodActions(escrowPeriodAddress: Address) {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -15,6 +15,9 @@ import type {
   RefundRequestStatus,
   X402rChainConfig,
 } from '@x402r/core'
+import type { ResolvedAgent } from '@x402r/erc8004/identity'
+import type { ResolvedServiceEndpoint } from '@x402r/erc8004/registration'
+import type { ReputationSummary } from '@x402r/erc8004/reputation'
 import type { Address, Hash, Hex, PublicClient, WalletClient } from 'viem'
 import type { PaymentStore } from './store/types.js'
 
@@ -200,6 +203,63 @@ export interface WatchActions {
   onRefundRequest(callback: (log: unknown) => void): () => void
   onRefundExecuted(callback: (log: unknown) => void): () => void
   onFeeDistribution(callback: (log: unknown) => void): () => void
+}
+
+// ---------------------------------------------------------------------------
+// ERC-8004 action groups
+// ---------------------------------------------------------------------------
+
+export interface Erc8004PluginOptions {
+  /** Identity registry address override (auto-resolved from chain by default). */
+  registryAddress?: Address
+  /** Reputation registry address override (auto-resolved from chain by default). */
+  reputationRegistryAddress?: Address
+  /** Default tag1 for rate() and getSummary() convenience methods. Default: 'starred'. */
+  defaultTag1?: string
+  /** Default tag2 for rate() and getSummary() convenience methods. Default: 'x402'. */
+  defaultTag2?: string
+}
+
+/** Raw parameters for giveFeedback — full control over tags and metadata. */
+export interface Erc8004GiveFeedbackParams {
+  /** int128 on-chain — negative values represent negative feedback. */
+  value: bigint
+  valueDecimals: number
+  tag1: string
+  tag2: string
+  endpoint?: string
+  feedbackURI?: string
+  feedbackHash?: Hex
+}
+
+export interface Erc8004IdentityActions {
+  register(agentURI?: string): Promise<Hash>
+  verifyAgentId(agentId: bigint, claimedAddress: Address): Promise<boolean>
+  resolveAgent(agentId: bigint): Promise<ResolvedAgent>
+  isRegistered(address: Address): Promise<boolean>
+}
+
+export interface Erc8004ReputationActions {
+  /** Convenience — uses default tags and valueDecimals: 0. */
+  rate(agentId: bigint, score: number): Promise<Hash>
+  /** Convenience — uses default tags unless overridden via options. */
+  getSummary(
+    agentId: bigint,
+    reviewers: readonly Address[],
+    options?: { tag1?: string; tag2?: string },
+  ): Promise<ReputationSummary>
+  /** Raw — full control over tags, value, and metadata. */
+  giveFeedback(
+    agentId: bigint,
+    params: Erc8004GiveFeedbackParams,
+  ): Promise<Hash>
+}
+
+export interface Erc8004DiscoveryActions {
+  resolveServiceEndpoint(
+    agentId: bigint,
+    serviceName: string,
+  ): Promise<ResolvedServiceEndpoint>
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/sdk/tests/actions/erc8004.test.ts
+++ b/packages/sdk/tests/actions/erc8004.test.ts
@@ -24,7 +24,7 @@ vi.mock('@x402r/erc8004/identity', () => ({
   resolveAgent: vi.fn().mockResolvedValue({
     agentId: 42n,
     owner: '0x1111111111111111111111111111111111111111',
-    agentWallet: '0x0000000000000000000000000000000000000000',
+    agentWallet: '0x1111111111111111111111111111111111111111',
     agentURI: 'https://example.com/agent.json',
     ownerMismatch: false,
   }),
@@ -82,6 +82,21 @@ describe('erc8004Actions plugin', () => {
     const extended = createX402r(baseConfig).extend(erc8004Actions())
     expect(extended.payment.authorize).toBeTypeOf('function')
     expect(extended.config.chainId).toBe(84532)
+  })
+
+  it('eagerly resolves registry addresses from chainId', async () => {
+    const { registerAgent } = await import('@x402r/erc8004/identity')
+    const extended = createX402r(baseConfig).extend(erc8004Actions())
+
+    await extended.identity.register('https://example.com/agent.json')
+
+    // Base Sepolia testnet identity registry
+    expect(registerAgent).toHaveBeenCalledWith(
+      baseConfig.walletClient,
+      expect.objectContaining({
+        registryAddress: '0x8004A818BFB912233c491871b3d84c89A494BD9e',
+      }),
+    )
   })
 })
 
@@ -191,6 +206,20 @@ describe('createErc8004ReputationActions', () => {
       tag2: 'x402',
       registryAddress: undefined,
     })
+  })
+
+  it('rate accepts boundary score 0', async () => {
+    const config = createTestConfig()
+    const actions = createErc8004ReputationActions(config)
+    const result = await actions.rate(42n, 0)
+    expect(result).toBe('0xfeedbackhash')
+  })
+
+  it('rate accepts boundary score 100', async () => {
+    const config = createTestConfig()
+    const actions = createErc8004ReputationActions(config)
+    const result = await actions.rate(42n, 100)
+    expect(result).toBe('0xfeedbackhash')
   })
 
   it('rate rejects score above 100', async () => {

--- a/packages/sdk/tests/actions/erc8004.test.ts
+++ b/packages/sdk/tests/actions/erc8004.test.ts
@@ -1,5 +1,5 @@
 import type { Address } from 'viem'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createErc8004DiscoveryActions,
   createErc8004IdentityActions,
@@ -57,6 +57,8 @@ const baseConfig: X402rConfig = {
 }
 
 const TEST_ADDR = '0x1111111111111111111111111111111111111111' as Address
+
+beforeEach(() => vi.clearAllMocks())
 
 // ---------------------------------------------------------------------------
 // Plugin shape
@@ -209,17 +211,31 @@ describe('createErc8004ReputationActions', () => {
   })
 
   it('rate accepts boundary score 0', async () => {
+    const { giveFeedback } = await import('@x402r/erc8004/reputation')
     const config = createTestConfig()
     const actions = createErc8004ReputationActions(config)
+
     const result = await actions.rate(42n, 0)
+
     expect(result).toBe('0xfeedbackhash')
+    expect(giveFeedback).toHaveBeenCalledWith(
+      config.walletClient,
+      expect.objectContaining({ value: 0n }),
+    )
   })
 
   it('rate accepts boundary score 100', async () => {
+    const { giveFeedback } = await import('@x402r/erc8004/reputation')
     const config = createTestConfig()
     const actions = createErc8004ReputationActions(config)
+
     const result = await actions.rate(42n, 100)
+
     expect(result).toBe('0xfeedbackhash')
+    expect(giveFeedback).toHaveBeenCalledWith(
+      config.walletClient,
+      expect.objectContaining({ value: 100n }),
+    )
   })
 
   it('rate rejects score above 100', async () => {

--- a/packages/sdk/tests/actions/erc8004.test.ts
+++ b/packages/sdk/tests/actions/erc8004.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_FEEDBACK_TAG1,
+  DEFAULT_FEEDBACK_TAG2,
+} from '../../src/actions/erc8004.js'
+import { createX402r } from '../../src/client.js'
+import { erc8004Actions } from '../../src/plugins/index.js'
+import type { X402rConfig } from '../../src/types.js'
+import {
+  TEST_OPERATOR as operatorAddress,
+  publicClient,
+  TEST_REFUND_REQUEST as refundRequestAddress,
+  walletClient,
+} from '../fixtures.js'
+
+const baseConfig: X402rConfig = {
+  publicClient,
+  walletClient,
+  operatorAddress,
+  refundRequestAddress,
+  chainId: 84532,
+}
+
+describe('erc8004Actions plugin', () => {
+  it('attaches identity, reputation, and discovery namespaces via extend', () => {
+    const client = createX402r(baseConfig)
+    const extended = client.extend(erc8004Actions())
+
+    expect(extended.identity).toBeDefined()
+    expect(extended.reputation).toBeDefined()
+    expect(extended.discovery).toBeDefined()
+  })
+
+  it('identity namespace has all expected functions', () => {
+    const extended = createX402r(baseConfig).extend(erc8004Actions())
+
+    expect(extended.identity.register).toBeTypeOf('function')
+    expect(extended.identity.verifyAgentId).toBeTypeOf('function')
+    expect(extended.identity.resolveAgent).toBeTypeOf('function')
+    expect(extended.identity.isRegistered).toBeTypeOf('function')
+  })
+
+  it('reputation namespace has all expected functions', () => {
+    const extended = createX402r(baseConfig).extend(erc8004Actions())
+
+    expect(extended.reputation.rate).toBeTypeOf('function')
+    expect(extended.reputation.getSummary).toBeTypeOf('function')
+    expect(extended.reputation.giveFeedback).toBeTypeOf('function')
+  })
+
+  it('discovery namespace has all expected functions', () => {
+    const extended = createX402r(baseConfig).extend(erc8004Actions())
+
+    expect(extended.discovery.resolveServiceEndpoint).toBeTypeOf('function')
+  })
+
+  it('is chainable with other plugins', () => {
+    const extended = createX402r(baseConfig)
+      .extend(erc8004Actions())
+      .extend(() => ({ custom: { hello: () => 'world' } }))
+
+    expect(extended.identity).toBeDefined()
+    expect(extended.reputation).toBeDefined()
+    expect(extended.discovery).toBeDefined()
+    expect(extended.custom.hello()).toBe('world')
+  })
+
+  it('does not override base client keys', () => {
+    const client = createX402r(baseConfig)
+    const extended = client.extend(erc8004Actions())
+
+    expect(extended.payment.authorize).toBeTypeOf('function')
+    expect(extended.operator.getConfig).toBeTypeOf('function')
+    expect(extended.config.chainId).toBe(84532)
+  })
+
+  it('accepts custom registry address overrides', () => {
+    const customAddress = '0x1111111111111111111111111111111111111111' as const
+    const extended = createX402r(baseConfig).extend(
+      erc8004Actions({
+        registryAddress: customAddress,
+        reputationRegistryAddress: customAddress,
+      }),
+    )
+
+    expect(extended.identity).toBeDefined()
+    expect(extended.reputation).toBeDefined()
+  })
+
+  it('accepts custom default tags', () => {
+    const extended = createX402r(baseConfig).extend(
+      erc8004Actions({
+        defaultTag1: 'x402-delivered',
+        defaultTag2: 'proof-of-payment',
+      }),
+    )
+
+    expect(extended.reputation.rate).toBeTypeOf('function')
+    expect(extended.reputation.getSummary).toBeTypeOf('function')
+  })
+})
+
+describe('default tag constants', () => {
+  it('exports default feedback tags', () => {
+    expect(DEFAULT_FEEDBACK_TAG1).toBe('starred')
+    expect(DEFAULT_FEEDBACK_TAG2).toBe('x402')
+  })
+})

--- a/packages/sdk/tests/actions/erc8004.test.ts
+++ b/packages/sdk/tests/actions/erc8004.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import type { Address } from 'viem'
+import { describe, expect, it, vi } from 'vitest'
 import {
+  createErc8004DiscoveryActions,
+  createErc8004IdentityActions,
+  createErc8004ReputationActions,
   DEFAULT_FEEDBACK_TAG1,
   DEFAULT_FEEDBACK_TAG2,
 } from '../../src/actions/erc8004.js'
@@ -7,11 +11,42 @@ import { createX402r } from '../../src/client.js'
 import { erc8004Actions } from '../../src/plugins/index.js'
 import type { X402rConfig } from '../../src/types.js'
 import {
+  createTestConfig,
   TEST_OPERATOR as operatorAddress,
   publicClient,
   TEST_REFUND_REQUEST as refundRequestAddress,
   walletClient,
 } from '../fixtures.js'
+
+vi.mock('@x402r/erc8004/identity', () => ({
+  registerAgent: vi.fn().mockResolvedValue('0xregisterhash'),
+  verifyAgentId: vi.fn().mockResolvedValue(true),
+  resolveAgent: vi.fn().mockResolvedValue({
+    agentId: 42n,
+    owner: '0x1111111111111111111111111111111111111111',
+    agentWallet: '0x0000000000000000000000000000000000000000',
+    agentURI: 'https://example.com/agent.json',
+    ownerMismatch: false,
+  }),
+  isRegistered: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('@x402r/erc8004/reputation', () => ({
+  giveFeedback: vi.fn().mockResolvedValue('0xfeedbackhash'),
+  getSummary: vi.fn().mockResolvedValue({
+    count: 5n,
+    summaryValue: 450n,
+    summaryValueDecimals: 0,
+  }),
+}))
+
+vi.mock('@x402r/erc8004/registration', () => ({
+  resolveServiceEndpoint: vi.fn().mockResolvedValue({
+    endpoint: 'https://arbiter.example.com',
+    service: { name: 'x402r.arbiter', endpoint: 'https://arbiter.example.com' },
+    agentURI: 'https://example.com/agent.json',
+  }),
+}))
 
 const baseConfig: X402rConfig = {
   publicClient,
@@ -21,100 +56,313 @@ const baseConfig: X402rConfig = {
   chainId: 84532,
 }
 
+const TEST_ADDR = '0x1111111111111111111111111111111111111111' as Address
+
+// ---------------------------------------------------------------------------
+// Plugin shape
+// ---------------------------------------------------------------------------
+
 describe('erc8004Actions plugin', () => {
   it('attaches identity, reputation, and discovery namespaces via extend', () => {
-    const client = createX402r(baseConfig)
-    const extended = client.extend(erc8004Actions())
-
+    const extended = createX402r(baseConfig).extend(erc8004Actions())
     expect(extended.identity).toBeDefined()
     expect(extended.reputation).toBeDefined()
     expect(extended.discovery).toBeDefined()
-  })
-
-  it('identity namespace has all expected functions', () => {
-    const extended = createX402r(baseConfig).extend(erc8004Actions())
-
-    expect(extended.identity.register).toBeTypeOf('function')
-    expect(extended.identity.verifyAgentId).toBeTypeOf('function')
-    expect(extended.identity.resolveAgent).toBeTypeOf('function')
-    expect(extended.identity.isRegistered).toBeTypeOf('function')
-  })
-
-  it('reputation namespace has all expected functions', () => {
-    const extended = createX402r(baseConfig).extend(erc8004Actions())
-
-    expect(extended.reputation.rate).toBeTypeOf('function')
-    expect(extended.reputation.getSummary).toBeTypeOf('function')
-    expect(extended.reputation.giveFeedback).toBeTypeOf('function')
-  })
-
-  it('discovery namespace has all expected functions', () => {
-    const extended = createX402r(baseConfig).extend(erc8004Actions())
-
-    expect(extended.discovery.resolveServiceEndpoint).toBeTypeOf('function')
   })
 
   it('is chainable with other plugins', () => {
     const extended = createX402r(baseConfig)
       .extend(erc8004Actions())
       .extend(() => ({ custom: { hello: () => 'world' } }))
-
     expect(extended.identity).toBeDefined()
-    expect(extended.reputation).toBeDefined()
-    expect(extended.discovery).toBeDefined()
     expect(extended.custom.hello()).toBe('world')
   })
 
   it('does not override base client keys', () => {
-    const client = createX402r(baseConfig)
-    const extended = client.extend(erc8004Actions())
-
+    const extended = createX402r(baseConfig).extend(erc8004Actions())
     expect(extended.payment.authorize).toBeTypeOf('function')
-    expect(extended.operator.getConfig).toBeTypeOf('function')
     expect(extended.config.chainId).toBe(84532)
   })
+})
 
-  it('accepts custom registry address overrides', () => {
-    const customAddress = '0x1111111111111111111111111111111111111111' as const
-    const extended = createX402r(baseConfig).extend(
-      erc8004Actions({
-        registryAddress: customAddress,
-        reputationRegistryAddress: customAddress,
-      }),
-    )
+// ---------------------------------------------------------------------------
+// Identity actions
+// ---------------------------------------------------------------------------
 
-    expect(extended.identity).toBeDefined()
-    expect(extended.reputation).toBeDefined()
+describe('createErc8004IdentityActions', () => {
+  it('register delegates to registerAgent with agentURI', async () => {
+    const { registerAgent } = await import('@x402r/erc8004/identity')
+    const config = createTestConfig()
+    const actions = createErc8004IdentityActions(config)
+
+    const result = await actions.register('https://example.com/agent.json')
+
+    expect(result).toBe('0xregisterhash')
+    expect(registerAgent).toHaveBeenCalledWith(config.walletClient, {
+      agentURI: 'https://example.com/agent.json',
+      registryAddress: undefined,
+    })
   })
 
-  it('accepts custom default tags', () => {
-    const extended = createX402r(baseConfig).extend(
-      erc8004Actions({
-        defaultTag1: 'x402-delivered',
-        defaultTag2: 'proof-of-payment',
-      }),
-    )
+  it('register throws without walletClient', async () => {
+    const config = createTestConfig({ walletClient: undefined })
+    const actions = createErc8004IdentityActions(config)
+    await expect(actions.register()).rejects.toThrow('walletClient is required')
+  })
 
-    expect(extended.reputation.rate).toBeTypeOf('function')
-    expect(extended.reputation.getSummary).toBeTypeOf('function')
+  it('verifyAgentId delegates to core with agentId and address', async () => {
+    const { verifyAgentId } = await import('@x402r/erc8004/identity')
+    const config = createTestConfig()
+    const actions = createErc8004IdentityActions(config)
+
+    const result = await actions.verifyAgentId(42n, TEST_ADDR)
+
+    expect(result).toBe(true)
+    expect(verifyAgentId).toHaveBeenCalledWith(config.publicClient, {
+      agentId: 42n,
+      claimedAddress: TEST_ADDR,
+      registryAddress: undefined,
+    })
+  })
+
+  it('resolveAgent delegates to core with agentId', async () => {
+    const { resolveAgent } = await import('@x402r/erc8004/identity')
+    const config = createTestConfig()
+    const actions = createErc8004IdentityActions(config)
+
+    const result = await actions.resolveAgent(42n)
+
+    expect(result.agentId).toBe(42n)
+    expect(result.agentURI).toBe('https://example.com/agent.json')
+    expect(resolveAgent).toHaveBeenCalledWith(config.publicClient, {
+      agentId: 42n,
+      registryAddress: undefined,
+    })
+  })
+
+  it('isRegistered delegates to core with address', async () => {
+    const { isRegistered } = await import('@x402r/erc8004/identity')
+    const config = createTestConfig()
+    const actions = createErc8004IdentityActions(config)
+
+    const result = await actions.isRegistered(TEST_ADDR)
+
+    expect(result).toBe(true)
+    expect(isRegistered).toHaveBeenCalledWith(config.publicClient, {
+      address: TEST_ADDR,
+      registryAddress: undefined,
+    })
+  })
+
+  it('passes registryAddress override to all calls', async () => {
+    const { verifyAgentId } = await import('@x402r/erc8004/identity')
+    const config = createTestConfig()
+    const actions = createErc8004IdentityActions(config, {
+      registryAddress: TEST_ADDR,
+    })
+
+    await actions.verifyAgentId(1n, TEST_ADDR)
+
+    expect(verifyAgentId).toHaveBeenCalledWith(
+      config.publicClient,
+      expect.objectContaining({ registryAddress: TEST_ADDR }),
+    )
   })
 })
 
-describe('rate() score validation', () => {
-  it('rejects score above 100', async () => {
-    const extended = createX402r(baseConfig).extend(erc8004Actions())
-    await expect(extended.reputation.rate(1n, 150)).rejects.toThrow(
+// ---------------------------------------------------------------------------
+// Reputation actions
+// ---------------------------------------------------------------------------
+
+describe('createErc8004ReputationActions', () => {
+  it('rate delegates to giveFeedback with default tags and score as bigint', async () => {
+    const { giveFeedback } = await import('@x402r/erc8004/reputation')
+    const config = createTestConfig()
+    const actions = createErc8004ReputationActions(config)
+
+    const result = await actions.rate(42n, 90)
+
+    expect(result).toBe('0xfeedbackhash')
+    expect(giveFeedback).toHaveBeenCalledWith(config.walletClient, {
+      agentId: 42n,
+      value: 90n,
+      valueDecimals: 0,
+      tag1: 'starred',
+      tag2: 'x402',
+      registryAddress: undefined,
+    })
+  })
+
+  it('rate rejects score above 100', async () => {
+    const config = createTestConfig()
+    const actions = createErc8004ReputationActions(config)
+    await expect(actions.rate(1n, 150)).rejects.toThrow(
       'rate() score must be 0–100',
     )
   })
 
-  it('rejects negative score', async () => {
-    const extended = createX402r(baseConfig).extend(erc8004Actions())
-    await expect(extended.reputation.rate(1n, -1)).rejects.toThrow(
+  it('rate rejects negative score', async () => {
+    const config = createTestConfig()
+    const actions = createErc8004ReputationActions(config)
+    await expect(actions.rate(1n, -1)).rejects.toThrow(
       'rate() score must be 0–100',
     )
   })
+
+  it('rate throws without walletClient', async () => {
+    const config = createTestConfig({ walletClient: undefined })
+    const actions = createErc8004ReputationActions(config)
+    await expect(actions.rate(1n, 50)).rejects.toThrow(
+      'walletClient is required',
+    )
+  })
+
+  it('getSummary delegates to core with default tags', async () => {
+    const { getSummary } = await import('@x402r/erc8004/reputation')
+    const config = createTestConfig()
+    const actions = createErc8004ReputationActions(config)
+    const reviewers = [TEST_ADDR]
+
+    const result = await actions.getSummary(42n, reviewers)
+
+    expect(result.count).toBe(5n)
+    expect(getSummary).toHaveBeenCalledWith(config.publicClient, {
+      agentId: 42n,
+      clientAddresses: reviewers,
+      tag1: 'starred',
+      tag2: 'x402',
+      registryAddress: undefined,
+    })
+  })
+
+  it('getSummary accepts custom tag overrides', async () => {
+    const { getSummary } = await import('@x402r/erc8004/reputation')
+    const config = createTestConfig()
+    const actions = createErc8004ReputationActions(config)
+
+    await actions.getSummary(42n, [TEST_ADDR], {
+      tag1: 'custom1',
+      tag2: 'custom2',
+    })
+
+    expect(getSummary).toHaveBeenCalledWith(
+      config.publicClient,
+      expect.objectContaining({ tag1: 'custom1', tag2: 'custom2' }),
+    )
+  })
+
+  it('giveFeedback delegates raw params to core', async () => {
+    const { giveFeedback } = await import('@x402r/erc8004/reputation')
+    const config = createTestConfig()
+    const actions = createErc8004ReputationActions(config)
+    const params = {
+      value: 85n,
+      valueDecimals: 2,
+      tag1: 'x402-delivered',
+      tag2: 'proof-of-payment',
+    }
+
+    const result = await actions.giveFeedback(42n, params)
+
+    expect(result).toBe('0xfeedbackhash')
+    expect(giveFeedback).toHaveBeenCalledWith(config.walletClient, {
+      agentId: 42n,
+      ...params,
+      registryAddress: undefined,
+    })
+  })
+
+  it('giveFeedback throws without walletClient', async () => {
+    const config = createTestConfig({ walletClient: undefined })
+    const actions = createErc8004ReputationActions(config)
+    await expect(
+      actions.giveFeedback(1n, {
+        value: 1n,
+        valueDecimals: 0,
+        tag1: 'a',
+        tag2: 'b',
+      }),
+    ).rejects.toThrow('walletClient is required')
+  })
+
+  it('uses custom default tags from plugin options', async () => {
+    const { giveFeedback } = await import('@x402r/erc8004/reputation')
+    const config = createTestConfig()
+    const actions = createErc8004ReputationActions(config, {
+      defaultTag1: 'x402-delivered',
+      defaultTag2: 'proof-of-payment',
+    })
+
+    await actions.rate(42n, 50)
+
+    expect(giveFeedback).toHaveBeenCalledWith(
+      config.walletClient,
+      expect.objectContaining({
+        tag1: 'x402-delivered',
+        tag2: 'proof-of-payment',
+      }),
+    )
+  })
+
+  it('passes reputationRegistryAddress override', async () => {
+    const { getSummary } = await import('@x402r/erc8004/reputation')
+    const config = createTestConfig()
+    const actions = createErc8004ReputationActions(config, {
+      reputationRegistryAddress: TEST_ADDR,
+    })
+
+    await actions.getSummary(42n, [TEST_ADDR])
+
+    expect(getSummary).toHaveBeenCalledWith(
+      config.publicClient,
+      expect.objectContaining({ registryAddress: TEST_ADDR }),
+    )
+  })
 })
+
+// ---------------------------------------------------------------------------
+// Discovery actions
+// ---------------------------------------------------------------------------
+
+describe('createErc8004DiscoveryActions', () => {
+  it('resolveServiceEndpoint delegates to core', async () => {
+    const { resolveServiceEndpoint } = await import(
+      '@x402r/erc8004/registration'
+    )
+    const config = createTestConfig()
+    const actions = createErc8004DiscoveryActions(config)
+
+    const result = await actions.resolveServiceEndpoint(7n, 'x402r.arbiter')
+
+    expect(result.endpoint).toBe('https://arbiter.example.com')
+    expect(resolveServiceEndpoint).toHaveBeenCalledWith(config.publicClient, {
+      agentId: 7n,
+      serviceName: 'x402r.arbiter',
+      registryAddress: undefined,
+    })
+  })
+
+  it('passes registryAddress override', async () => {
+    const { resolveServiceEndpoint } = await import(
+      '@x402r/erc8004/registration'
+    )
+    const config = createTestConfig()
+    const actions = createErc8004DiscoveryActions(config, {
+      registryAddress: TEST_ADDR,
+    })
+
+    await actions.resolveServiceEndpoint(7n, 'x402r.arbiter')
+
+    expect(resolveServiceEndpoint).toHaveBeenCalledWith(
+      config.publicClient,
+      expect.objectContaining({ registryAddress: TEST_ADDR }),
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
 
 describe('default tag constants', () => {
   it('exports default feedback tags', () => {

--- a/packages/sdk/tests/actions/erc8004.test.ts
+++ b/packages/sdk/tests/actions/erc8004.test.ts
@@ -100,6 +100,22 @@ describe('erc8004Actions plugin', () => {
   })
 })
 
+describe('rate() score validation', () => {
+  it('rejects score above 100', async () => {
+    const extended = createX402r(baseConfig).extend(erc8004Actions())
+    await expect(extended.reputation.rate(1n, 150)).rejects.toThrow(
+      'rate() score must be 0–100',
+    )
+  })
+
+  it('rejects negative score', async () => {
+    const extended = createX402r(baseConfig).extend(erc8004Actions())
+    await expect(extended.reputation.rate(1n, -1)).rejects.toThrow(
+      'rate() score must be 0–100',
+    )
+  })
+})
+
 describe('default tag constants', () => {
   it('exports default feedback tags', () => {
     expect(DEFAULT_FEEDBACK_TAG1).toBe('starred')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       '@x402r/core':
         specifier: workspace:*
         version: link:../core
+      '@x402r/erc8004':
+        specifier: ^0.1.0-alpha.1
+        version: 0.1.0-alpha.1(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))
       viem:
         specifier: ^2.46.3
         version: 2.47.1(typescript@5.9.3)(zod@4.3.6)
@@ -1130,6 +1133,12 @@ packages:
 
   '@x402/extensions@2.5.0':
     resolution: {integrity: sha512-e7IQShbGUM/XQmzI8DQh2tX/k2XDUGI9DNF+ij2NHUyPEqAt5/mJCwOlaxS/60FWFdfFRfWjTsqaoS7Z8WLi+A==}
+
+  '@x402r/erc8004@0.1.0-alpha.1':
+    resolution: {integrity: sha512-fmxSbpFAR/bVLmzcLpxyPZhr/8wAeEaLthZ8Q0PqNeO4oTGNTeoLBXOHTZMaLdETsileDHcSJJmwxbXJ3z214Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      viem: ^2.0.0
 
   '@x402r/evm@0.0.3':
     resolution: {integrity: sha512-b8sEZ5VTRpVdy/kxCgZFW1YVQvmZCUpRa7x4tdpoDZPZQannnlJn0haNF2Bxsl2jVhLzLXBCjOrTKKBCy/lQ1g==}
@@ -3300,6 +3309,10 @@ snapshots:
       - ethers
       - typescript
       - utf-8-validate
+
+  '@x402r/erc8004@0.1.0-alpha.1(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))':
+    dependencies:
+      viem: 2.47.1(typescript@5.9.3)(zod@4.3.6)
 
   '@x402r/evm@0.0.3(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@3.25.76))':
     dependencies:


### PR DESCRIPTION
## Summary

- Add `erc8004Actions()` extend plugin wrapping `@x402r/erc8004` with SDK client binding
- Three new namespaces: `identity` (register, verify, resolve, isRegistered), `reputation` (rate, getSummary, giveFeedback), `discovery` (resolveServiceEndpoint)
- Default feedback tags `starred`/`x402`, configurable via plugin options
- Re-export key `@x402r/erc8004` types (`ResolvedAgent`, `ReputationSummary`, `ResolvedServiceEndpoint`) from `@x402r/sdk`

## Usage

```typescript
import { createX402r, erc8004Actions } from '@x402r/sdk'

const client = createX402r(config).extend(erc8004Actions())

await client.identity.verifyAgentId(7n, '0xABC...')
await client.reputation.rate(7n, 90)
await client.discovery.resolveServiceEndpoint(7n, 'x402r.arbiter')
```

## Test plan

- [x] `pnpm typecheck` passes
- [x] `pnpm test` — 144 tests pass (9 new erc8004 plugin tests)
- [x] `pnpm build` — clean build, plugins entry includes erc8004Actions
- [x] Pre-commit hooks (biome, build, typecheck) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)