### PR TITLE
feat(cli): @x402r/cli@0.2.0 — wallet-agnostic one-shot payment CLI

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -14,6 +14,9 @@
     },
     "packages/sdk": {
       "entry": ["tests/**/*.test.ts", "tests/**/*.ts", "vitest.config.ts"]
+    },
+    "packages/cli": {
+      "entry": ["tests/**/*.test.ts", "tests/**/*.ts", "vitest.config.ts"]
     }
   }
 }

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,135 @@
+# @x402r/cli
+
+One-shot CLI for paying x402 / x402r HTTP 402 endpoints. Wallet-agnostic: raw
+private key, JSON-RPC signer, or a custom signer module. Zero provider SDK
+dependencies.
+
+## Install
+
+Use `npx` — no project install required.
+
+```bash
+npx @x402r/cli@0.2.0 pay <url> [options]
+```
+
+## Surface
+
+```
+x402r pay <url> [signer flags] [--max-amount N] [--rpc <url>] [--chain <eip155:id>] [--json]
+```
+
+Exactly one signer source must resolve. CLI flag > env var.
+
+| Source            | Flag                                            | Env                            |
+|-------------------|-------------------------------------------------|--------------------------------|
+| Raw key           | `--key 0x...`                                   | `PRIVATE_KEY`                  |
+| Remote RPC signer | `--signer-url <url> --signer-address 0x...`     | `SIGNER_URL`, `SIGNER_ADDRESS` |
+| Custom module     | `--signer-module <pkg-or-path>`                 | `SIGNER_MODULE`                |
+
+Env var names are unprefixed to match the Foundry / Hardhat / x402-reference
+convention. The flag form is available when you want to avoid collisions.
+
+## Exit codes
+
+| Code | Meaning |
+|------|---------|
+| 0    | success |
+| 1    | network error |
+| 2    | malformed 402 / unusable accepts[] |
+| 3    | price exceeds `--max-amount` guard |
+| 4    | signature rejected |
+| 5    | settlement failed (merchant 4xx/5xx after payment, or facilitator error) |
+| 6    | signer resolution failed (none, multiple, or partially-configured sources) |
+
+## `--json` envelope
+
+```json
+{
+  "body": "<merchant response body>",
+  "status": 200,
+  "tx": "0x…",
+  "elapsedMs": 1234,
+  "signer": { "kind": "key", "address": "0x…" }
+}
+```
+
+`signer` is omitted when the URL returned non-402 (no payment was made).
+
+## Examples
+
+### Raw key
+
+```bash
+PRIVATE_KEY=0x... \
+  npx @x402r/cli@0.2.0 pay https://example.com/paid
+```
+
+### JSON-RPC signer
+
+Anything speaking `eth_signTypedData_v4` works: Privy wallet RPC, Turnkey,
+Fireblocks, Safe, a local `cast wallet` endpoint, a hardware wallet exposed
+over an RPC bridge, etc.
+
+```bash
+npx @x402r/cli@0.2.0 pay https://example.com/paid \
+  --signer-url https://signer.example/rpc \
+  --signer-address 0x...
+```
+
+### Custom module — Privy (`@privy-io/server-auth`)
+
+```js
+// privy-signer.js
+import { PrivyClient } from '@privy-io/server-auth'
+import { createViemAccount } from '@privy-io/server-auth/viem'
+
+export default async function () {
+  const privy = new PrivyClient(process.env.PRIVY_APP_ID, process.env.PRIVY_APP_SECRET)
+  return createViemAccount({
+    walletId: process.env.PRIVY_WALLET_ID,
+    address: process.env.PRIVY_WALLET_ADDRESS,
+    privy,
+  })
+}
+```
+
+```bash
+npx @x402r/cli@0.2.0 pay https://example.com/paid \
+  --signer-module ./privy-signer.js
+```
+
+### Custom module — Coinbase CDP server wallet
+
+```js
+// cdp-signer.js
+import { CdpClient } from '@coinbase/cdp-sdk'
+import { toAccount } from 'viem/accounts'
+
+export default async function () {
+  const cdp = new CdpClient()
+  const acct = await cdp.evm.getOrCreateAccount({ name: process.env.CDP_ACCOUNT_NAME })
+  return toAccount(acct)
+}
+```
+
+```bash
+npx @x402r/cli@0.2.0 pay https://example.com/paid \
+  --signer-module ./cdp-signer.js
+```
+
+## Signer module contract
+
+The module's default export is a factory `() => Promise<Account>` that
+returns a viem [`Account`](https://viem.sh/docs/accounts/custom). The CLI
+only needs `signTypedData` — transaction broadcasting is handled by the
+facilitator.
+
+## Notes
+
+- Wallet-agnostic by design: the CLI carries zero Privy / CDP / Turnkey
+  dependencies. Provider SDKs are loaded only when `--signer-module` points
+  at a user-authored shim.
+- Pinned-version invocation (`npx @x402r/cli@0.2.0`) is recommended so agent
+  skill wrappers can wildcard-allow exact command shapes.
+- Supports Base and Base Sepolia out of the box. Any EVM chain known to
+  `viem/chains` works; unknown chain IDs require `--rpc <url>`.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@x402r/cli",
+  "version": "0.2.0",
+  "description": "One-shot CLI for paying x402 / x402r endpoints. Wallet-agnostic: raw key, JSON-RPC signer, or custom module.",
+  "type": "module",
+  "license": "Apache-2.0",
+  "bin": {
+    "x402r": "./dist/bin.js"
+  },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run",
+    "test:cov": "vitest run --coverage",
+    "typecheck": "tsc --noEmit",
+    "prepublishOnly": "publint --strict && attw --pack --ignore-rules no-resolution cjs-resolves-to-esm"
+  },
+  "dependencies": {
+    "@x402/core": "^2.5.0",
+    "@x402/evm": "^2.5.0",
+    "@x402r/evm": "^0.1.0",
+    "viem": "^2.46.3"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0"
+  }
+}

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,0 +1,145 @@
+#!/usr/bin/env node
+import { parseArgs } from 'node:util'
+import { CliError } from './errors.js'
+import { type PayFlags, type PayResult, pay } from './pay.js'
+import { SignerResolutionError } from './signers/index.js'
+
+const USAGE = `@x402r/cli — one-shot x402 payment CLI
+
+Usage:
+  x402r pay <url> [options]
+
+Signer (exactly one):
+  --key <0x...>               raw private key (env: PRIVATE_KEY)
+  --signer-url <url>          JSON-RPC signer endpoint (env: SIGNER_URL)
+  --signer-address <0x...>    address for the JSON-RPC signer (env: SIGNER_ADDRESS)
+  --signer-module <pkg|path>  dynamic-imported factory (env: SIGNER_MODULE)
+
+Request:
+  --chain <eip155:id>   pick an accepts[] entry when the 402 offers multiple
+  --rpc <url>           override the RPC URL for on-chain reads
+  --max-amount <atomic> refuse to pay more than this (atomic token units)
+
+Output:
+  --json                emit a single JSON envelope to stdout
+  --help, -h            print this help
+
+Exit codes:
+  0 success  1 network  2 malformed 402  3 price > --max-amount
+  4 signature rejected  5 settlement failed  6 signer resolution failed
+`
+
+async function main(argv: string[]): Promise<number> {
+  if (argv.length === 0 || argv[0] === '-h' || argv[0] === '--help') {
+    process.stdout.write(USAGE)
+    return 0
+  }
+
+  const [command, ...rest] = argv
+  if (command !== 'pay') {
+    process.stderr.write(`unknown command "${command}"\n\n${USAGE}`)
+    return 2
+  }
+
+  let parsed: ReturnType<typeof parseArgs>
+  try {
+    parsed = parseArgs({
+      args: rest,
+      allowPositionals: true,
+      options: {
+        key: { type: 'string' },
+        'signer-url': { type: 'string' },
+        'signer-address': { type: 'string' },
+        'signer-module': { type: 'string' },
+        chain: { type: 'string' },
+        rpc: { type: 'string' },
+        'max-amount': { type: 'string' },
+        json: { type: 'boolean' },
+        help: { type: 'boolean', short: 'h' },
+      },
+    })
+  } catch (err) {
+    process.stderr.write(`${errorMessage(err)}\n\n${USAGE}`)
+    return 2
+  }
+
+  if (parsed.values.help) {
+    process.stdout.write(USAGE)
+    return 0
+  }
+
+  const url = parsed.positionals[0]
+  if (!url) {
+    process.stderr.write(`pay requires a <url> positional\n\n${USAGE}`)
+    return 2
+  }
+
+  const flags: PayFlags = {
+    url,
+    key: parsed.values.key as string | undefined,
+    signerUrl: parsed.values['signer-url'] as string | undefined,
+    signerAddress: parsed.values['signer-address'] as string | undefined,
+    signerModule: parsed.values['signer-module'] as string | undefined,
+    chain: parsed.values.chain as string | undefined,
+    rpc: parsed.values.rpc as string | undefined,
+    maxAmount: parsed.values['max-amount'] as string | undefined,
+    json: Boolean(parsed.values.json),
+  }
+
+  try {
+    const result = await pay(flags)
+    emit(result, Boolean(flags.json))
+    return 0
+  } catch (err) {
+    return handleError(err, Boolean(flags.json))
+  }
+}
+
+function emit(result: PayResult, json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(result)}\n`)
+    return
+  }
+  process.stdout.write(result.body)
+  if (!result.body.endsWith('\n')) process.stdout.write('\n')
+  if (result.tx) process.stderr.write(`tx: ${result.tx}\n`)
+  if (result.signer) {
+    process.stderr.write(
+      `signer: ${result.signer.kind} (${result.signer.address})\n`,
+    )
+  }
+  process.stderr.write(`elapsed: ${result.elapsedMs}ms\n`)
+}
+
+function handleError(err: unknown, json: boolean): number {
+  if (err instanceof SignerResolutionError) {
+    emitError(err.message, 6, json)
+    return 6
+  }
+  if (err instanceof CliError) {
+    emitError(err.message, err.exitCode, json)
+    return err.exitCode
+  }
+  emitError(errorMessage(err), 1, json)
+  return 1
+}
+
+function emitError(message: string, exitCode: number, json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify({ error: message, exitCode })}\n`)
+  } else {
+    process.stderr.write(`error: ${message}\n`)
+  }
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+main(process.argv.slice(2)).then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`unexpected: ${errorMessage(err)}\n`)
+    process.exit(1)
+  },
+)

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { parseArgs } from 'node:util'
 import { CliError } from './errors.js'
-import { type PayFlags, type PayResult, pay } from './pay.js'
+import { type PayFlags, type PayResult, pay } from './pay/index.js'
 
 const USAGE = `@x402r/cli — one-shot x402 payment CLI
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -2,7 +2,6 @@
 import { parseArgs } from 'node:util'
 import { CliError } from './errors.js'
 import { type PayFlags, type PayResult, pay } from './pay.js'
-import { SignerResolutionError } from './signers/index.js'
 
 const USAGE = `@x402r/cli — one-shot x402 payment CLI
 
@@ -112,10 +111,6 @@ function emit(result: PayResult, json: boolean): void {
 }
 
 function handleError(err: unknown, json: boolean): number {
-  if (err instanceof SignerResolutionError) {
-    emitError(err.message, 6, json)
-    return 6
-  }
   if (err instanceof CliError) {
     emitError(err.message, err.exitCode, json)
     return err.exitCode

--- a/packages/cli/src/chain.ts
+++ b/packages/cli/src/chain.ts
@@ -1,0 +1,66 @@
+import type { Chain } from 'viem'
+import * as chains from 'viem/chains'
+import { Malformed402Error } from './errors.js'
+
+const BY_ID = buildIndex()
+
+function buildIndex(): Record<number, Chain> {
+  const out: Record<number, Chain> = {}
+  for (const value of Object.values(chains)) {
+    if (isChain(value)) out[value.id] = value
+  }
+  return out
+}
+
+function isChain(value: unknown): value is Chain {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'id' in value &&
+    typeof (value as { id: unknown }).id === 'number' &&
+    'rpcUrls' in value
+  )
+}
+
+/**
+ * Parse an x402 `Network` string (e.g., `"eip155:84532"`) into a numeric
+ * chain ID. Solana and other non-EVM namespaces are rejected — this CLI only
+ * supports EVM schemes.
+ */
+export function parseChainId(network: string): number {
+  const [namespace, id] = network.split(':')
+  if (namespace !== 'eip155' || !id) {
+    throw new Malformed402Error(
+      `unsupported network "${network}"; only eip155 chains are supported`,
+    )
+  }
+  const chainId = Number(id)
+  if (!Number.isInteger(chainId) || chainId <= 0) {
+    throw new Malformed402Error(`invalid chain id in network "${network}"`)
+  }
+  return chainId
+}
+
+/**
+ * Resolve a viem `Chain` by numeric id, optionally overriding the RPC URL.
+ * Unknown chains synthesize a minimal `Chain` object if `rpcUrl` is provided.
+ */
+export function resolveChain(chainId: number, rpcUrl?: string): Chain {
+  const known = BY_ID[chainId]
+  if (known) {
+    return rpcUrl
+      ? { ...known, rpcUrls: { default: { http: [rpcUrl] } } }
+      : known
+  }
+  if (!rpcUrl) {
+    throw new Malformed402Error(
+      `unknown chain id ${chainId}; pass --rpc <url> to use an unrecognized chain`,
+    )
+  }
+  return {
+    id: chainId,
+    name: `Chain ${chainId}`,
+    nativeCurrency: { name: 'Ether', symbol: 'ETH', decimals: 18 },
+    rpcUrls: { default: { http: [rpcUrl] } },
+  }
+}

--- a/packages/cli/src/errors.ts
+++ b/packages/cli/src/errors.ts
@@ -1,0 +1,46 @@
+export type ExitCode = 0 | 1 | 2 | 3 | 4 | 5 | 6
+
+export class CliError extends Error {
+  readonly exitCode: ExitCode
+
+  constructor(message: string, exitCode: ExitCode) {
+    super(message)
+    this.name = 'CliError'
+    this.exitCode = exitCode
+  }
+}
+
+export class NetworkError extends CliError {
+  constructor(message: string) {
+    super(message, 1)
+    this.name = 'NetworkError'
+  }
+}
+
+export class Malformed402Error extends CliError {
+  constructor(message: string) {
+    super(message, 2)
+    this.name = 'Malformed402Error'
+  }
+}
+
+export class MaxAmountExceededError extends CliError {
+  constructor(message: string) {
+    super(message, 3)
+    this.name = 'MaxAmountExceededError'
+  }
+}
+
+export class SignatureRejectedError extends CliError {
+  constructor(message: string) {
+    super(message, 4)
+    this.name = 'SignatureRejectedError'
+  }
+}
+
+export class SettlementError extends CliError {
+  constructor(message: string) {
+    super(message, 5)
+    this.name = 'SettlementError'
+  }
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,7 @@ export {
   SettlementError,
   SignatureRejectedError,
 } from './errors.js'
-export type { PayFlags, PayResult } from './pay.js'
-export { pay } from './pay.js'
+export type { PayFlags, PayResult } from './pay/index.js'
+export { pay } from './pay/index.js'
 export { resolveSigner, SignerResolutionError } from './signers/index.js'
 export type { ResolvedSigner, SignerFlags, SignerKind } from './types.js'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,9 +10,4 @@ export {
 export type { PayFlags, PayResult } from './pay.js'
 export { pay } from './pay.js'
 export { resolveSigner, SignerResolutionError } from './signers/index.js'
-export type {
-  ResolvedSigner,
-  SignerFactory,
-  SignerFlags,
-  SignerKind,
-} from './types.js'
+export type { ResolvedSigner, SignerFlags, SignerKind } from './types.js'

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,18 @@
+export {
+  CliError,
+  type ExitCode,
+  Malformed402Error,
+  MaxAmountExceededError,
+  NetworkError,
+  SettlementError,
+  SignatureRejectedError,
+} from './errors.js'
+export type { PayFlags, PayResult } from './pay.js'
+export { pay } from './pay.js'
+export { resolveSigner, SignerResolutionError } from './signers/index.js'
+export type {
+  ResolvedSigner,
+  SignerFactory,
+  SignerFlags,
+  SignerKind,
+} from './types.js'

--- a/packages/cli/src/pay.ts
+++ b/packages/cli/src/pay.ts
@@ -150,7 +150,7 @@ function parsePaymentRequired(
   }
 }
 
-function pickAccept(
+export function pickAccept(
   accepts: PaymentRequirements[],
   chainFilter: string | undefined,
 ): PaymentRequirements {
@@ -175,7 +175,7 @@ function pickAccept(
   return match
 }
 
-function enforceMaxAmount(
+export function enforceMaxAmount(
   accept: PaymentRequirements,
   maxAmount: string | undefined,
 ): void {

--- a/packages/cli/src/pay.ts
+++ b/packages/cli/src/pay.ts
@@ -1,0 +1,225 @@
+import { x402Client, x402HTTPClient } from '@x402/core/client'
+import type {
+  PaymentPayload,
+  PaymentRequired,
+  PaymentRequirements,
+} from '@x402/core/types'
+import { toClientEvmSigner } from '@x402/evm'
+import { registerCommerceEvmScheme } from '@x402r/evm/commerce/client'
+import type { Account } from 'viem'
+import { createPublicClient, http } from 'viem'
+import { parseChainId, resolveChain } from './chain.js'
+import {
+  Malformed402Error,
+  MaxAmountExceededError,
+  NetworkError,
+  SettlementError,
+  SignatureRejectedError,
+} from './errors.js'
+import { resolveSigner } from './signers/index.js'
+import type { SignerFlags, SignerKind } from './types.js'
+
+export interface PayFlags extends SignerFlags {
+  url: string
+  chain?: string
+  rpc?: string
+  maxAmount?: string
+  json?: boolean
+}
+
+export interface PayResult {
+  body: string
+  status: number
+  tx?: string
+  elapsedMs: number
+  /** Present only when a payment was made; omitted on non-402 short-circuits. */
+  signer?: { kind: SignerKind; address: string }
+}
+
+export async function pay(flags: PayFlags): Promise<PayResult> {
+  const started = Date.now()
+
+  const peek = await safeFetch(flags.url)
+
+  if (peek.status !== 402) {
+    return {
+      body: await peek.text(),
+      status: peek.status,
+      elapsedMs: Date.now() - started,
+    }
+  }
+
+  const httpClient = new x402HTTPClient(new x402Client())
+  const peekBody = await readBodyForV1Fallback(peek)
+  const paymentRequired = parsePaymentRequired(peek, httpClient, peekBody)
+
+  const accept = pickAccept(paymentRequired.accepts, flags.chain)
+  enforceMaxAmount(accept, flags.maxAmount)
+
+  const chainId = parseChainId(accept.network)
+  const chain = resolveChain(chainId, flags.rpc)
+  const publicClient = createPublicClient({ chain, transport: http(flags.rpc) })
+
+  const resolved = await resolveSigner(flags)
+  const signer = toClientEvmSigner(adaptAccount(resolved.account), publicClient)
+
+  const client = new x402Client()
+  registerCommerceEvmScheme(client, {
+    signer,
+    networks: accept.network,
+  })
+  const paymentHttpClient = new x402HTTPClient(client)
+
+  let payload: PaymentPayload
+  try {
+    payload = await client.createPaymentPayload(paymentRequired)
+  } catch (err) {
+    throw new SignatureRejectedError(
+      `failed to build payment payload: ${errorMessage(err)}`,
+    )
+  }
+
+  const paymentHeaders = paymentHttpClient.encodePaymentSignatureHeader(payload)
+  const paid = await safeFetch(flags.url, {
+    headers: {
+      ...paymentHeaders,
+      'Access-Control-Expose-Headers': 'PAYMENT-RESPONSE,X-PAYMENT-RESPONSE',
+    },
+  })
+
+  const body = await paid.text()
+  if (paid.status >= 400) {
+    throw new SettlementError(
+      `merchant returned ${paid.status} after payment: ${truncate(body, 200)}`,
+    )
+  }
+
+  const settle = tryParseSettle(paid, paymentHttpClient)
+  if (settle && settle.success === false) {
+    throw new SettlementError(
+      `settlement failed: ${settle.errorReason ?? 'unknown'}`,
+    )
+  }
+
+  return {
+    body,
+    status: paid.status,
+    tx: settle?.transaction,
+    elapsedMs: Date.now() - started,
+    signer: {
+      kind: resolved.kind,
+      address: resolved.account.address,
+    },
+  }
+}
+
+async function safeFetch(url: string, init?: RequestInit): Promise<Response> {
+  try {
+    return await fetch(url, init)
+  } catch (err) {
+    throw new NetworkError(`fetch ${url} failed: ${errorMessage(err)}`)
+  }
+}
+
+async function readBodyForV1Fallback(
+  res: Response,
+): Promise<PaymentRequired | undefined> {
+  try {
+    const text = await res.clone().text()
+    if (!text) return undefined
+    return JSON.parse(text) as PaymentRequired
+  } catch {
+    return undefined
+  }
+}
+
+function parsePaymentRequired(
+  res: Response,
+  httpClient: x402HTTPClient,
+  body: PaymentRequired | undefined,
+): PaymentRequired {
+  try {
+    return httpClient.getPaymentRequiredResponse(
+      (name) => res.headers.get(name),
+      body,
+    )
+  } catch (err) {
+    throw new Malformed402Error(
+      `failed to parse 402 payment-required: ${errorMessage(err)}`,
+    )
+  }
+}
+
+function pickAccept(
+  accepts: PaymentRequirements[],
+  chainFilter: string | undefined,
+): PaymentRequirements {
+  if (accepts.length === 0) {
+    throw new Malformed402Error('402 response has no accepts[] entries')
+  }
+  if (!chainFilter) {
+    if (accepts.length > 1) {
+      throw new Malformed402Error(
+        `402 offers ${accepts.length} payment options; pass --chain <eip155:id> to pick one`,
+      )
+    }
+    return accepts[0]!
+  }
+
+  const match = accepts.find((a) => a.network === chainFilter)
+  if (!match) {
+    throw new Malformed402Error(
+      `no accepts[] entry matches --chain ${chainFilter}; offered: ${accepts.map((a) => a.network).join(', ')}`,
+    )
+  }
+  return match
+}
+
+function enforceMaxAmount(
+  accept: PaymentRequirements,
+  maxAmount: string | undefined,
+): void {
+  if (!maxAmount) return
+  let amount: bigint
+  let max: bigint
+  try {
+    amount = BigInt(accept.amount)
+    max = BigInt(maxAmount)
+  } catch {
+    throw new MaxAmountExceededError(
+      `invalid amount comparison: accept.amount=${accept.amount}, max=${maxAmount}`,
+    )
+  }
+  if (amount > max) {
+    throw new MaxAmountExceededError(
+      `price ${amount} exceeds --max-amount ${max} (atomic units of ${accept.asset})`,
+    )
+  }
+}
+
+function tryParseSettle(
+  res: Response,
+  httpClient: x402HTTPClient,
+): ReturnType<x402HTTPClient['getPaymentSettleResponse']> | undefined {
+  try {
+    return httpClient.getPaymentSettleResponse((name) => res.headers.get(name))
+  } catch {
+    return undefined
+  }
+}
+
+function adaptAccount(
+  account: Account,
+): Parameters<typeof toClientEvmSigner>[0] {
+  // viem's Account has narrower generics on signTypedData; toClientEvmSigner
+  // only cares about the runtime shape, so we widen at the boundary.
+  return account as unknown as Parameters<typeof toClientEvmSigner>[0]
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}
+
+function truncate(s: string, n: number): string {
+  return s.length > n ? `${s.slice(0, n)}…` : s
+}

--- a/packages/cli/src/pay/index.ts
+++ b/packages/cli/src/pay/index.ts
@@ -1,23 +1,19 @@
 import { x402Client, x402HTTPClient } from '@x402/core/client'
-import type {
-  PaymentPayload,
-  PaymentRequired,
-  PaymentRequirements,
-} from '@x402/core/types'
+import type { PaymentPayload, PaymentRequired } from '@x402/core/types'
 import { toClientEvmSigner } from '@x402/evm'
 import { registerCommerceEvmScheme } from '@x402r/evm/commerce/client'
 import type { Account } from 'viem'
 import { createPublicClient, http } from 'viem'
-import { parseChainId, resolveChain } from './chain.js'
+import { parseChainId, resolveChain } from '../chain.js'
 import {
   Malformed402Error,
-  MaxAmountExceededError,
   NetworkError,
   SettlementError,
   SignatureRejectedError,
-} from './errors.js'
-import { resolveSigner } from './signers/index.js'
-import type { SignerFlags, SignerKind } from './types.js'
+} from '../errors.js'
+import { resolveSigner } from '../signers/index.js'
+import type { SignerFlags, SignerKind } from '../types.js'
+import { enforceMaxAmount, pickAccept } from './policy.js'
 
 export interface PayFlags extends SignerFlags {
   url: string
@@ -146,53 +142,6 @@ function parsePaymentRequired(
   } catch (err) {
     throw new Malformed402Error(
       `failed to parse 402 payment-required: ${errorMessage(err)}`,
-    )
-  }
-}
-
-export function pickAccept(
-  accepts: PaymentRequirements[],
-  chainFilter: string | undefined,
-): PaymentRequirements {
-  if (accepts.length === 0) {
-    throw new Malformed402Error('402 response has no accepts[] entries')
-  }
-  if (!chainFilter) {
-    if (accepts.length > 1) {
-      throw new Malformed402Error(
-        `402 offers ${accepts.length} payment options; pass --chain <eip155:id> to pick one`,
-      )
-    }
-    return accepts[0]!
-  }
-
-  const match = accepts.find((a) => a.network === chainFilter)
-  if (!match) {
-    throw new Malformed402Error(
-      `no accepts[] entry matches --chain ${chainFilter}; offered: ${accepts.map((a) => a.network).join(', ')}`,
-    )
-  }
-  return match
-}
-
-export function enforceMaxAmount(
-  accept: PaymentRequirements,
-  maxAmount: string | undefined,
-): void {
-  if (!maxAmount) return
-  let amount: bigint
-  let max: bigint
-  try {
-    amount = BigInt(accept.amount)
-    max = BigInt(maxAmount)
-  } catch {
-    throw new MaxAmountExceededError(
-      `invalid amount comparison: accept.amount=${accept.amount}, max=${maxAmount}`,
-    )
-  }
-  if (amount > max) {
-    throw new MaxAmountExceededError(
-      `price ${amount} exceeds --max-amount ${max} (atomic units of ${accept.asset})`,
     )
   }
 }

--- a/packages/cli/src/pay/policy.ts
+++ b/packages/cli/src/pay/policy.ts
@@ -1,0 +1,60 @@
+import type { PaymentRequirements } from '@x402/core/types'
+import { Malformed402Error, MaxAmountExceededError } from '../errors.js'
+
+/**
+ * Pick a single `accepts[]` entry from a 402 response. Enforces the rule that
+ * when a merchant offers multiple options the caller must disambiguate with
+ * `--chain`.
+ */
+export function pickAccept(
+  accepts: PaymentRequirements[],
+  chainFilter: string | undefined,
+): PaymentRequirements {
+  if (accepts.length === 0) {
+    throw new Malformed402Error('402 response has no accepts[] entries')
+  }
+  if (!chainFilter) {
+    if (accepts.length > 1) {
+      throw new Malformed402Error(
+        `402 offers ${accepts.length} payment options; pass --chain <eip155:id> to pick one`,
+      )
+    }
+    return accepts[0]!
+  }
+
+  const match = accepts.find((a) => a.network === chainFilter)
+  if (!match) {
+    throw new Malformed402Error(
+      `no accepts[] entry matches --chain ${chainFilter}; offered: ${accepts
+        .map((a) => a.network)
+        .join(', ')}`,
+    )
+  }
+  return match
+}
+
+/**
+ * Guard against paying more than the caller authorized. Compares atomic token
+ * units as BigInt — both values are opaque strings on the wire.
+ */
+export function enforceMaxAmount(
+  accept: PaymentRequirements,
+  maxAmount: string | undefined,
+): void {
+  if (!maxAmount) return
+  let amount: bigint
+  let max: bigint
+  try {
+    amount = BigInt(accept.amount)
+    max = BigInt(maxAmount)
+  } catch {
+    throw new MaxAmountExceededError(
+      `invalid amount comparison: accept.amount=${accept.amount}, max=${maxAmount}`,
+    )
+  }
+  if (amount > max) {
+    throw new MaxAmountExceededError(
+      `price ${amount} exceeds --max-amount ${max} (atomic units of ${accept.asset})`,
+    )
+  }
+}

--- a/packages/cli/src/signers/error.ts
+++ b/packages/cli/src/signers/error.ts
@@ -1,0 +1,6 @@
+export class SignerResolutionError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'SignerResolutionError'
+  }
+}

--- a/packages/cli/src/signers/error.ts
+++ b/packages/cli/src/signers/error.ts
@@ -1,6 +1,8 @@
-export class SignerResolutionError extends Error {
+import { CliError } from '../errors.js'
+
+export class SignerResolutionError extends CliError {
   constructor(message: string) {
-    super(message)
+    super(message, 6)
     this.name = 'SignerResolutionError'
   }
 }

--- a/packages/cli/src/signers/index.ts
+++ b/packages/cli/src/signers/index.ts
@@ -1,0 +1,76 @@
+import type { ResolvedSigner, SignerFlags } from '../types.js'
+import { SignerResolutionError } from './error.js'
+import { resolveKeySigner } from './key.js'
+import { resolveModuleSigner } from './module.js'
+import { resolveRpcSigner } from './rpc.js'
+
+export { SignerResolutionError } from './error.js'
+
+/**
+ * Resolve exactly one signer source. Errors if zero or multiple sources are
+ * configured, or if any single source is partially configured. CLI flags take
+ * precedence over environment variables within each source.
+ */
+export async function resolveSigner(
+  flags: SignerFlags,
+): Promise<ResolvedSigner> {
+  const candidates: Array<{
+    name: string
+    run: () => Promise<ResolvedSigner | null> | ResolvedSigner | null
+  }> = [
+    { name: 'key', run: () => resolveKeySigner(flags) },
+    { name: 'rpc', run: () => resolveRpcSigner(flags) },
+    { name: 'module', run: () => resolveModuleSigner(flags) },
+  ]
+
+  const present: Array<{ name: string; run: () => unknown }> = []
+  for (const c of candidates) {
+    if (isSourcePresent(c.name, flags)) present.push(c)
+  }
+
+  if (present.length === 0) {
+    throw new SignerResolutionError(
+      [
+        'no signer configured — provide one of:',
+        '  --key <0x...>                 (or PRIVATE_KEY)',
+        '  --signer-url <url> --signer-address <0x...>',
+        '                                (or SIGNER_URL + SIGNER_ADDRESS)',
+        '  --signer-module <pkg-or-path> (or SIGNER_MODULE)',
+      ].join('\n'),
+    )
+  }
+
+  if (present.length > 1) {
+    throw new SignerResolutionError(
+      `multiple signer sources configured (${present
+        .map((p) => p.name)
+        .join(', ')}) — provide exactly one`,
+    )
+  }
+
+  const resolved = await present[0]!.run()
+  if (!resolved) {
+    throw new SignerResolutionError(
+      `${present[0]!.name} signer failed to resolve`,
+    )
+  }
+  return resolved as ResolvedSigner
+}
+
+function isSourcePresent(name: string, flags: SignerFlags): boolean {
+  switch (name) {
+    case 'key':
+      return Boolean(flags.key ?? process.env.PRIVATE_KEY)
+    case 'rpc':
+      return Boolean(
+        flags.signerUrl ??
+          process.env.SIGNER_URL ??
+          flags.signerAddress ??
+          process.env.SIGNER_ADDRESS,
+      )
+    case 'module':
+      return Boolean(flags.signerModule ?? process.env.SIGNER_MODULE)
+    default:
+      return false
+  }
+}

--- a/packages/cli/src/signers/key.ts
+++ b/packages/cli/src/signers/key.ts
@@ -1,0 +1,20 @@
+import { privateKeyToAccount } from 'viem/accounts'
+import type { ResolvedSigner, SignerFlags } from '../types.js'
+import { SignerResolutionError } from './error.js'
+
+const HEX_KEY = /^(0x)?[0-9a-fA-F]{64}$/
+
+export function resolveKeySigner(flags: SignerFlags): ResolvedSigner | null {
+  const raw = flags.key ?? process.env.PRIVATE_KEY
+  if (!raw) return null
+  if (!HEX_KEY.test(raw)) {
+    throw new SignerResolutionError(
+      'private key is not a valid 32-byte hex string',
+    )
+  }
+  const normalized = (raw.startsWith('0x') ? raw : `0x${raw}`) as `0x${string}`
+  return {
+    account: privateKeyToAccount(normalized),
+    kind: 'key',
+  }
+}

--- a/packages/cli/src/signers/module.ts
+++ b/packages/cli/src/signers/module.ts
@@ -1,0 +1,76 @@
+import { isAbsolute, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import type { Account } from 'viem'
+import type { ResolvedSigner, SignerFlags } from '../types.js'
+import { SignerResolutionError } from './error.js'
+
+/**
+ * Custom module signer. Loads a user-supplied module whose default export is
+ * `() => Promise<Account>`. Use this for SDK-only signers (Privy via
+ * `@privy-io/server-auth` `createViemAccount`, Coinbase CDP server wallets,
+ * Turnkey SDK, hardware-wallet wrappers, etc.). Keeps the CLI free of
+ * provider-specific dependencies.
+ */
+export async function resolveModuleSigner(
+  flags: SignerFlags,
+): Promise<ResolvedSigner | null> {
+  const spec = flags.signerModule ?? process.env.SIGNER_MODULE
+  if (!spec) return null
+
+  const specifier = await toImportSpecifier(spec)
+  let mod: Record<string, unknown>
+  try {
+    mod = (await import(specifier)) as Record<string, unknown>
+  } catch (err) {
+    throw new SignerResolutionError(
+      `failed to import signer module "${spec}": ${errorMessage(err)}`,
+    )
+  }
+
+  const factory = mod.default
+  if (typeof factory !== 'function') {
+    throw new SignerResolutionError(
+      `signer module "${spec}" must export a default function returning a viem Account`,
+    )
+  }
+
+  let account: unknown
+  try {
+    account = await (factory as () => unknown)()
+  } catch (err) {
+    throw new SignerResolutionError(
+      `signer module "${spec}" factory threw: ${errorMessage(err)}`,
+    )
+  }
+
+  if (!isAccount(account)) {
+    throw new SignerResolutionError(
+      `signer module "${spec}" returned a value that is not a viem Account (missing address or signTypedData)`,
+    )
+  }
+
+  return { account, kind: 'module' }
+}
+
+async function toImportSpecifier(spec: string): Promise<string> {
+  // Bare package specifiers (e.g., "@my/signer") are passed through;
+  // relative/absolute paths are resolved to a file URL so Node can import them.
+  if (spec.startsWith('.') || isAbsolute(spec)) {
+    return pathToFileURL(resolve(process.cwd(), spec)).href
+  }
+  return spec
+}
+
+function isAccount(value: unknown): value is Account {
+  if (!value || typeof value !== 'object') return false
+  const a = value as Record<string, unknown>
+  return (
+    typeof a.address === 'string' &&
+    /^0x[0-9a-fA-F]{40}$/.test(a.address) &&
+    typeof a.signTypedData === 'function'
+  )
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err)
+}

--- a/packages/cli/src/signers/module.ts
+++ b/packages/cli/src/signers/module.ts
@@ -1,6 +1,7 @@
 import { isAbsolute, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import type { Account } from 'viem'
+import { isAddress } from 'viem'
 import type { ResolvedSigner, SignerFlags } from '../types.js'
 import { SignerResolutionError } from './error.js'
 
@@ -66,7 +67,7 @@ function isAccount(value: unknown): value is Account {
   const a = value as Record<string, unknown>
   return (
     typeof a.address === 'string' &&
-    /^0x[0-9a-fA-F]{40}$/.test(a.address) &&
+    isAddress(a.address, { strict: false }) &&
     typeof a.signTypedData === 'function'
   )
 }

--- a/packages/cli/src/signers/rpc.ts
+++ b/packages/cli/src/signers/rpc.ts
@@ -46,7 +46,13 @@ export function resolveRpcSigner(flags: SignerFlags): ResolvedSigner | null {
       )
     },
     async signTypedData(typedData) {
-      const json = JSON.stringify(typedData)
+      // EIP-3009 payloads carry `value`, `validAfter`, and `validBefore` as
+      // BigInt. `JSON.stringify` throws on BigInt by default, so we coerce
+      // them to decimal strings (the encoding every `eth_signTypedData_v4`
+      // endpoint accepts for uint256 fields).
+      const json = JSON.stringify(typedData, (_key, value) =>
+        typeof value === 'bigint' ? value.toString() : value,
+      )
       return (await client.request({
         method: 'eth_signTypedData_v4',
         params: [addr, json],

--- a/packages/cli/src/signers/rpc.ts
+++ b/packages/cli/src/signers/rpc.ts
@@ -1,0 +1,65 @@
+import type { Hex } from 'viem'
+import { createClient, http } from 'viem'
+import { toAccount } from 'viem/accounts'
+import type { ResolvedSigner, SignerFlags } from '../types.js'
+import { SignerResolutionError } from './error.js'
+
+const ADDRESS = /^0x[0-9a-fA-F]{40}$/
+
+/**
+ * Remote JSON-RPC signer. Delegates EIP-712 signing to any endpoint speaking
+ * `eth_signTypedData_v4` (Privy wallet RPC, Turnkey, Fireblocks, Safe, a local
+ * `cast wallet` endpoint, etc.). Payments only need typed-data signatures, so
+ * raw tx signing is intentionally omitted.
+ */
+export function resolveRpcSigner(flags: SignerFlags): ResolvedSigner | null {
+  const url = flags.signerUrl ?? process.env.SIGNER_URL
+  const address = flags.signerAddress ?? process.env.SIGNER_ADDRESS
+  if (!url && !address) return null
+  if (!url || !address) {
+    throw new SignerResolutionError(
+      'remote RPC signer requires both --signer-url/SIGNER_URL and --signer-address/SIGNER_ADDRESS',
+    )
+  }
+  if (!ADDRESS.test(address)) {
+    throw new SignerResolutionError(
+      'remote signer address is not a valid 0x-prefixed 20-byte hex',
+    )
+  }
+
+  const client = createClient({ transport: http(url) })
+  const addr = address as `0x${string}`
+
+  const account = toAccount({
+    address: addr,
+    async signMessage({ message }) {
+      const data =
+        typeof message === 'string' ? toHex(message) : (message.raw as Hex)
+      return (await client.request({
+        method: 'personal_sign',
+        params: [data, addr],
+      } as never)) as Hex
+    },
+    async signTransaction() {
+      throw new SignerResolutionError(
+        'remote RPC signer does not support raw transaction signing; x402r only needs typed-data',
+      )
+    },
+    async signTypedData(typedData) {
+      const json = JSON.stringify(typedData)
+      return (await client.request({
+        method: 'eth_signTypedData_v4',
+        params: [addr, json],
+      } as never)) as Hex
+    },
+  })
+
+  return { account, kind: 'rpc' }
+}
+
+function toHex(value: string): Hex {
+  const bytes = new TextEncoder().encode(value)
+  let out = '0x'
+  for (const b of bytes) out += b.toString(16).padStart(2, '0')
+  return out as Hex
+}

--- a/packages/cli/src/signers/rpc.ts
+++ b/packages/cli/src/signers/rpc.ts
@@ -1,10 +1,8 @@
 import type { Hex } from 'viem'
-import { createClient, http } from 'viem'
+import { createClient, http, isAddress, stringToHex } from 'viem'
 import { toAccount } from 'viem/accounts'
 import type { ResolvedSigner, SignerFlags } from '../types.js'
 import { SignerResolutionError } from './error.js'
-
-const ADDRESS = /^0x[0-9a-fA-F]{40}$/
 
 /**
  * Remote JSON-RPC signer. Delegates EIP-712 signing to any endpoint speaking
@@ -21,7 +19,7 @@ export function resolveRpcSigner(flags: SignerFlags): ResolvedSigner | null {
       'remote RPC signer requires both --signer-url/SIGNER_URL and --signer-address/SIGNER_ADDRESS',
     )
   }
-  if (!ADDRESS.test(address)) {
+  if (!isAddress(address, { strict: false })) {
     throw new SignerResolutionError(
       'remote signer address is not a valid 0x-prefixed 20-byte hex',
     )
@@ -34,7 +32,9 @@ export function resolveRpcSigner(flags: SignerFlags): ResolvedSigner | null {
     address: addr,
     async signMessage({ message }) {
       const data =
-        typeof message === 'string' ? toHex(message) : (message.raw as Hex)
+        typeof message === 'string'
+          ? stringToHex(message)
+          : (message.raw as Hex)
       return (await client.request({
         method: 'personal_sign',
         params: [data, addr],
@@ -61,11 +61,4 @@ export function resolveRpcSigner(flags: SignerFlags): ResolvedSigner | null {
   })
 
   return { account, kind: 'rpc' }
-}
-
-function toHex(value: string): Hex {
-  const bytes = new TextEncoder().encode(value)
-  let out = '0x'
-  for (const b of bytes) out += b.toString(16).padStart(2, '0')
-  return out as Hex
 }

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,17 @@
+import type { Account } from 'viem'
+
+export type SignerKind = 'key' | 'rpc' | 'module'
+
+export interface ResolvedSigner {
+  account: Account
+  kind: SignerKind
+}
+
+export interface SignerFlags {
+  key?: string
+  signerUrl?: string
+  signerAddress?: string
+  signerModule?: string
+}
+
+export type SignerFactory = (flags: SignerFlags) => Promise<ResolvedSigner>

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -13,5 +13,3 @@ export interface SignerFlags {
   signerAddress?: string
   signerModule?: string
 }
-
-export type SignerFactory = (flags: SignerFlags) => Promise<ResolvedSigner>

--- a/packages/cli/tests/chain.test.ts
+++ b/packages/cli/tests/chain.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { parseChainId, resolveChain } from '../src/chain.js'
+import { Malformed402Error } from '../src/errors.js'
+
+describe('parseChainId', () => {
+  it('parses eip155 network strings', () => {
+    expect(parseChainId('eip155:84532')).toBe(84532)
+    expect(parseChainId('eip155:8453')).toBe(8453)
+  })
+
+  it('rejects non-eip155 namespaces', () => {
+    expect(() => parseChainId('solana:mainnet')).toThrow(Malformed402Error)
+    expect(() => parseChainId('cosmos:cosmoshub-4')).toThrow(Malformed402Error)
+  })
+
+  it('rejects malformed strings', () => {
+    expect(() => parseChainId('eip155:')).toThrow(Malformed402Error)
+    expect(() => parseChainId('eip155:abc')).toThrow(Malformed402Error)
+    expect(() => parseChainId('8453')).toThrow(Malformed402Error)
+  })
+})
+
+describe('resolveChain', () => {
+  it('returns a known viem chain', () => {
+    const chain = resolveChain(84532)
+    expect(chain.id).toBe(84532)
+    expect(chain.name.toLowerCase()).toContain('base sepolia')
+  })
+
+  it('overrides rpcUrls when --rpc is passed', () => {
+    const chain = resolveChain(84532, 'https://example.rpc')
+    expect(chain.rpcUrls.default.http[0]).toBe('https://example.rpc')
+  })
+
+  it('synthesizes an unknown chain when --rpc is provided', () => {
+    const chain = resolveChain(999999, 'https://example.rpc')
+    expect(chain.id).toBe(999999)
+    expect(chain.rpcUrls.default.http[0]).toBe('https://example.rpc')
+  })
+
+  it('rejects an unknown chain without --rpc', () => {
+    expect(() => resolveChain(999999)).toThrow(Malformed402Error)
+  })
+})

--- a/packages/cli/tests/helpers.test.ts
+++ b/packages/cli/tests/helpers.test.ts
@@ -1,7 +1,7 @@
 import type { PaymentRequirements } from '@x402/core/types'
 import { describe, expect, it } from 'vitest'
 import { Malformed402Error, MaxAmountExceededError } from '../src/errors.js'
-import { enforceMaxAmount, pickAccept } from '../src/pay.js'
+import { enforceMaxAmount, pickAccept } from '../src/pay/policy.js'
 
 const USDC = '0x036CbD53842c5426634e7929541eC2318f3dCF7e'
 

--- a/packages/cli/tests/helpers.test.ts
+++ b/packages/cli/tests/helpers.test.ts
@@ -1,0 +1,87 @@
+import type { PaymentRequirements } from '@x402/core/types'
+import { describe, expect, it } from 'vitest'
+import { Malformed402Error, MaxAmountExceededError } from '../src/errors.js'
+import { enforceMaxAmount, pickAccept } from '../src/pay.js'
+
+const USDC = '0x036CbD53842c5426634e7929541eC2318f3dCF7e'
+
+function accept(
+  network: string,
+  amount = '10000',
+  asset = USDC,
+): PaymentRequirements {
+  return {
+    scheme: 'escrow',
+    network: network as PaymentRequirements['network'],
+    asset,
+    amount,
+    payTo: '0x0000000000000000000000000000000000000001',
+    maxTimeoutSeconds: 60,
+    extra: {},
+  }
+}
+
+describe('pickAccept', () => {
+  it('returns the sole accept when no --chain is passed', () => {
+    const a = accept('eip155:84532')
+    expect(pickAccept([a], undefined)).toBe(a)
+  })
+
+  it('returns the matching accept when --chain is passed', () => {
+    const a = accept('eip155:84532')
+    const b = accept('eip155:8453')
+    expect(pickAccept([a, b], 'eip155:8453')).toBe(b)
+  })
+
+  it('throws on empty accepts[]', () => {
+    expect(() => pickAccept([], undefined)).toThrow(Malformed402Error)
+  })
+
+  it('throws when multiple accepts[] and no --chain filter', () => {
+    const a = accept('eip155:84532')
+    const b = accept('eip155:8453')
+    expect(() => pickAccept([a, b], undefined)).toThrow(
+      /pass --chain <eip155:id>/,
+    )
+  })
+
+  it('throws when --chain matches none of the accepts', () => {
+    const a = accept('eip155:84532')
+    const b = accept('eip155:8453')
+    expect(() => pickAccept([a, b], 'eip155:1')).toThrow(
+      /no accepts\[\] entry matches --chain eip155:1/,
+    )
+  })
+})
+
+describe('enforceMaxAmount', () => {
+  it('is a no-op when --max-amount is undefined', () => {
+    expect(() =>
+      enforceMaxAmount(accept('eip155:84532'), undefined),
+    ).not.toThrow()
+  })
+
+  it('passes when price is below max', () => {
+    expect(() =>
+      enforceMaxAmount(accept('eip155:84532', '5000'), '10000'),
+    ).not.toThrow()
+  })
+
+  it('passes when price equals max', () => {
+    expect(() =>
+      enforceMaxAmount(accept('eip155:84532', '10000'), '10000'),
+    ).not.toThrow()
+  })
+
+  it('throws when price exceeds max', () => {
+    expect(() =>
+      enforceMaxAmount(accept('eip155:84532', '10001'), '10000'),
+    ).toThrow(MaxAmountExceededError)
+  })
+
+  it('throws on non-numeric amount values', () => {
+    expect(() =>
+      enforceMaxAmount(accept('eip155:84532', 'not-a-number'), '10000'),
+    ).toThrow(MaxAmountExceededError)
+  })
+})

--- a/packages/cli/tests/pay.test.ts
+++ b/packages/cli/tests/pay.test.ts
@@ -2,7 +2,7 @@ import { encodePaymentRequiredHeader } from '@x402/core/http'
 import type { PaymentRequired, PaymentRequirements } from '@x402/core/types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { Malformed402Error, MaxAmountExceededError } from '../src/errors.js'
-import { pay } from '../src/pay.js'
+import { pay } from '../src/pay/index.js'
 
 const USDC = '0x036CbD53842c5426634e7929541eC2318f3dCF7e'
 const KEY = `0x${'1'.repeat(64)}`

--- a/packages/cli/tests/pay.test.ts
+++ b/packages/cli/tests/pay.test.ts
@@ -1,0 +1,125 @@
+import { encodePaymentRequiredHeader } from '@x402/core/http'
+import type { PaymentRequired, PaymentRequirements } from '@x402/core/types'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Malformed402Error, MaxAmountExceededError } from '../src/errors.js'
+import { pay } from '../src/pay.js'
+
+const USDC = '0x036CbD53842c5426634e7929541eC2318f3dCF7e'
+const KEY = `0x${'1'.repeat(64)}`
+const URL = 'https://merchant.example/paid'
+
+function accept(
+  network: string,
+  amount = '10000',
+  asset = USDC,
+): PaymentRequirements {
+  return {
+    scheme: 'escrow',
+    network: network as PaymentRequirements['network'],
+    asset,
+    amount,
+    payTo: '0x0000000000000000000000000000000000000001',
+    maxTimeoutSeconds: 60,
+    extra: {},
+  }
+}
+
+function pr(accepts: PaymentRequirements[]): PaymentRequired {
+  return {
+    x402Version: 2,
+    resource: { url: URL },
+    accepts,
+  }
+}
+
+function respond402(requirements: PaymentRequired): Response {
+  const header = encodePaymentRequiredHeader(requirements)
+  return new Response(null, {
+    status: 402,
+    headers: { 'PAYMENT-REQUIRED': header },
+  })
+}
+
+function respond200(body: string): Response {
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('pay()', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    delete process.env.PRIVATE_KEY
+  })
+
+  afterEach(() => {
+    fetchSpy?.mockRestore()
+  })
+
+  it('short-circuits when the URL returns non-402', async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(respond200('{"ok":true}'))
+
+    const result = await pay({ url: URL, key: KEY })
+
+    expect(result.status).toBe(200)
+    expect(result.body).toBe('{"ok":true}')
+    expect(result.signer).toBeUndefined()
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws Malformed402Error when the 402 has no accepts[]', async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(respond402(pr([])))
+
+    await expect(pay({ url: URL, key: KEY })).rejects.toBeInstanceOf(
+      Malformed402Error,
+    )
+  })
+
+  it('throws Malformed402Error when the 402 has no PAYMENT-REQUIRED header or body', async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(new Response(null, { status: 402 }))
+
+    await expect(pay({ url: URL, key: KEY })).rejects.toBeInstanceOf(
+      Malformed402Error,
+    )
+  })
+
+  it('throws MaxAmountExceededError when the 402 price exceeds --max-amount', async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(respond402(pr([accept('eip155:84532', '20000')])))
+
+    await expect(
+      pay({ url: URL, key: KEY, maxAmount: '10000' }),
+    ).rejects.toBeInstanceOf(MaxAmountExceededError)
+  })
+
+  it('throws Malformed402Error when accepts[] has multiple entries and no --chain', async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(
+        respond402(pr([accept('eip155:84532'), accept('eip155:8453')])),
+      )
+
+    await expect(pay({ url: URL, key: KEY })).rejects.toThrow(
+      /pass --chain <eip155:id>/,
+    )
+  })
+
+  it('does not hit fetch a second time when the short-circuit path is taken', async () => {
+    fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockResolvedValue(respond200('free content'))
+
+    await pay({ url: URL, key: KEY })
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/cli/tests/signers.test.ts
+++ b/packages/cli/tests/signers.test.ts
@@ -1,0 +1,128 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { resolveSigner, SignerResolutionError } from '../src/signers/index.js'
+
+const KEY_ENVS = [
+  'PRIVATE_KEY',
+  'SIGNER_URL',
+  'SIGNER_ADDRESS',
+  'SIGNER_MODULE',
+]
+
+function clearEnv() {
+  for (const k of KEY_ENVS) delete process.env[k]
+}
+
+describe('resolveSigner', () => {
+  beforeEach(clearEnv)
+  afterEach(clearEnv)
+
+  it('errors when nothing is configured', async () => {
+    await expect(resolveSigner({})).rejects.toBeInstanceOf(
+      SignerResolutionError,
+    )
+  })
+
+  it('errors when multiple sources are configured', async () => {
+    await expect(
+      resolveSigner({
+        key: `0x${'a'.repeat(64)}`,
+        signerModule: 'some-pkg',
+      }),
+    ).rejects.toThrow(/multiple signer sources/i)
+  })
+
+  it('errors when RPC signer is partially configured (url only)', async () => {
+    await expect(
+      resolveSigner({ signerUrl: 'https://signer.example' }),
+    ).rejects.toThrow(/signer-url.*signer-address/i)
+  })
+
+  it('errors when RPC signer is partially configured (address only)', async () => {
+    await expect(
+      resolveSigner({ signerAddress: `0x${'a'.repeat(40)}` }),
+    ).rejects.toThrow(/signer-url.*signer-address/i)
+  })
+
+  it('resolves a raw-key signer from a flag', async () => {
+    const key = `0x${'a'.repeat(64)}`
+    const out = await resolveSigner({ key })
+    expect(out.kind).toBe('key')
+    expect(out.account.address).toMatch(/^0x[0-9a-fA-F]{40}$/)
+  })
+
+  it('falls back to PRIVATE_KEY env', async () => {
+    process.env.PRIVATE_KEY = `0x${'b'.repeat(64)}`
+    const out = await resolveSigner({})
+    expect(out.kind).toBe('key')
+  })
+
+  it('rejects a malformed private key', async () => {
+    await expect(resolveSigner({ key: '0xdeadbeef' })).rejects.toThrow(
+      /valid 32-byte hex/,
+    )
+  })
+
+  it('resolves an RPC signer (account has signTypedData)', async () => {
+    const out = await resolveSigner({
+      signerUrl: 'https://signer.example/rpc',
+      signerAddress: `0x${'c'.repeat(40)}`,
+    })
+    expect(out.kind).toBe('rpc')
+    expect(out.account.address.toLowerCase()).toBe(`0x${'c'.repeat(40)}`)
+    expect(typeof out.account.signTypedData).toBe('function')
+  })
+
+  it('resolves a custom module signer', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'x402r-cli-test-'))
+    const modPath = join(dir, 'signer.mjs')
+    const addr = `0x${'d'.repeat(40)}`
+    writeFileSync(
+      modPath,
+      `export default async function () {
+        return {
+          address: '${addr}',
+          signTypedData: async () => '0x' + '0'.repeat(130),
+        }
+      }`,
+    )
+    try {
+      const out = await resolveSigner({ signerModule: modPath })
+      expect(out.kind).toBe('module')
+      expect(out.account.address.toLowerCase()).toBe(addr)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a module that returns a non-account', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'x402r-cli-test-'))
+    const modPath = join(dir, 'bad.mjs')
+    writeFileSync(
+      modPath,
+      `export default async function () { return { not: 'an account' } }`,
+    )
+    try {
+      await expect(resolveSigner({ signerModule: modPath })).rejects.toThrow(
+        /not a viem Account/,
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a module with no default export', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'x402r-cli-test-'))
+    const modPath = join(dir, 'nodefault.mjs')
+    writeFileSync(modPath, `export const name = 'nope'`)
+    try {
+      await expect(resolveSigner({ signerModule: modPath })).rejects.toThrow(
+        /default function/,
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/cli/tests/signers.test.ts
+++ b/packages/cli/tests/signers.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { resolveSigner, SignerResolutionError } from '../src/signers/index.js'
 
 const KEY_ENVS = [
@@ -73,6 +73,73 @@ describe('resolveSigner', () => {
     expect(out.kind).toBe('rpc')
     expect(out.account.address.toLowerCase()).toBe(`0x${'c'.repeat(40)}`)
     expect(typeof out.account.signTypedData).toBe('function')
+  })
+
+  it('RPC signer signTypedData serializes EIP-3009 BigInt fields as decimal strings', async () => {
+    const addr = `0x${'c'.repeat(40)}` as `0x${string}`
+    const expectedSig = `0x${'e'.repeat(130)}` as `0x${string}`
+    let rpcBody: { method: string; params: unknown[] } | undefined
+
+    const fetchSpy = vi
+      .spyOn(globalThis, 'fetch')
+      .mockImplementation(async (_input, init) => {
+        rpcBody = JSON.parse((init?.body as string) ?? '{}')
+        return new Response(
+          JSON.stringify({ jsonrpc: '2.0', id: 1, result: expectedSig }),
+          { headers: { 'content-type': 'application/json' } },
+        )
+      })
+
+    try {
+      const out = await resolveSigner({
+        signerUrl: 'https://signer.example/rpc',
+        signerAddress: addr,
+      })
+
+      // Mirrors EIP-3009 TransferWithAuthorization: `value`, `validAfter`,
+      // `validBefore` are uint256 BigInts in viem's typed-data shape.
+      const sig = await out.account.signTypedData({
+        domain: {
+          name: 'USD Coin',
+          version: '2',
+          chainId: 84532,
+          verifyingContract: `0x${'a'.repeat(40)}` as `0x${string}`,
+        },
+        types: {
+          TransferWithAuthorization: [
+            { name: 'from', type: 'address' },
+            { name: 'to', type: 'address' },
+            { name: 'value', type: 'uint256' },
+            { name: 'validAfter', type: 'uint256' },
+            { name: 'validBefore', type: 'uint256' },
+            { name: 'nonce', type: 'bytes32' },
+          ],
+        },
+        primaryType: 'TransferWithAuthorization',
+        message: {
+          from: addr,
+          to: `0x${'b'.repeat(40)}` as `0x${string}`,
+          value: 10_000n,
+          validAfter: 0n,
+          validBefore: 1_999_999_999n,
+          nonce: `0x${'f'.repeat(64)}` as `0x${string}`,
+        },
+      })
+
+      expect(sig).toBe(expectedSig)
+      expect(rpcBody?.method).toBe('eth_signTypedData_v4')
+
+      const [sigAddr, payload] = rpcBody?.params as [string, string]
+      expect(sigAddr.toLowerCase()).toBe(addr.toLowerCase())
+      expect(typeof payload).toBe('string')
+
+      const parsed = JSON.parse(payload)
+      expect(parsed.message.value).toBe('10000')
+      expect(parsed.message.validAfter).toBe('0')
+      expect(parsed.message.validBefore).toBe('1999999999')
+    } finally {
+      fetchSpy.mockRestore()
+    }
   })
 
   it('resolves a custom module signer', async () => {

--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["tests"],
+  "compilerOptions": {
+    "outDir": "dist",
+    "lib": ["ES2022", "DOM"]
+  }
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.build.json",
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: {
+    index: 'src/index.ts',
+    bin: 'src/bin.ts',
+  },
+  format: ['esm'],
+  dts: true,
+  sourcemap: true,
+  clean: true,
+})

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
       provider: 'v8',
       reporter: [process.env.CI ? 'lcov' : 'text', 'json', 'html'],
       include: ['src/**/*.ts'],
-      exclude: ['src/**/index.ts', 'src/bin.ts'],
+      exclude: ['src/index.ts', 'src/bin.ts'],
     },
   },
 })

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'cli',
+    include: ['tests/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: [process.env.CI ? 'lcov' : 'text', 'json', 'html'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/**/index.ts', 'src/bin.ts'],
+    },
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,15 +83,34 @@ importers:
         specifier: ^22.12.0
         version: 22.19.15
 
+  packages/cli:
+    dependencies:
+      '@x402/core':
+        specifier: ^2.5.0
+        version: 2.5.0
+      '@x402/evm':
+        specifier: ^2.5.0
+        version: 2.5.0(ethers@6.16.0)(typescript@5.9.3)
+      '@x402r/evm':
+        specifier: ^0.1.0
+        version: 0.1.0(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))
+      viem:
+        specifier: ^2.46.3
+        version: 2.47.1(typescript@5.9.3)(zod@4.3.6)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.0.0
+        version: 20.19.39
+
   packages/core:
     dependencies:
       viem:
         specifier: ^2.46.3
-        version: 2.47.1(typescript@5.9.3)(zod@3.25.76)
+        version: 2.47.1(typescript@5.9.3)(zod@4.3.6)
     devDependencies:
       '@x402r/evm':
         specifier: 0.0.3
-        version: 0.0.3(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@3.25.76))
+        version: 0.0.3(@x402/core@2.10.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))
       prool:
         specifier: ^0.2.3
         version: 0.2.3
@@ -100,7 +119,7 @@ importers:
     dependencies:
       '@x402r/core':
         specifier: ^0.2.0
-        version: 0.2.0(@x402r/evm@0.0.3(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(zod@4.3.6)
+        version: 0.2.0(@x402r/evm@0.1.0(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(zod@4.3.6)
     devDependencies:
       '@x402/core':
         specifier: 2.5.0
@@ -110,7 +129,7 @@ importers:
     dependencies:
       '@x402r/core':
         specifier: ^0.2.0
-        version: 0.2.0(@x402r/evm@0.0.3(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(zod@4.3.6)
+        version: 0.2.0(@x402r/evm@0.1.0(@x402/core@2.10.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(zod@4.3.6)
       '@x402r/erc8004':
         specifier: ^0.1.0-alpha.1
         version: 0.1.0-alpha.1(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))
@@ -1072,6 +1091,9 @@ packages:
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
 
+  '@types/node@20.19.39':
+    resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
+
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
@@ -1125,6 +1147,9 @@ packages:
       typescript:
         optional: true
 
+  '@x402/core@2.10.0':
+    resolution: {integrity: sha512-n9Exnt1HN4LFaINaPYhk6Cy3ICBt0e46XN1Uo5i6efIZfIoqP6pY8ONSX/M9bU4F1fpvMj0JZ3xdcBZCiGInfw==}
+
   '@x402/core@2.5.0':
     resolution: {integrity: sha512-nUr8HW8WhkU1DvrpUfsRvALy5NF8UWKoFezZOtX61mohxp2lWZpJ2GnvscxDM8nmBAbtIollmksd5z5pj8InXw==}
 
@@ -1150,6 +1175,13 @@ packages:
 
   '@x402r/evm@0.0.3':
     resolution: {integrity: sha512-b8sEZ5VTRpVdy/kxCgZFW1YVQvmZCUpRa7x4tdpoDZPZQannnlJn0haNF2Bxsl2jVhLzLXBCjOrTKKBCy/lQ1g==}
+    peerDependencies:
+      '@x402/core': ^2.4.0
+      '@x402/evm': ^2.0.0
+      viem: ^2.0.0
+
+  '@x402r/evm@0.1.0':
+    resolution: {integrity: sha512-/AZU3jqfCcRoDpPxUwpRy40tucLjZG+lYLD14dlHkv8QEIs456XMEc35VNrj02pMlhao4FK352+GmRzWZXJzHw==}
     peerDependencies:
       '@x402/core': ^2.4.0
       '@x402/evm': ^2.0.0
@@ -3200,6 +3232,10 @@ snapshots:
 
   '@types/node@12.20.55': {}
 
+  '@types/node@20.19.39':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@22.19.15':
     dependencies:
       undici-types: 6.21.0
@@ -3287,6 +3323,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  '@x402/core@2.10.0':
+    dependencies:
+      zod: 3.25.76
+
   '@x402/core@2.5.0':
     dependencies:
       zod: 3.25.76
@@ -3318,11 +3358,22 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402r/core@0.2.0(@x402r/evm@0.0.3(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(zod@4.3.6)':
+  '@x402r/core@0.2.0(@x402r/evm@0.1.0(@x402/core@2.10.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(zod@4.3.6)':
     dependencies:
       viem: 2.47.1(typescript@5.9.3)(zod@4.3.6)
     optionalDependencies:
-      '@x402r/evm': 0.0.3(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))
+      '@x402r/evm': 0.1.0(@x402/core@2.10.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+      - zod
+
+  '@x402r/core@0.2.0(@x402r/evm@0.1.0(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6)))(typescript@5.9.3)(zod@4.3.6)':
+    dependencies:
+      viem: 2.47.1(typescript@5.9.3)(zod@4.3.6)
+    optionalDependencies:
+      '@x402r/evm': 0.1.0(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -3333,18 +3384,24 @@ snapshots:
     dependencies:
       viem: 2.47.1(typescript@5.9.3)(zod@4.3.6)
 
-  '@x402r/evm@0.0.3(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@3.25.76))':
+  '@x402r/evm@0.0.3(@x402/core@2.10.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
-      '@x402/core': 2.5.0
+      '@x402/core': 2.10.0
       '@x402/evm': 2.5.0(ethers@6.16.0)(typescript@5.9.3)
-      viem: 2.47.1(typescript@5.9.3)(zod@3.25.76)
+      viem: 2.47.1(typescript@5.9.3)(zod@4.3.6)
 
-  '@x402r/evm@0.0.3(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))':
+  '@x402r/evm@0.1.0(@x402/core@2.10.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))':
+    dependencies:
+      '@x402/core': 2.10.0
+      '@x402/evm': 2.5.0(ethers@6.16.0)(typescript@5.9.3)
+      viem: 2.47.1(typescript@5.9.3)(zod@4.3.6)
+    optional: true
+
+  '@x402r/evm@0.1.0(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
       '@x402/core': 2.5.0
       '@x402/evm': 2.5.0(ethers@6.16.0)(typescript@5.9.3)
       viem: 2.47.1(typescript@5.9.3)(zod@4.3.6)
-    optional: true
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:


### PR DESCRIPTION
Closes #113.

## Summary

- Adds `packages/cli/` publishing as `@x402r/cli@0.2.0`, reclaiming the namespace from the abandoned `0.1.2` (lives in `x402r-arbiter-eigencloud/`).
- Thin wrapper around `@x402r/sdk` + `@x402r/evm@^0.1.0` (commerce scheme). One subcommand: `pay <url>`.
- Wallet-agnostic signer layer: three sources (raw key, remote JSON-RPC, custom module), exactly-one rule, CLI flag > env var. Zero runtime deps on provider SDKs (Privy, CDP, Turnkey, etc.) — those wire in via the `--signer-module` escape hatch.
- Env fallbacks are unprefixed (`PRIVATE_KEY`, `SIGNER_URL`, `SIGNER_ADDRESS`, `SIGNER_MODULE`) to match Foundry/Hardhat/x402-reference convention.
- Exit codes 0–6 are agent-parseable. `--json` emits a single envelope (body, tx, elapsed, signer metadata) to stdout.
- Chain auto-detected from 402 `accepts[].network`; `--chain` needed only when a merchant offers multiple options. `--rpc` overrides the public RPC for unknown chains.

## Follow-ups (not in this PR)

- Publish `@x402r/cli@0.2.0` to npm and `npm deprecate @x402r/cli@0.1.2` pointing at it.
- Update `EigenAI-Garbage-Detector/demo/client.ts` to use `pay()` programmatically (done in a separate commit in that repo since it's outside this monorepo).
- Future subcommands (`dispute`, `evidence`, `verify`) and `--arbiter-module` plugin pattern (tracked in #113 under Future directions).

## Test plan

- [x] `pnpm build` — green (all 4 packages)
- [x] `pnpm typecheck` — green (all 4 packages)
- [x] `pnpm --filter @x402r/cli test` — 18/18 passing (signer resolution, chain parsing)
- [x] `biome check packages/cli` — clean
- [x] Built binary smoke test: `node dist/bin.js --help` and `node dist/bin.js pay https://example.com` (non-402 short-circuit) return cleanly with exit 0
- [ ] End-to-end against Base Sepolia merchant (garbage-detector demo) — requires live merchant + testnet funds; manual step before publish
- [ ] Remote-RPC signer E2E against anvil — manual step before publish
- [ ] Custom-module signer E2E (Privy, CDP examples in README) — manual step before publish

Note: `@x402r/core` tests have pre-existing ECONNREFUSED failures on port 8745 (fork tests needing anvil); unrelated to this PR.