### PR TITLE
readme: drop pre-stable warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 TypeScript SDK for x402r refundable payments on EVM chains.
 
-> **Not production-ready.** Packages are not yet published to npm. Expect breaking changes.
-
 ## Packages
 
 | Package | Description |


### PR DESCRIPTION
## Summary
- Removes the "Not production-ready / not yet published to npm" warning from the top-level README.
- Packages are published: `@x402r/sdk@0.2.1`, `@x402r/core@0.2.0`, `@x402r/helpers@0.2.1`.

## Test plan
- [x] `pnpm check` (biome) — passes via pre-commit hook
- [x] `pnpm build` — passes via pre-commit hook
- [x] `pnpm typecheck` — passes via pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)