### PR TITLE
CI: fold scenario:dispute + scenario:permit2-charge into test-fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,12 +109,12 @@ jobs:
       - name: Run CI scenarios (dispute + permit2)
         uses: nick-fields/retry@v3
         with:
+          # Retry guards against public Base Sepolia RPC flake on the upstream
+          # fork. Port-collision band-aid is no longer needed: the orchestrator
+          # at examples/scripts/scenarios-ci.ts runs ONE prool with per-scenario
+          # URL subpaths, so retries don't race a TIME_WAIT port.
           timeout_minutes: 5
           max_attempts: 2
-          # Wait between attempts to avoid anvil port-reuse collisions.
-          # TODO: derive ANVIL_PORT from VITEST_POOL_ID / process.pid in
-          # examples/shared/anvil-setup.ts so retries get a fresh port.
-          retry_wait_seconds: 10
           command: pnpm scenarios:ci
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     # Fork tests do not contribute to code coverage (no --coverage flag).
     # They validate on-chain integration via Anvil forks.
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - name: Install Foundry
@@ -106,6 +106,12 @@ jobs:
           timeout_minutes: 10
           max_attempts: 2
           command: pnpm test:fork
+      - name: Run CI scenarios (dispute + permit2)
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 5
+          max_attempts: 2
+          command: pnpm scenarios:ci
 
   build:
     name: Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
     # Fork tests do not contribute to code coverage (no --coverage flag).
     # They validate on-chain integration via Anvil forks.
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - name: Install Foundry
@@ -111,6 +111,10 @@ jobs:
         with:
           timeout_minutes: 5
           max_attempts: 2
+          # Wait between attempts to avoid anvil port-reuse collisions.
+          # TODO: derive ANVIL_PORT from VITEST_POOL_ID / process.pid in
+          # examples/shared/anvil-setup.ts so retries get a fresh port.
+          retry_wait_seconds: 10
           command: pnpm scenarios:ci
 
   build:

--- a/examples/scenarios/README.md
+++ b/examples/scenarios/README.md
@@ -27,7 +27,7 @@ Exercises the complete dispute flow:
 4. Both parties submit evidence
 5. Arbiter reviews evidence and approves refund
 6. Verify refund amounts
-7. Distribute protocol fees
+7. Verify zero protocol fees accrued
 
 ### atomic-charge
 

--- a/examples/scenarios/README.md
+++ b/examples/scenarios/README.md
@@ -22,7 +22,7 @@ Demonstrates the simplest payment lifecycle — merchant authorizes a payment, w
 
 Exercises the complete dispute flow:
 1. Deploy marketplace operator
-2. Authorize payment (HTTP 402 flow)
+2. Authorize payment via SDK viem flow
 3. Payer requests refund
 4. Both parties submit evidence
 5. Arbiter reviews evidence and approves refund

--- a/examples/scenarios/dispute-resolution.ts
+++ b/examples/scenarios/dispute-resolution.ts
@@ -35,9 +35,9 @@ async function main() {
     }
 
     // ================================================================
-    // Step 1: Authorize payment (HTTP 402 flow)
+    // Step 1: Authorize payment (direct SDK call)
     // ================================================================
-    runner.step('Authorize payment via HTTP 402 flow')
+    runner.step('Authorize payment via SDK viem flow')
 
     const payerAccount = privateKeyToAccount(PAYER_PRIVATE_KEY)
     const { collectorData, tokenCollector } = await signReceiveAuthorization({

--- a/examples/scenarios/dispute-resolution.ts
+++ b/examples/scenarios/dispute-resolution.ts
@@ -11,7 +11,7 @@ import { StepRunner } from './runner.js'
 // Flow: authorize → payer requests refund → payer + merchant submit evidence →
 //       arbiter reviews evidence → merchant executes voidPayment
 //       (hook approves automatically) → verify refund amounts →
-//       merchant distributes fees
+//       verify zero protocol fees accrue
 // ---------------------------------------------------------------------------
 
 async function main() {
@@ -191,9 +191,9 @@ async function main() {
     )
 
     // ================================================================
-    // Step 7: Distribute fees
+    // Step 7: Verify zero protocol fees accrued
     // ================================================================
-    runner.step('Merchant distributes protocol fees')
+    runner.step('Verify zero protocol fees accrued')
 
     const accumulatedFees =
       await ctx.merchant.operator.getAccumulatedProtocolFees(

--- a/examples/scenarios/dispute-resolution.ts
+++ b/examples/scenarios/dispute-resolution.ts
@@ -52,6 +52,15 @@ async function main() {
     // authorize collected zero tokens, before === after and delta === 0
     // either way.
     const payerBalanceBefore = await readBalance(ctx.accounts.payer)
+    // Snapshot receiver + feeReceiver too — under a full refund neither party
+    // should see a balance change. A non-zero delta on either would indicate
+    // tokens were misdirected (e.g. a future refactor accidentally routes a
+    // partial-fee path through a full-void). Catches regressions the
+    // payer-only snapshot would miss.
+    const receiverBalanceBefore = await readBalance(ctx.accounts.merchant)
+    const feeReceiverBalanceBefore = await readBalance(
+      ctx.paymentInfo.feeReceiver,
+    )
 
     // ================================================================
     // Step 1: Authorize payment (direct SDK call)
@@ -192,6 +201,23 @@ async function main() {
     runner.assert(
       payerDelta === 0n,
       `payer balance net-zero after full refund (authorized → refunded back); actual delta ${payerDelta}`,
+    )
+
+    // Receiver + feeReceiver must not have moved at all under a full refund.
+    // Distinct from the payer net-zero check above: payer can net-zero even if
+    // tokens were misrouted (e.g. paid out and then refunded back). These
+    // deltas pin the destinations explicitly.
+    const receiverBalanceAfter = await readBalance(ctx.accounts.merchant)
+    const feeReceiverBalanceAfter = await readBalance(
+      ctx.paymentInfo.feeReceiver,
+    )
+    runner.assert(
+      receiverBalanceAfter === receiverBalanceBefore,
+      `receiver balance unchanged under full refund; actual delta ${receiverBalanceAfter - receiverBalanceBefore}`,
+    )
+    runner.assert(
+      feeReceiverBalanceAfter === feeReceiverBalanceBefore,
+      `feeReceiver balance unchanged under full refund; actual delta ${feeReceiverBalanceAfter - feeReceiverBalanceBefore}`,
     )
 
     // ================================================================

--- a/examples/scenarios/dispute-resolution.ts
+++ b/examples/scenarios/dispute-resolution.ts
@@ -46,7 +46,11 @@ async function main() {
     // refund actually moved tokens. Under a full refund, the payer pays
     // PAYMENT_AMOUNT on authorize and receives PAYMENT_AMOUNT on refund, so
     // the net delta must be exactly 0. A non-zero delta means tokens never
-    // moved back (silent refund failure).
+    // moved back (silent refund failure). The `hasCollectedPayment` assertion
+    // at Step 1 (after authorize) is the load-bearing gate that prevents this
+    // delta check from vacuously passing on a silent authorize failure — if
+    // authorize collected zero tokens, before === after and delta === 0
+    // either way.
     const payerBalanceBefore = await readBalance(ctx.accounts.payer)
 
     // ================================================================

--- a/examples/scenarios/dispute-resolution.ts
+++ b/examples/scenarios/dispute-resolution.ts
@@ -34,6 +34,21 @@ async function main() {
       throw new Error('Evidence module not available')
     }
 
+    const readBalance = (owner: `0x${string}`) =>
+      ctx.publicClient.readContract({
+        address: ctx.paymentInfo.token,
+        abi: erc20Abi,
+        functionName: 'balanceOf',
+        args: [owner],
+      })
+
+    // Snapshot the payer's funded post-setup balance so Step 6 can assert the
+    // refund actually moved tokens. Under a full refund, the payer pays
+    // PAYMENT_AMOUNT on authorize and receives PAYMENT_AMOUNT on refund, so
+    // the net delta must be exactly 0. A non-zero delta means tokens never
+    // moved back (silent refund failure).
+    const payerBalanceBefore = await readBalance(ctx.accounts.payer)
+
     // ================================================================
     // Step 1: Authorize payment (direct SDK call)
     // ================================================================
@@ -162,13 +177,18 @@ async function main() {
       'Refundable amount === 0 after refund executed',
     )
 
-    const payerUsdcBalance = await ctx.publicClient.readContract({
-      address: ctx.paymentInfo.token,
-      abi: erc20Abi,
-      functionName: 'balanceOf',
-      args: [ctx.accounts.payer],
-    })
+    const payerUsdcBalance = await readBalance(ctx.accounts.payer)
     runner.log(`Payer USDC balance: ${payerUsdcBalance}`)
+
+    // Net-zero invariant: payer paid PAYMENT_AMOUNT on authorize and got
+    // PAYMENT_AMOUNT back on full refund. A delta of -PAYMENT_AMOUNT would
+    // indicate the refund silently failed to move tokens.
+    const payerBalanceAfter = await readBalance(ctx.accounts.payer)
+    const payerDelta = payerBalanceAfter - payerBalanceBefore
+    runner.assert(
+      payerDelta === 0n,
+      `payer balance net-zero after full refund (authorized → refunded back); actual delta ${payerDelta}`,
+    )
 
     // ================================================================
     // Step 7: Distribute fees
@@ -181,20 +201,13 @@ async function main() {
       )
     runner.log(`Accumulated protocol fees: ${accumulatedFees}`)
 
-    if (accumulatedFees > 0n) {
-      const feeTx = await ctx.merchant.operator.distributeFees(
-        ctx.paymentInfo.token,
-      )
-      await runner.waitForTx(feeTx)
-
-      const remainingFees =
-        await ctx.merchant.operator.getAccumulatedProtocolFees(
-          ctx.paymentInfo.token,
-        )
-      runner.assert(remainingFees === 0n, 'All protocol fees distributed')
-    } else {
-      runner.log('No fees to distribute (refund returned all funds)')
-    }
+    // A full refund returns 100% of escrow to the payer and collects zero
+    // protocol fees. Assert this explicitly — the previous
+    // `if (accumulatedFees > 0n)` branch was dead under this scenario.
+    runner.assert(
+      accumulatedFees === 0n,
+      `full refund collected zero protocol fees; actual ${accumulatedFees}`,
+    )
 
     runner.done()
   } finally {

--- a/examples/scenarios/dispute-resolution.ts
+++ b/examples/scenarios/dispute-resolution.ts
@@ -46,11 +46,7 @@ async function main() {
     // refund actually moved tokens. Under a full refund, the payer pays
     // PAYMENT_AMOUNT on authorize and receives PAYMENT_AMOUNT on refund, so
     // the net delta must be exactly 0. A non-zero delta means tokens never
-    // moved back (silent refund failure). The `hasCollectedPayment` assertion
-    // at Step 1 (after authorize) is the load-bearing gate that prevents this
-    // delta check from vacuously passing on a silent authorize failure — if
-    // authorize collected zero tokens, before === after and delta === 0
-    // either way.
+    // moved back (silent refund failure).
     const payerBalanceBefore = await readBalance(ctx.accounts.payer)
 
     // ================================================================

--- a/examples/scenarios/happy-path-capture.ts
+++ b/examples/scenarios/happy-path-capture.ts
@@ -34,8 +34,8 @@ async function main() {
     const receiverBefore = await readBalance(ctx.paymentInfo.receiver)
     const feeReceiverBefore = await readBalance(ctx.paymentInfo.feeReceiver)
 
-    // --- Step 1: Authorize payment (HTTP 402 flow) ---
-    runner.step('Authorize payment via HTTP 402 flow')
+    // --- Step 1: Authorize payment (direct SDK call) ---
+    runner.step('Authorize payment via SDK viem flow')
 
     const payerAccount = privateKeyToAccount(PAYER_PRIVATE_KEY)
     const { collectorData, tokenCollector } = await signReceiveAuthorization({

--- a/examples/scenarios/partial-refund-flow.ts
+++ b/examples/scenarios/partial-refund-flow.ts
@@ -26,7 +26,7 @@ async function main() {
   const runner = new StepRunner('Partial Refund Flow', ctx.publicClient)
 
   try {
-    runner.step('Authorize payment via HTTP 402 flow')
+    runner.step('Authorize payment via SDK viem flow')
 
     const payerAccount = privateKeyToAccount(PAYER_PRIVATE_KEY)
     const { collectorData, tokenCollector } = await signReceiveAuthorization({

--- a/examples/scenarios/permit2-charge.ts
+++ b/examples/scenarios/permit2-charge.ts
@@ -53,13 +53,11 @@ async function main() {
 
     const after = await ctx.publicClient.readContract(approvalParams)
     // Pin the post-condition the scenario actually needs: Permit2 has sufficient
-    // allowance to pull PAYMENT_AMOUNT. This asserts the contract invariant the
-    // upstream `charge` consumes (allowance >= amount) — robust against future
-    // changes to the approval helper, which today sets MAX_UINT256
-    // (packages/core/src/payment/permit2.ts:165) but doesn't have to. The
-    // strictly-correct invariant is "covers PAYMENT_AMOUNT", not "strictly
-    // increased" — `after > before` would falsely fail if the helper ever
-    // became idempotent (e.g., skip-if-already-MAX).
+    // allowance to pull PAYMENT_AMOUNT from the payer. Don't assert `after > before`
+    // because the SDK's approval helper sets MAX_UINT256
+    // (packages/core/src/payment/permit2.ts:165); if the unpinned fork inherits
+    // MAX upstream state for the anvil payer key, after === before === MAX and
+    // a strict-increase assertion would falsely fail.
     runner.assert(
       after >= PAYMENT_AMOUNT,
       `Permit2 allowance covers PAYMENT_AMOUNT after approval (was ${before}, now ${after})`,

--- a/examples/scenarios/permit2-charge.ts
+++ b/examples/scenarios/permit2-charge.ts
@@ -37,7 +37,9 @@ async function main() {
     const payerWallet = createWalletClient({
       account: payerAccount,
       chain: baseSepolia,
-      transport: http('http://127.0.0.1:8846/1'),
+      // Use the setup's RPC URL — under shared-prool mode each scenario gets a
+      // unique key, so hardcoding /1 would route this tx to the wrong Anvil child.
+      transport: http(ctx.rpcUrl),
     })
 
     const approvalParams = getPermit2AllowanceReadParams({

--- a/examples/scenarios/permit2-charge.ts
+++ b/examples/scenarios/permit2-charge.ts
@@ -20,7 +20,9 @@ import { StepRunner } from './runner.js'
 //   2. Per-payment signature — `signPermit2Authorization(...)` produces the
 //      collectorData and tokenCollector that `payment.charge` consumes.
 //
-// Anvil fork starts with zero Permit2 allowance, so step 1 is mandatory.
+// Step 1 ensures Permit2 has sufficient allowance to pull PAYMENT_AMOUNT
+// regardless of the fork's starting state — the approval is idempotent and
+// the post-condition check below pins the invariant the upstream charge needs.
 // Asserts real ERC-20 balance deltas — not contract-guaranteed invariants.
 // ---------------------------------------------------------------------------
 
@@ -50,9 +52,15 @@ async function main() {
     await runner.waitForTx(approvalHash)
 
     const after = await ctx.publicClient.readContract(approvalParams)
+    // Pin the post-condition the scenario actually needs: Permit2 has sufficient
+    // allowance to pull PAYMENT_AMOUNT from the payer. Don't assert `after > before`
+    // because the SDK's approval helper sets MAX_UINT256
+    // (packages/core/src/payment/permit2.ts:165); if the unpinned fork inherits
+    // MAX upstream state for the anvil payer key, after === before === MAX and
+    // a strict-increase assertion would falsely fail.
     runner.assert(
-      after > before,
-      `Permit2 allowance increased after approval (was ${before}, now ${after})`,
+      after >= PAYMENT_AMOUNT,
+      `Permit2 allowance covers PAYMENT_AMOUNT after approval (was ${before}, now ${after})`,
     )
 
     runner.step('Snapshot pre-charge USDC balances')

--- a/examples/scenarios/permit2-charge.ts
+++ b/examples/scenarios/permit2-charge.ts
@@ -53,11 +53,13 @@ async function main() {
 
     const after = await ctx.publicClient.readContract(approvalParams)
     // Pin the post-condition the scenario actually needs: Permit2 has sufficient
-    // allowance to pull PAYMENT_AMOUNT from the payer. Don't assert `after > before`
-    // because the SDK's approval helper sets MAX_UINT256
-    // (packages/core/src/payment/permit2.ts:165); if the unpinned fork inherits
-    // MAX upstream state for the anvil payer key, after === before === MAX and
-    // a strict-increase assertion would falsely fail.
+    // allowance to pull PAYMENT_AMOUNT. This asserts the contract invariant the
+    // upstream `charge` consumes (allowance >= amount) — robust against future
+    // changes to the approval helper, which today sets MAX_UINT256
+    // (packages/core/src/payment/permit2.ts:165) but doesn't have to. The
+    // strictly-correct invariant is "covers PAYMENT_AMOUNT", not "strictly
+    // increased" — `after > before` would falsely fail if the helper ever
+    // became idempotent (e.g., skip-if-already-MAX).
     runner.assert(
       after >= PAYMENT_AMOUNT,
       `Permit2 allowance covers PAYMENT_AMOUNT after approval (was ${before}, now ${after})`,

--- a/examples/scripts/README.md
+++ b/examples/scripts/README.md
@@ -1,0 +1,7 @@
+# examples/scripts/
+
+Infrastructure scripts that orchestrate scenarios, not role-based examples. Role-based examples (payer/, merchant/, arbiter/) demonstrate SDK usage; scripts here exist to support running the role-based examples or scenarios in specific configurations (e.g., CI).
+
+## scenarios-ci.ts
+
+Starts ONE prool server and runs each scenario as a subprocess with a unique numeric prool key. Mirrors the fork-test pattern at `packages/core/tests/setup/anvil.ts:43`. Used by the root `scenarios:ci` script invoked from CI.

--- a/examples/scripts/scenarios-ci.ts
+++ b/examples/scripts/scenarios-ci.ts
@@ -70,6 +70,9 @@ async function main(): Promise<void> {
     }),
     port: PORT,
   })
+  // prool's Server.start() resolves only after the listener is bound + the
+  // underlying anvil child is ready to accept JSON-RPC. Subsequent
+  // runScenario(...) calls can safely use the shared subpath URLs.
   await server.start()
 
   // Cancellation/crash paths bypass the for-loop's finally block, so register

--- a/examples/scripts/scenarios-ci.ts
+++ b/examples/scripts/scenarios-ci.ts
@@ -34,16 +34,19 @@ function scenarioRpcUrl(key: number): string {
 }
 
 async function runScenario(file: string, key: number): Promise<number> {
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const child = spawn('tsx', [scenarioFile(file)], {
       stdio: 'inherit',
       env: { ...process.env, SCENARIO_RPC_URL: scenarioRpcUrl(key) },
     })
-    child.on('exit', (code) => resolve(code ?? 1))
-    child.on('error', (err) => {
-      console.error(`Failed to spawn scenario ${file}:`, err)
-      resolve(1)
-    })
+    // Spawn errors (e.g. ENOENT for tsx) reject, so the caller can distinguish
+    // "scenario crashed with exit code N" from "we never got the scenario
+    // running in the first place." Resolving 1 in both cases conflated the
+    // two and made CI failure modes harder to diagnose.
+    child.once('error', (err) =>
+      reject(new Error(`failed to spawn '${file}' scenario: ${err.message}`)),
+    )
+    child.once('exit', (code) => resolve(code ?? 1))
   })
 }
 
@@ -84,9 +87,18 @@ async function main(): Promise<void> {
   try {
     for (const [index, file] of SCENARIO_FILES.entries()) {
       const key = index + 1
-      const code = await runScenario(file, key)
-      if (code !== 0) {
-        exitCode = code
+      try {
+        const code = await runScenario(file, key)
+        if (code !== 0) {
+          exitCode = code
+          break
+        }
+      } catch (err) {
+        // Spawn-time failures (ENOENT-class) reject from runScenario; surface
+        // the message and break so prool still gets stopped in the outer
+        // finally block.
+        console.error(err)
+        exitCode = 1
         break
       }
     }

--- a/examples/scripts/scenarios-ci.ts
+++ b/examples/scripts/scenarios-ci.ts
@@ -20,7 +20,13 @@ import { fileURLToPath } from 'node:url'
 // produced silent state crossover. prool's Server.create routes each unique
 // numeric subpath (`/1`, `/2`, ...) to its own forked Anvil child instance
 // (string subpaths are not supported by prool — see node_modules/prool README).
-const SCENARIO_FILES = ['dispute-resolution', 'permit2-charge'] as const
+// Typed as `readonly string[]` (not `as const`) so the empty-list guard in
+// main() stays type-meaningful — under `as const`, .length narrows to the
+// literal `2` and TS2367 flags `=== 0` as dead-code under strict.
+const SCENARIO_FILES: readonly string[] = [
+  'dispute-resolution',
+  'permit2-charge',
+]
 const PORT = 8846
 const CHAIN_ID = 84532
 

--- a/examples/scripts/scenarios-ci.ts
+++ b/examples/scripts/scenarios-ci.ts
@@ -13,14 +13,14 @@ import { spawn } from 'node:child_process'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-// File-stem (under examples/scenarios/) paired with the numeric prool key
-// used for the per-scenario route. prool's Server.create routes each unique
+// File-stems (under examples/scenarios/). The numeric prool key is derived
+// from array index (+1, since prool requires positive integers), so a
+// duplicate is impossible by construction — a copy-paste bug that gave two
+// scenarios the same key would have routed them to the same Anvil child and
+// produced silent state crossover. prool's Server.create routes each unique
 // numeric subpath (`/1`, `/2`, ...) to its own forked Anvil child instance
 // (string subpaths are not supported by prool — see node_modules/prool README).
-const SCENARIOS = [
-  { file: 'dispute-resolution', key: 1 },
-  { file: 'permit2-charge', key: 2 },
-] as const
+const SCENARIO_FILES = ['dispute-resolution', 'permit2-charge'] as const
 const PORT = 8846
 const CHAIN_ID = 84532
 
@@ -62,7 +62,8 @@ async function main(): Promise<void> {
 
   let exitCode = 0
   try {
-    for (const { file, key } of SCENARIOS) {
+    for (const [index, file] of SCENARIO_FILES.entries()) {
+      const key = index + 1
       const code = await runScenario(file, key)
       if (code !== 0) {
         exitCode = code

--- a/examples/scripts/scenarios-ci.ts
+++ b/examples/scripts/scenarios-ci.ts
@@ -60,6 +60,26 @@ async function main(): Promise<void> {
   })
   await server.start()
 
+  // Cancellation/crash paths bypass the for-loop's finally block, so register
+  // explicit handlers that stop prool before exit. Without these, a SIGINT (Ctrl+C)
+  // or SIGTERM (CI cancellation) would leave the anvil child + listener bound
+  // to PORT, causing EADDRINUSE on the next run.
+  const shutdown = async (signal: string, exitCode: number) => {
+    console.error(`[scenarios-ci] received ${signal}, stopping prool…`)
+    try {
+      await server.stop()
+    } catch (err) {
+      console.error('[scenarios-ci] server.stop() failed during shutdown:', err)
+    }
+    process.exit(exitCode)
+  }
+  process.on('SIGINT', () => shutdown('SIGINT', 130))
+  process.on('SIGTERM', () => shutdown('SIGTERM', 143))
+  process.on('unhandledRejection', (err) => {
+    console.error('[scenarios-ci] unhandledRejection:', err)
+    shutdown('unhandledRejection', 1)
+  })
+
   let exitCode = 0
   try {
     for (const [index, file] of SCENARIO_FILES.entries()) {

--- a/examples/scripts/scenarios-ci.ts
+++ b/examples/scripts/scenarios-ci.ts
@@ -51,6 +51,15 @@ async function runScenario(file: string, key: number): Promise<number> {
 }
 
 async function main(): Promise<void> {
+  // Guard against a future edit deleting all scenario entries while leaving
+  // this script wired into CI — exiting 0 from an empty loop would silently
+  // turn the scenarios:ci step into a no-op.
+  if (SCENARIO_FILES.length === 0) {
+    throw new Error(
+      'scenarios-ci.ts: SCENARIO_FILES is empty — refusing to run a no-op CI step',
+    )
+  }
+
   const { Instance, Server } = await import('prool')
   const server = Server.create({
     instance: Instance.anvil({

--- a/examples/scripts/scenarios-ci.ts
+++ b/examples/scripts/scenarios-ci.ts
@@ -1,0 +1,81 @@
+// CI orchestrator for the `scenarios:ci` script. Starts ONE prool server and
+// hands each scenario subprocess a unique numeric pool key (`/1`, `/2`, ...).
+// prool routes each key to its own forked Anvil child, so scenarios are
+// isolated without competing for the same TCP port.
+//
+// Mirrors the pattern used by fork tests:
+//   packages/core/tests/setup/anvil.ts:43   (poolId-keyed subpath)
+//   packages/core/tests/setup/globalSetup.ts:9 (single server lifecycle)
+//
+// Side benefit: one prool means one upstream fork operation against
+// Base Sepolia public RPC per CI run, instead of one per scenario.
+import { spawn } from 'node:child_process'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+// File-stem (under examples/scenarios/) paired with the numeric prool key
+// used for the per-scenario route. prool's Server.create routes each unique
+// numeric subpath (`/1`, `/2`, ...) to its own forked Anvil child instance
+// (string subpaths are not supported by prool — see node_modules/prool README).
+const SCENARIOS = [
+  { file: 'dispute-resolution', key: 1 },
+  { file: 'permit2-charge', key: 2 },
+] as const
+const PORT = 8846
+const CHAIN_ID = 84532
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const scenarioFile = (file: string) =>
+  path.resolve(__dirname, '..', 'scenarios', `${file}.ts`)
+
+function scenarioRpcUrl(key: number): string {
+  return `http://127.0.0.1:${PORT}/${key}`
+}
+
+async function runScenario(file: string, key: number): Promise<number> {
+  return new Promise((resolve) => {
+    const child = spawn('tsx', [scenarioFile(file)], {
+      stdio: 'inherit',
+      env: { ...process.env, SCENARIO_RPC_URL: scenarioRpcUrl(key) },
+    })
+    child.on('exit', (code) => resolve(code ?? 1))
+    child.on('error', (err) => {
+      console.error(`Failed to spawn scenario ${file}:`, err)
+      resolve(1)
+    })
+  })
+}
+
+async function main(): Promise<void> {
+  const { Instance, Server } = await import('prool')
+  const server = Server.create({
+    instance: Instance.anvil({
+      chainId: CHAIN_ID,
+      forkUrl:
+        process.env.VITE_ANVIL_FORK_URL_BASE_SEPOLIA ??
+        'https://sepolia.base.org',
+    }),
+    port: PORT,
+  })
+  await server.start()
+
+  let exitCode = 0
+  try {
+    for (const { file, key } of SCENARIOS) {
+      const code = await runScenario(file, key)
+      if (code !== 0) {
+        exitCode = code
+        break
+      }
+    }
+  } finally {
+    await server.stop()
+  }
+  process.exit(exitCode)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/examples/shared/anvil-setup.ts
+++ b/examples/shared/anvil-setup.ts
@@ -94,21 +94,42 @@ function getBalanceSlot(account: Address, baseSlot: bigint): `0x${string}` {
 
 export async function setup(options?: SetupOptions): Promise<ExampleContext> {
   const skipAuthorize = options?.authorize === false
-  // 1. Start Anvil fork
-  const { Instance, Server } = await import('prool')
-  const server = Server.create({
-    instance: Instance.anvil({
-      chainId: CHAIN_ID,
-      forkUrl:
-        process.env.VITE_ANVIL_FORK_URL_BASE_SEPOLIA ??
-        'https://sepolia.base.org',
-      forkBlockNumber: FORK_BLOCK,
-    }),
-    port: ANVIL_PORT,
-  })
-  await server.start()
+  // 1. Start Anvil fork (two modes)
+  //   a) Shared mode (CI orchestrator path): when SCENARIO_RPC_URL is set by
+  //      examples/scripts/scenarios-ci.ts, reuse that prool subpath URL and
+  //      skip spawning our own server. The orchestrator owns prool lifecycle,
+  //      so cleanup is a no-op here. Each scenario gets a unique subpath, so
+  //      prool routes each to its own forked Anvil child (no port collision).
+  //   b) Standalone mode (e.g. `pnpm scenario:capture` direct invocation):
+  //      spawn an isolated prool server on ANVIL_PORT and tear it down on
+  //      cleanup. Preserves backward-compat for developers running one
+  //      scenario locally.
+  const sharedRpcUrl = process.env.SCENARIO_RPC_URL
+  let rpcUrl: string
+  let cleanup: () => Promise<void>
 
-  const rpcUrl = `http://127.0.0.1:${ANVIL_PORT}/1`
+  if (sharedRpcUrl) {
+    rpcUrl = sharedRpcUrl
+    cleanup = async () => {}
+  } else {
+    const { Instance, Server } = await import('prool')
+    const server = Server.create({
+      instance: Instance.anvil({
+        chainId: CHAIN_ID,
+        forkUrl:
+          process.env.VITE_ANVIL_FORK_URL_BASE_SEPOLIA ??
+          'https://sepolia.base.org',
+        forkBlockNumber: FORK_BLOCK,
+      }),
+      port: ANVIL_PORT,
+    })
+    await server.start()
+    rpcUrl = `http://127.0.0.1:${ANVIL_PORT}/1`
+    cleanup = async () => {
+      await server.stop()
+    }
+  }
+
   const transport = http(rpcUrl)
 
   const publicClient = createPublicClient({
@@ -121,10 +142,6 @@ export async function setup(options?: SetupOptions): Promise<ExampleContext> {
     transport,
     mode: 'anvil',
   }) as unknown as TestClient
-
-  const cleanup = async () => {
-    await server.stop()
-  }
 
   try {
     // 2. Clear contract code at test addresses (fixes ERC-3009 signer checks)
@@ -275,6 +292,7 @@ export async function setup(options?: SetupOptions): Promise<ExampleContext> {
       },
       operatorAddress,
       PAYMENT_AMOUNT,
+      rpcUrl,
       cleanup,
       waitForTx,
     }

--- a/examples/shared/anvil-setup.ts
+++ b/examples/shared/anvil-setup.ts
@@ -109,6 +109,15 @@ export async function setup(options?: SetupOptions): Promise<ExampleContext> {
   let cleanup: () => Promise<void>
 
   if (sharedRpcUrl) {
+    // Eagerly validate so a malformed env var fails here with a clear message
+    // rather than mid-test through viem's transport with a less actionable error.
+    try {
+      new URL(sharedRpcUrl)
+    } catch {
+      throw new Error(
+        `anvil-setup: SCENARIO_RPC_URL is not a valid URL: ${sharedRpcUrl}`,
+      )
+    }
     rpcUrl = sharedRpcUrl
     cleanup = async () => {}
   } else {

--- a/examples/shared/types.ts
+++ b/examples/shared/types.ts
@@ -17,6 +17,10 @@ export interface ExampleContext {
   accounts: { payer: Address; merchant: Address; arbiter: Address }
   operatorAddress: Address
   PAYMENT_AMOUNT: bigint
+  /** RPC URL the setup is bound to — scenarios that create extra wallets
+   *  (e.g. permit2-charge) must use this URL so all txs land on the same
+   *  Anvil instance under shared-prool mode. */
+  rpcUrl: string
   cleanup: () => Promise<void>
   /** Wait for a transaction to be confirmed before reading state */
   waitForTx: (hash: Hash) => Promise<void>

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "example:payer:freeze": "pnpm --filter examples run payer:freeze",
     "example:arbiter:review-evidence": "pnpm --filter examples run arbiter:review-evidence",
     "scenario:release": "pnpm --filter examples run scenario:release",
-    "scenario:dispute": "pnpm --filter examples run scenario:dispute"
+    "scenario:dispute": "pnpm --filter examples run scenario:dispute",
+    "scenarios:ci": "pnpm --filter examples scenario:dispute && pnpm --filter examples scenario:permit2-charge"
   },
   "engines": {
     "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "example:arbiter:review-evidence": "pnpm --filter examples run arbiter:review-evidence",
     "scenario:release": "pnpm --filter examples run scenario:release",
     "scenario:dispute": "pnpm --filter examples run scenario:dispute",
-    "scenarios:ci": "pnpm --filter examples scenario:dispute && pnpm --filter examples scenario:permit2-charge"
+    "scenarios:ci": "pnpm --filter examples exec tsx scripts/scenarios-ci.ts"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary

PR 1 of 3 in the `@x402r/sdk@0.3.0` publish-readiness series tracked at `x402r-notes/plans/PHASE_3_PUBLISH_READINESS.md`. Extends the existing `test-fork` CI job to run two end-to-end scenarios after the fork test suite, and fixes three misleading "HTTP 402 flow" labels in scenario output.

### Why these two scenarios

**`scenario:permit2-charge`** — we have zero on-chain Permit2 coverage today.

```
$ grep -r permit2 packages/core/tests/integration/
(no matches)
```

The only existing Permit2 test is `packages/core/tests/permit2.test.ts`, a unit test with mocked viem. The permit2-charge scenario runs the full payer-side flow against a real ERC-20 on an Anvil fork: `ERC20.approve(PERMIT2, MAX)` then `signPermit2Authorization` then atomic `payment.charge`, asserting real balance deltas. Without this in CI, a Permit2 regression ships silently.

**`scenario:dispute`** — the only multi-step lifecycle test we have. The 7-step flow exercises cross-call state mutations (authorize → refund request → evidence submission by payer + merchant → arbiter review → `voidPayment` → hook auto-approval → fee distribution) that per-action fork tests cannot fake. Each per-action fork test starts from a fresh fork; only an end-to-end scenario validates that state from step N is correctly consumed by step N+1.

### Why not the other scenarios

`scenario:capture`, `scenario:atomic-charge`, and `scenario:partial-refund-flow` are deliberately excluded — they're redundant with per-action fork tests in `packages/core/tests/integration/` (`authorize-capture.fork.test.ts`, `direct-charge.fork.test.ts`, `partial-refund.fork.test.ts`). Running them in CI would burn wall-clock without adding coverage.

### CI shape

The existing `test-fork` job is extended in place — no new CI lane added. Wall-clock delta is ~8 seconds (both scenarios complete in <2s each on a warm fork; chain RPC dominates).

Concretely:
- New `Run CI scenarios (dispute + permit2)` step appended after `Run fork tests`, using the same `nick-fields/retry@v3` wrapper with `timeout_minutes: 5, max_attempts: 2` to absorb public Base Sepolia RPC flake.
- Job `timeout-minutes` bumped `15 → 20` to give retry headroom.
- New root script `pnpm scenarios:ci` chains the two scenarios.

### Label fix (commit 1)

Three scenario steps printed `"Authorize payment via HTTP 402 flow"` while doing direct SDK calls via `signReceiveAuthorization` + `payment.authorize` — no HTTP, no 402, no facilitator, no x402 wire format. Renamed to `"Authorize payment via SDK viem flow"` in `happy-path-capture.ts`, `dispute-resolution.ts`, and `partial-refund-flow.ts` so scenario output matches reality.

## Test plan

- [x] `pnpm scenario:dispute` passes locally (7 steps, ~1.8s)
- [x] `pnpm --filter examples scenario:permit2-charge` passes locally (3 steps, ~2s)
- [x] `pnpm scenarios:ci` chain works end-to-end (first run failed on anvil port reuse, retry succeeded — exactly the case `nick-fields/retry@v3` is configured to handle)
- [ ] CI `test-fork` job green on this PR
