### PR TITLE
core: partial-capture edge case tests (void-after-full, double-application)

### DIFF
--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -319,3 +319,72 @@ describe('Edge case: double capture+void on same paymentInfo', () => {
     expect(payerBalanceAfter).toBe(payerBalanceBefore)
   }, 60_000)
 })
+
+// ---------------------------------------------------------------------------
+// Edge case (d): capture overspend — capture(amount > capturableAmount)
+// ---------------------------------------------------------------------------
+
+// Pins down on-chain behavior when a merchant tries to capture MORE than the
+// authorized capturableAmount (e.g., off-by-one in their amount math, or a
+// stale read of capturableAmount before another capture drained it). The SDK
+// path (`packages/core/src/actions/payment/capture.ts:17-34`) wraps
+// `writeContract` with no client-side amount validation, so the behavior is
+// purely contract-defined.
+describe('Edge case: capture overspend (amount > capturableAmount)', () => {
+  it('reverts and leaves capturableAmount unchanged', async () => {
+    // Fresh paymentInfo with salt: 5n to avoid colliding with Scenarios above.
+    const overspendInfo: PaymentInfo = { ...paymentInfo, salt: 5n }
+    const { collectorData, tokenCollector } = await createCollectorData(
+      anvilBaseSepolia.getWalletClient(testRoles.payer.address),
+      overspendInfo,
+    )
+    const authHash = await payerClient.payment.authorize(
+      overspendInfo,
+      DEFAULT_AMOUNT,
+      tokenCollector,
+      collectorData,
+    )
+    await publicClient.waitForTransactionReceipt({ hash: authHash })
+
+    await testClient.increaseTime({ seconds: ESCROW_FAST_FORWARD })
+    await testClient.mine({ blocks: 1 })
+
+    const amountsBefore = await merchant.payment.getAmounts(overspendInfo)
+    expect(amountsBefore.capturableAmount).toBe(DEFAULT_AMOUNT)
+
+    // Snapshot receiver USDC balance — if the overspend silently let an
+    // out-of-range amount through, receiver tokens would move.
+    const receiverBalanceBefore = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.receiver.address],
+    })
+
+    // Attempt to capture MORE than authorized. SDK returns a tx hash (no
+    // pre-simulation), on-chain reverts at receipt level (same pattern as
+    // edge cases (b) and (c)).
+    const overspendHash = await merchant.payment.capture(
+      overspendInfo,
+      DEFAULT_AMOUNT + 1n,
+      '0x',
+    )
+    const overspendReceipt = await publicClient.waitForTransactionReceipt({
+      hash: overspendHash,
+    })
+    expect(overspendReceipt.status).toBe('reverted')
+
+    // State invariants: capturableAmount unchanged, receiver tokens didn't
+    // move. Together these prove the contract gate held.
+    const amountsAfter = await merchant.payment.getAmounts(overspendInfo)
+    expect(amountsAfter.capturableAmount).toBe(DEFAULT_AMOUNT)
+
+    const receiverBalanceAfter = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.receiver.address],
+    })
+    expect(receiverBalanceAfter).toBe(receiverBalanceBefore)
+  }, 60_000)
+})

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -160,3 +160,117 @@ describe('Scenario 3: Partial capture + void remainder', () => {
     expect(payerBalanceAfter - payerBalanceBeforeVoid).toBe(REFUND_AMOUNT)
   }, 60_000)
 })
+
+// ---------------------------------------------------------------------------
+// Edge case (b): voidPayment after full capture
+// ---------------------------------------------------------------------------
+
+// Pins down on-chain behavior when a merchant calls `voidPayment()` after
+// already capturing the full authorized amount (capturableAmount === 0). The
+// JSDoc on `voidPayment` (packages/core/src/actions/refund-budget/voidPayment.ts:17-18)
+// describes the call as "empties the authorization in one transaction" but
+// doesn't specify what happens when there's nothing left to empty. This test
+// documents the actual contract behavior so a future contract change can't
+// silently change the SDK's surface.
+describe('Edge case: voidPayment after full capture', () => {
+  it('reverts (or no-ops) when capturableAmount is already 0', async () => {
+    // Fresh paymentInfo with salt: 4n to avoid colliding with Scenario 3's
+    // salt: 3n (same payer + receiver + asset means salt is the only
+    // disambiguator in the escrow nonce).
+    const edgePaymentInfo: PaymentInfo = { ...paymentInfo, salt: 4n }
+    const { collectorData, tokenCollector } = await createCollectorData(
+      anvilBaseSepolia.getWalletClient(testRoles.payer.address),
+      edgePaymentInfo,
+    )
+    const authHash = await payerClient.payment.authorize(
+      edgePaymentInfo,
+      DEFAULT_AMOUNT,
+      tokenCollector,
+      collectorData,
+    )
+    await publicClient.waitForTransactionReceipt({ hash: authHash })
+
+    await testClient.increaseTime({ seconds: ESCROW_FAST_FORWARD })
+    await testClient.mine({ blocks: 1 })
+
+    // Capture the full DEFAULT_AMOUNT so capturableAmount drains to 0.
+    const captureHash = await merchant.payment.capture(
+      edgePaymentInfo,
+      DEFAULT_AMOUNT,
+      '0x',
+    )
+    await publicClient.waitForTransactionReceipt({ hash: captureHash })
+
+    const amounts = await merchant.payment.getAmounts(edgePaymentInfo)
+    expect(amounts.capturableAmount).toBe(0n)
+
+    // Observed behavior (pinned 2026-05-18 against the deployed
+    // PaymentOperator + EscrowPeriod fixtures): the SDK's `voidPayment()`
+    // submits the tx and the wallet client returns a tx hash without throwing
+    // (`writeContract` on anvil doesn't simulate before sending). On-chain,
+    // the `void()` call REVERTS — see the receipt status below. The
+    // capturableAmount stays at 0n (no state change), confirming nothing was
+    // double-voided.
+    //
+    // This pins down the contract-side guarantee: if a future contract
+    // version turns the revert into a no-op success, or starts simulating
+    // pre-send (so the SDK throws), this test will fail and force a
+    // deliberate decision.
+    const voidHash = await merchant.payment.voidPayment(edgePaymentInfo)
+    const voidReceipt = await publicClient.waitForTransactionReceipt({
+      hash: voidHash,
+    })
+    expect(voidReceipt.status).toBe('reverted')
+
+    const amountsAfter = await merchant.payment.getAmounts(edgePaymentInfo)
+    expect(amountsAfter.capturableAmount).toBe(0n)
+  }, 60_000)
+})
+
+// ---------------------------------------------------------------------------
+// Edge case (c): double-application / nonce reuse
+// ---------------------------------------------------------------------------
+
+// Depends on the file-level `beforeAll` paymentInfo (salt: 3n) being
+// capture+void'd by the preceding `Scenario 3: Partial capture + void
+// remainder` describe block. Vitest runs `describe` blocks in file order, so
+// by the time this runs, `paymentInfo` has been fully consumed (authorized,
+// partial-captured, then voided). Reusing the same paymentInfo here exercises
+// the replay-protection boundary: the escrow nonce (see
+// `computeEscrowNonce` at packages/core/src/payment/hashing.ts:87-97) is
+// derived from `(chainId, escrowAddress, paymentInfo with payer=0)`, so a
+// second authorize with the same salt should collide with the already-spent
+// nonce and revert.
+describe('Edge case: double capture+void on same paymentInfo', () => {
+  it('rejects second authorize on the same salt (nonce collision)', async () => {
+    const { collectorData, tokenCollector } = await createCollectorData(
+      anvilBaseSepolia.getWalletClient(testRoles.payer.address),
+      paymentInfo,
+    )
+
+    // Observed behavior (pinned 2026-05-18): the SDK's `authorize()` submits
+    // the tx and returns a hash without throwing (no pre-send simulation).
+    // The on-chain `authorize()` REVERTS in the receipt — the escrow nonce
+    // (see `computeEscrowNonce` at packages/core/src/payment/hashing.ts:87-97)
+    // is already consumed by Scenario 3's capture+void, and ERC-3009 nonces
+    // are single-use, so the second authorize cannot pull tokens. The
+    // capturableAmount stays at 0n.
+    //
+    // This is the replay-protection boundary: if a future contract version
+    // ever lets this succeed, a malicious or buggy caller could re-collect
+    // tokens against a paymentInfo the payer thought was fully consumed.
+    const replayHash = await payerClient.payment.authorize(
+      paymentInfo,
+      DEFAULT_AMOUNT,
+      tokenCollector,
+      collectorData,
+    )
+    const replayReceipt = await publicClient.waitForTransactionReceipt({
+      hash: replayHash,
+    })
+    expect(replayReceipt.status).toBe('reverted')
+
+    const amountsAfter = await merchant.payment.getAmounts(paymentInfo)
+    expect(amountsAfter.capturableAmount).toBe(0n)
+  }, 60_000)
+})

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -206,8 +206,14 @@ describe('Edge case: voidPayment after full capture', () => {
 
     // Observed behavior against the deployed PaymentOperator + EscrowPeriod
     // fixtures: the SDK's `voidPayment()` submits the tx and the wallet client
-    // returns a tx hash without throwing (`writeContract` on anvil doesn't
-    // simulate before sending). On-chain, the `void()` call REVERTS — see the
+    // returns a tx hash without throwing. viem's `walletClient.writeContract`
+    // does not pre-simulate before sending (same behavior on Base mainnet —
+    // verified zero `simulateContract` calls across
+    // `packages/core/src/actions/{operator,refund-budget}/`). So the SDK
+    // returns a tx hash without throwing; the on-chain revert surfaces only at
+    // receipt-level. A merchant integration that trusts
+    // `await payment.voidPayment(...)` to throw on failure will silently miss
+    // reverts in production. On-chain, the `void()` call REVERTS — see the
     // receipt status below. The capturableAmount stays at 0n (no state
     // change), confirming nothing was double-voided.
     //
@@ -241,6 +247,10 @@ describe('Edge case: voidPayment after full capture', () => {
       functionName: 'balanceOf',
       args: [testRoles.payer.address],
     })
+    // Tautological in current context — between the full capture
+    // (escrow→receiver) and this reverting void, nothing can touch payer
+    // balance. Kept as a future-regression guard if the test ordering ever
+    // changes.
     expect(payerBalanceAfter).toBe(payerBalanceBefore)
   }, 60_000)
 })
@@ -275,12 +285,21 @@ describe('Edge case: double capture+void on same paymentInfo', () => {
     )
 
     // Observed behavior: the SDK's `authorize()` submits the tx and returns a
-    // hash without throwing (no pre-send simulation). The on-chain
-    // `authorize()` REVERTS in the receipt — the escrow nonce (see
-    // `computeEscrowNonce` at packages/core/src/payment/hashing.ts:87-97) is
-    // already consumed by Scenario 3's capture+void, and ERC-3009 nonces are
-    // single-use, so the second authorize cannot pull tokens. The
-    // capturableAmount stays at 0n.
+    // hash without throwing. viem's `walletClient.writeContract` does not
+    // pre-simulate before sending (same behavior on Base mainnet — verified
+    // zero `simulateContract` calls across
+    // `packages/core/src/actions/{operator,refund-budget}/`). So the SDK
+    // returns a tx hash without throwing; the on-chain revert surfaces only at
+    // receipt-level. A merchant integration that trusts
+    // `await payment.voidPayment(...)` to throw on failure will silently miss
+    // reverts in production. The on-chain `authorize()` REVERTS in the
+    // receipt — the replay-protection gate is USDC's ERC-3009
+    // `authorizationState(payer, nonce)` mapping — the nonce was consumed
+    // when the first authorize landed (Scenario 3 above). `computeEscrowNonce`
+    // at `packages/core/src/payment/hashing.ts:87-97` is just the
+    // deterministic nonce *derivation*; the escrow contract doesn't maintain
+    // its own consumption map. So the second authorize cannot pull tokens.
+    // The capturableAmount stays at 0n.
     //
     // This is the replay-protection boundary: if a future contract version
     // ever lets this succeed, a malicious or buggy caller could re-collect
@@ -361,9 +380,14 @@ describe('Edge case: capture overspend (amount > capturableAmount)', () => {
       args: [testRoles.receiver.address],
     })
 
-    // Attempt to capture MORE than authorized. SDK returns a tx hash (no
-    // pre-simulation), on-chain reverts at receipt level (same pattern as
-    // edge cases (b) and (c)).
+    // Attempt to capture MORE than authorized. viem's
+    // `walletClient.writeContract` does not pre-simulate before sending (same
+    // behavior on Base mainnet — verified zero `simulateContract` calls across
+    // `packages/core/src/actions/{operator,refund-budget}/`). So the SDK
+    // returns a tx hash without throwing; the on-chain revert surfaces only at
+    // receipt-level (same pattern as edge cases (b) and (c)). A merchant
+    // integration that trusts `await payment.capture(...)` to throw on failure
+    // will silently miss reverts in production.
     const overspendHash = await merchant.payment.capture(
       overspendInfo,
       DEFAULT_AMOUNT + 1n,

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -42,6 +42,25 @@ const MERCHANT_NET = (MERCHANT_AMOUNT * (10_000n - FEE_BPS)) / 10_000n
 const baseSepolia = x402rChains[84532]
 const USDC = baseSepolia.usdc
 
+// Minimal ERC-3009 ABI snippet for the read-only `authorizationState` getter.
+// viem does not expose an ERC-3009 ABI export, and the SDK does not define one
+// either (no callers in `packages/core/src/`), so we keep this local. Hoisted
+// to module scope so any future test that wants to assert nonce-consumption
+// at the token-contract layer can reuse it instead of inlining.
+// Spec: https://eips.ethereum.org/EIPS/eip-3009#authorizationstate
+const erc3009Abi = [
+  {
+    name: 'authorizationState',
+    type: 'function',
+    stateMutability: 'view',
+    inputs: [
+      { name: 'authorizer', type: 'address' },
+      { name: 'nonce', type: 'bytes32' },
+    ],
+    outputs: [{ type: 'bool' }],
+  },
+] as const
+
 let paymentInfo: PaymentInfo
 let receiverBalanceBefore: bigint
 let payerBalanceBeforeVoid: bigint
@@ -433,18 +452,7 @@ describe('Edge case: double capture+void on same paymentInfo', () => {
 
     const consumed = await publicClient.readContract({
       address: USDC,
-      abi: [
-        {
-          name: 'authorizationState',
-          type: 'function',
-          stateMutability: 'view',
-          inputs: [
-            { name: 'authorizer', type: 'address' },
-            { name: 'nonce', type: 'bytes32' },
-          ],
-          outputs: [{ type: 'bool' }],
-        },
-      ] as const,
+      abi: erc3009Abi,
       functionName: 'authorizationState',
       args: [testRoles.payer.address, escrowNonce],
     })

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -417,6 +417,14 @@ describe('Edge case: double capture+void on same paymentInfo', () => {
   // balance assertions stay green and the replay door silently opens — this
   // assertion would catch that.
   it('USDC authorizationState(payer, escrowNonce) === true after consumption', async () => {
+    // Precondition (in-test guard): Scenario 3 + case (c)/case (f) above must
+    // have consumed the ERC-3009 nonce. Under `--shuffle` or `.only`, this
+    // precondition fails fast with an actionable diagnostic instead of the
+    // downstream "expected true received false" from the authorizationState
+    // check.
+    const preAmounts = await merchant.payment.getAmounts(paymentInfo)
+    expect(preAmounts.capturableAmount).toBe(0n)
+
     const escrowNonce = computeEscrowNonce(
       baseSepolia.chainId,
       authCaptureEscrow,

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -237,6 +237,11 @@ describe('Edge case: voidPayment after full capture', () => {
       hash: voidHash,
     })
     expect(voidReceipt.status).toBe('reverted')
+    // Stronger guarantee than receipt-status + balance-unchanged alone:
+    // catches the "partial state mutation where some events fired before the
+    // EVM reverted" bug class. Reference: PaymentVoided/PaymentAuthorized/
+    // PaymentCaptured events at packages/core/src/abis/generated.ts:686+.
+    expect(voidReceipt.logs).toHaveLength(0)
 
     const amountsAfter = await merchant.payment.getAmounts(edgePaymentInfo)
     expect(amountsAfter.capturableAmount).toBe(0n)
@@ -325,6 +330,11 @@ describe('Edge case: double capture+void on same paymentInfo', () => {
       hash: replayHash,
     })
     expect(replayReceipt.status).toBe('reverted')
+    // Stronger guarantee than receipt-status + balance-unchanged alone:
+    // catches the "partial state mutation where some events fired before the
+    // EVM reverted" bug class. Reference: PaymentVoided/PaymentAuthorized/
+    // PaymentCaptured events at packages/core/src/abis/generated.ts:686+.
+    expect(replayReceipt.logs).toHaveLength(0)
 
     const amountsAfter = await merchant.payment.getAmounts(paymentInfo)
     expect(amountsAfter.capturableAmount).toBe(0n)
@@ -397,6 +407,11 @@ describe('Edge case: capture overspend (amount > capturableAmount)', () => {
       hash: overspendHash,
     })
     expect(overspendReceipt.status).toBe('reverted')
+    // Stronger guarantee than receipt-status + balance-unchanged alone:
+    // catches the "partial state mutation where some events fired before the
+    // EVM reverted" bug class. Reference: PaymentVoided/PaymentAuthorized/
+    // PaymentCaptured events at packages/core/src/abis/generated.ts:686+.
+    expect(overspendReceipt.logs).toHaveLength(0)
 
     // State invariants: capturableAmount unchanged, receiver tokens didn't
     // move. Together these prove the contract gate held.

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -327,7 +327,7 @@ describe('Edge case: double capture+void on same paymentInfo', () => {
 // Pins down on-chain behavior when a merchant tries to capture MORE than the
 // authorized capturableAmount (e.g., off-by-one in their amount math, or a
 // stale read of capturableAmount before another capture drained it). The SDK
-// path (`packages/core/src/actions/payment/capture.ts:17-34`) wraps
+// path (`packages/core/src/actions/operator/capture.ts:17-34`) wraps
 // `writeContract` with no client-side amount validation, so the behavior is
 // purely contract-defined.
 describe('Edge case: capture overspend (amount > capturableAmount)', () => {

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -661,3 +661,50 @@ describe('Edge case: sequential overspend after partial capture', () => {
     expect(receiverBalanceAfter).toBe(receiverBalanceBefore)
   }, 60_000)
 })
+
+// ---------------------------------------------------------------------------
+// Edge case (h): void on never-authorized paymentInfo
+// ---------------------------------------------------------------------------
+
+// Pins behavior when the merchant calls `voidPayment` against a paymentInfo
+// that was never authorized. Different SDK path than (b) — no prior state on
+// this paymentInfo at all. The escrow has nothing in `paymentState(hash)`
+// (capturableAmount === 0n from zero-init), so the underlying `escrow.void`
+// call has nothing to release. Production failure mode: an arbiter or
+// merchant integration that doesn't pre-check `getAmounts()` calls
+// `voidPayment` on a stale or never-seen paymentInfo and assumes the
+// promise rejection signals an authorization existed — it doesn't, the
+// receipt-level revert is the same shape as case (b).
+describe('Edge case: voidPayment on never-authorized paymentInfo', () => {
+  it('reverts and leaves payer balance untouched', async () => {
+    // Fresh paymentInfo with salt: 8n — SKIP authorize entirely.
+    const neverAuthInfo: PaymentInfo = { ...paymentInfo, salt: 8n }
+
+    // Sanity: capturableAmount is 0n because escrow has no state on this
+    // paymentInfo.
+    const preAmounts = await merchant.payment.getAmounts(neverAuthInfo)
+    expect(preAmounts.capturableAmount).toBe(0n)
+
+    const payerBalanceBefore = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.payer.address],
+    })
+
+    const voidHash = await merchant.payment.voidPayment(neverAuthInfo)
+    const voidReceipt = await publicClient.waitForTransactionReceipt({
+      hash: voidHash,
+    })
+    expect(voidReceipt.status).toBe('reverted')
+    expect(voidReceipt.logs).toHaveLength(0)
+
+    const payerBalanceAfter = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.payer.address],
+    })
+    expect(payerBalanceAfter).toBe(payerBalanceBefore)
+  }, 60_000)
+})

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -577,6 +577,11 @@ describe('Edge case: void during escrow window (asymmetry vs capture)', () => {
     })
     // SUCCESS, not reverted — the void path is unconditional on time.
     expect(voidReceipt.status).toBe('success')
+    // On success, the void should have emitted the PaymentVoided event (and
+    // possibly transfer events for the refund). Catches a regression where
+    // the void succeeds at state level but doesn't emit — e.g., if the hook
+    // silently swallowed the post-action event.
+    expect(voidReceipt.logs.length).toBeGreaterThan(0)
 
     const amountsAfter = await merchant.payment.getAmounts(escrowVoidInfo)
     expect(amountsAfter.capturableAmount).toBe(0n)

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -584,3 +584,80 @@ describe('Edge case: void during escrow window (asymmetry vs capture)', () => {
     expect(payerBalanceAfter - payerBalanceBefore).toBe(DEFAULT_AMOUNT)
   }, 60_000)
 })
+
+// ---------------------------------------------------------------------------
+// Edge case (g): sequential overspend after partial capture
+// ---------------------------------------------------------------------------
+
+// Pins the overspend boundary at `capturableAmount + 1` exactly — distinct
+// from case (d) which tests overspend on fresh state. After a partial capture
+// mutates state, the boundary moves: the contract gate must be reading
+// live escrow state, not the original authorized amount. A regression
+// where the gate accidentally compares against `paymentInfo.maxAmount`
+// (or any other stale snapshot) would let this overspend slip through
+// while case (d) still passes.
+describe('Edge case: sequential overspend after partial capture', () => {
+  it('reverts when capturing capturableAmount + 1 after a partial capture', async () => {
+    // Fresh paymentInfo with salt: 7n to avoid colliding with prior scenarios.
+    const seqInfo: PaymentInfo = { ...paymentInfo, salt: 7n }
+    const { collectorData, tokenCollector } = await createCollectorData(
+      anvilBaseSepolia.getWalletClient(testRoles.payer.address),
+      seqInfo,
+    )
+    const authHash = await payerClient.payment.authorize(
+      seqInfo,
+      DEFAULT_AMOUNT,
+      tokenCollector,
+      collectorData,
+    )
+    await publicClient.waitForTransactionReceipt({ hash: authHash })
+
+    await testClient.increaseTime({ seconds: ESCROW_FAST_FORWARD })
+    await testClient.mine({ blocks: 1 })
+
+    // Partial capture: half of DEFAULT_AMOUNT. After this, capturableAmount
+    // should drop to DEFAULT_AMOUNT / 2n.
+    const partialCaptureHash = await merchant.payment.capture(
+      seqInfo,
+      DEFAULT_AMOUNT / 2n,
+      '0x',
+    )
+    await publicClient.waitForTransactionReceipt({ hash: partialCaptureHash })
+
+    const amountsBefore = await merchant.payment.getAmounts(seqInfo)
+    expect(amountsBefore.capturableAmount).toBe(DEFAULT_AMOUNT / 2n)
+
+    // Snapshot receiver USDC balance — overspend must not move tokens.
+    const receiverBalanceBefore = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.receiver.address],
+    })
+
+    // Attempt to capture exactly `capturableAmount + 1` — the boundary.
+    const overspendHash = await merchant.payment.capture(
+      seqInfo,
+      amountsBefore.capturableAmount + 1n,
+      '0x',
+    )
+    const overspendReceipt = await publicClient.waitForTransactionReceipt({
+      hash: overspendHash,
+    })
+    expect(overspendReceipt.status).toBe('reverted')
+    expect(overspendReceipt.logs).toHaveLength(0)
+
+    // State invariants: capturableAmount unchanged, receiver tokens didn't
+    // move.
+    const amountsAfter = await merchant.payment.getAmounts(seqInfo)
+    expect(amountsAfter.capturableAmount).toBe(DEFAULT_AMOUNT / 2n)
+
+    const receiverBalanceAfter = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.receiver.address],
+    })
+    expect(receiverBalanceAfter).toBe(receiverBalanceBefore)
+  }, 60_000)
+})

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -261,6 +261,14 @@ describe('Edge case: voidPayment after full capture', () => {
 // nonce and revert.
 describe('Edge case: double capture+void on same paymentInfo', () => {
   it('rejects second authorize on the same salt (nonce collision)', async () => {
+    // Precondition (in-test guard): Scenario 3 above must have fully consumed
+    // paymentInfo (capture + void → capturableAmount === 0n). If this test is
+    // run with `--shuffle` or `.only`, the precondition fails fast here rather
+    // than confusing the diagnoser with an "expected reverted got success"
+    // receipt-status failure downstream.
+    const preAmounts = await merchant.payment.getAmounts(paymentInfo)
+    expect(preAmounts.capturableAmount).toBe(0n)
+
     const { collectorData, tokenCollector } = await createCollectorData(
       anvilBaseSepolia.getWalletClient(testRoles.payer.address),
       paymentInfo,

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -7,7 +7,8 @@ import {
   type MerchantClient,
   type X402r,
 } from '../../../sdk/src/index.js'
-import { x402rChains } from '../../src/config/index.js'
+import { authCaptureEscrow, x402rChains } from '../../src/config/index.js'
+import { computeEscrowNonce } from '../../src/payment/hashing.js'
 import type { PaymentInfo } from '../../src/types/index.js'
 import { anvilBaseSepolia } from '../setup/anvil.js'
 import {
@@ -346,6 +347,100 @@ describe('Edge case: double capture+void on same paymentInfo', () => {
       args: [testRoles.payer.address],
     })
     expect(payerBalanceAfter).toBe(payerBalanceBefore)
+  }, 60_000)
+
+  // -------------------------------------------------------------------------
+  // Edge case (f): replay-with-different-amount in case (c)
+  // -------------------------------------------------------------------------
+
+  // Pins down that ERC-3009 nonce rejection is amount-agnostic — replaying
+  // with a different amount still fails at the same layer. The case (c) test
+  // above replays with the same DEFAULT_AMOUNT; this one varies the amount to
+  // prove the nonce gate is the binding check, not an amount-comparison.
+  it('rejects replay even with a different amount (nonce-gate is amount-agnostic)', async () => {
+    // Precondition (in-test guard): the file-level paymentInfo (salt: 3n) has
+    // already been fully consumed by Scenario 3 and the case (c) test above.
+    const preAmounts = await merchant.payment.getAmounts(paymentInfo)
+    expect(preAmounts.capturableAmount).toBe(0n)
+
+    const { collectorData, tokenCollector } = await createCollectorData(
+      anvilBaseSepolia.getWalletClient(testRoles.payer.address),
+      paymentInfo,
+    )
+
+    const payerBalanceBefore = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.payer.address],
+    })
+
+    // DIFFERENT amount than the original authorize (DEFAULT_AMOUNT / 2n vs
+    // DEFAULT_AMOUNT). If the contract gate were amount-based rather than
+    // nonce-based, this could slip through. It does not — the ERC-3009
+    // nonce mapping is checked first.
+    const replayHash = await payerClient.payment.authorize(
+      paymentInfo,
+      DEFAULT_AMOUNT / 2n,
+      tokenCollector,
+      collectorData,
+    )
+    const replayReceipt = await publicClient.waitForTransactionReceipt({
+      hash: replayHash,
+    })
+    expect(replayReceipt.status).toBe('reverted')
+    expect(replayReceipt.logs).toHaveLength(0)
+
+    const amountsAfter = await merchant.payment.getAmounts(paymentInfo)
+    expect(amountsAfter.capturableAmount).toBe(0n)
+
+    const payerBalanceAfter = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.payer.address],
+    })
+    expect(payerBalanceAfter).toBe(payerBalanceBefore)
+  }, 60_000)
+
+  // -------------------------------------------------------------------------
+  // Edge case (i): USDC `authorizationState` direct check
+  // -------------------------------------------------------------------------
+
+  // ADDITIONAL assertion ON case (c) — reads USDC's ERC-3009 nonce mapping
+  // directly via `authorizationState(authorizer, nonce)`. This is the
+  // strongest possible replay-protection check: strictly stronger than the
+  // balance-unchanged proxy in case (c), because it goes to the source of
+  // truth (the token contract's own state) rather than inferring from
+  // observed effects. If a future contract version ever stops marking the
+  // nonce consumed but still happens to revert for an unrelated reason, the
+  // balance assertions stay green and the replay door silently opens — this
+  // assertion would catch that.
+  it('USDC authorizationState(payer, escrowNonce) === true after consumption', async () => {
+    const escrowNonce = computeEscrowNonce(
+      baseSepolia.chainId,
+      authCaptureEscrow,
+      paymentInfo,
+    )
+
+    const consumed = await publicClient.readContract({
+      address: USDC,
+      abi: [
+        {
+          name: 'authorizationState',
+          type: 'function',
+          stateMutability: 'view',
+          inputs: [
+            { name: 'authorizer', type: 'address' },
+            { name: 'nonce', type: 'bytes32' },
+          ],
+          outputs: [{ type: 'bool' }],
+        },
+      ] as const,
+      functionName: 'authorizationState',
+      args: [testRoles.payer.address, escrowNonce],
+    })
+    expect(consumed).toBe(true)
   }, 60_000)
 })
 

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -1,5 +1,5 @@
 import type { PublicClient, TestClient } from 'viem'
-import { erc20Abi } from 'viem'
+import { erc20Abi, parseEventLogs } from 'viem'
 import { beforeAll, describe, expect, it } from 'vitest'
 import {
   createMerchantClient,
@@ -7,6 +7,7 @@ import {
   type MerchantClient,
   type X402r,
 } from '../../../sdk/src/index.js'
+import { authCaptureEscrowAbi } from '../../src/abis/generated.js'
 import { authCaptureEscrow, x402rChains } from '../../src/config/index.js'
 import { computeEscrowNonce } from '../../src/payment/hashing.js'
 import type { PaymentInfo } from '../../src/types/index.js'
@@ -585,11 +586,23 @@ describe('Edge case: void during escrow window (asymmetry vs capture)', () => {
     })
     // SUCCESS, not reverted — the void path is unconditional on time.
     expect(voidReceipt.status).toBe('success')
-    // On success, the void should have emitted the PaymentVoided event (and
-    // possibly transfer events for the refund). Catches a regression where
-    // the void succeeds at state level but doesn't emit — e.g., if the hook
-    // silently swallowed the post-action event.
-    expect(voidReceipt.logs.length).toBeGreaterThan(0)
+    // Catches the silent-drop case where the void succeeds at state level but
+    // `PaymentVoided` doesn't emit — `parseEventLogs` filters by event topic
+    // against the escrow ABI (the actual emitter; the operator emits
+    // `VoidExecuted` instead, while `PaymentVoided` lives on
+    // `authCaptureEscrowAbi` at `packages/core/src/abis/generated.ts:686`).
+    // A Transfer-only success (e.g., refund tokens move but the escrow's
+    // post-action event is silently swallowed) would fail the assertion.
+    // Strictly stronger than `logs.length > 0`, which would pass on the bug
+    // class this test is meant to catch since a successful void emits at
+    // least one USDC `Transfer(escrow → payer)` log independently of the
+    // escrow event.
+    const voidEvents = parseEventLogs({
+      abi: authCaptureEscrowAbi,
+      eventName: 'PaymentVoided',
+      logs: voidReceipt.logs,
+    })
+    expect(voidEvents.length).toBeGreaterThan(0)
 
     const amountsAfter = await merchant.payment.getAmounts(escrowVoidInfo)
     expect(amountsAfter.capturableAmount).toBe(0n)

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -427,3 +427,65 @@ describe('Edge case: capture overspend (amount > capturableAmount)', () => {
     expect(receiverBalanceAfter).toBe(receiverBalanceBefore)
   }, 60_000)
 })
+
+// ---------------------------------------------------------------------------
+// Edge case (e): void during escrow window — asymmetry vs capture's time gate
+// ---------------------------------------------------------------------------
+
+// Capture is time-gated via `EscrowPeriod.CAPTURE_PRE_ACTION_CONDITION`. Void
+// is NOT (`PaymentOperator.sol:323-327` shows `VOID_PRE_ACTION_CONDITION`
+// defaults to `address(0)`). This asymmetry isn't otherwise documented in
+// test form — pinning it here so the merchant DX assumption (void is always
+// available post-authorize) doesn't silently regress.
+describe('Edge case: void during escrow window (asymmetry vs capture)', () => {
+  it('void succeeds inside escrow window even though capture would not', async () => {
+    // Fresh paymentInfo with salt: 6n to avoid colliding with prior scenarios.
+    const escrowVoidInfo: PaymentInfo = { ...paymentInfo, salt: 6n }
+    const { collectorData, tokenCollector } = await createCollectorData(
+      anvilBaseSepolia.getWalletClient(testRoles.payer.address),
+      escrowVoidInfo,
+    )
+    const authHash = await payerClient.payment.authorize(
+      escrowVoidInfo,
+      DEFAULT_AMOUNT,
+      tokenCollector,
+      collectorData,
+    )
+    await publicClient.waitForTransactionReceipt({ hash: authHash })
+
+    // Deliberately DO NOT fast-forward past escrow — stay inside the window.
+    // Capture would revert here; void should not.
+    const amountsBefore = await merchant.payment.getAmounts(escrowVoidInfo)
+    expect(amountsBefore.capturableAmount).toBe(DEFAULT_AMOUNT)
+
+    // Snapshot payer balance — void inside the escrow window is a full
+    // refund (no capture happened, no fees taken). Payer should net
+    // DEFAULT_AMOUNT back, exact.
+    const payerBalanceBefore = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.payer.address],
+    })
+
+    const voidHash = await merchant.payment.voidPayment(escrowVoidInfo)
+    const voidReceipt = await publicClient.waitForTransactionReceipt({
+      hash: voidHash,
+    })
+    // SUCCESS, not reverted — the void path is unconditional on time.
+    expect(voidReceipt.status).toBe('success')
+
+    const amountsAfter = await merchant.payment.getAmounts(escrowVoidInfo)
+    expect(amountsAfter.capturableAmount).toBe(0n)
+
+    const payerBalanceAfter = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.payer.address],
+    })
+    // Full refund, no fees — nothing was captured, so receiver fee path
+    // never ran.
+    expect(payerBalanceAfter - payerBalanceBefore).toBe(DEFAULT_AMOUNT)
+  }, 60_000)
+})

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -204,18 +204,28 @@ describe('Edge case: voidPayment after full capture', () => {
     const amounts = await merchant.payment.getAmounts(edgePaymentInfo)
     expect(amounts.capturableAmount).toBe(0n)
 
-    // Observed behavior (pinned 2026-05-18 against the deployed
-    // PaymentOperator + EscrowPeriod fixtures): the SDK's `voidPayment()`
-    // submits the tx and the wallet client returns a tx hash without throwing
-    // (`writeContract` on anvil doesn't simulate before sending). On-chain,
-    // the `void()` call REVERTS — see the receipt status below. The
-    // capturableAmount stays at 0n (no state change), confirming nothing was
-    // double-voided.
+    // Observed behavior against the deployed PaymentOperator + EscrowPeriod
+    // fixtures: the SDK's `voidPayment()` submits the tx and the wallet client
+    // returns a tx hash without throwing (`writeContract` on anvil doesn't
+    // simulate before sending). On-chain, the `void()` call REVERTS — see the
+    // receipt status below. The capturableAmount stays at 0n (no state
+    // change), confirming nothing was double-voided.
     //
     // This pins down the contract-side guarantee: if a future contract
     // version turns the revert into a no-op success, or starts simulating
     // pre-send (so the SDK throws), this test will fail and force a
-    // deliberate decision.
+    // deliberate decision. JSDoc reference: voidPayment.ts:17-18.
+    //
+    // Snapshot payer balance to prove the reverting void didn't move ERC-20
+    // funds. State assertion (capturableAmount === 0n) proves escrow state;
+    // this balance assertion proves the token layer is untouched.
+    const payerBalanceBefore = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.payer.address],
+    })
+
     const voidHash = await merchant.payment.voidPayment(edgePaymentInfo)
     const voidReceipt = await publicClient.waitForTransactionReceipt({
       hash: voidHash,
@@ -224,6 +234,14 @@ describe('Edge case: voidPayment after full capture', () => {
 
     const amountsAfter = await merchant.payment.getAmounts(edgePaymentInfo)
     expect(amountsAfter.capturableAmount).toBe(0n)
+
+    const payerBalanceAfter = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.payer.address],
+    })
+    expect(payerBalanceAfter).toBe(payerBalanceBefore)
   }, 60_000)
 })
 
@@ -248,17 +266,28 @@ describe('Edge case: double capture+void on same paymentInfo', () => {
       paymentInfo,
     )
 
-    // Observed behavior (pinned 2026-05-18): the SDK's `authorize()` submits
-    // the tx and returns a hash without throwing (no pre-send simulation).
-    // The on-chain `authorize()` REVERTS in the receipt — the escrow nonce
-    // (see `computeEscrowNonce` at packages/core/src/payment/hashing.ts:87-97)
-    // is already consumed by Scenario 3's capture+void, and ERC-3009 nonces
-    // are single-use, so the second authorize cannot pull tokens. The
+    // Observed behavior: the SDK's `authorize()` submits the tx and returns a
+    // hash without throwing (no pre-send simulation). The on-chain
+    // `authorize()` REVERTS in the receipt — the escrow nonce (see
+    // `computeEscrowNonce` at packages/core/src/payment/hashing.ts:87-97) is
+    // already consumed by Scenario 3's capture+void, and ERC-3009 nonces are
+    // single-use, so the second authorize cannot pull tokens. The
     // capturableAmount stays at 0n.
     //
     // This is the replay-protection boundary: if a future contract version
     // ever lets this succeed, a malicious or buggy caller could re-collect
     // tokens against a paymentInfo the payer thought was fully consumed.
+    //
+    // Snapshot payer balance to prove the reverting authorize didn't pull
+    // any tokens at the ERC-20 layer. State assertion (capturableAmount === 0n)
+    // proves escrow state; this balance assertion proves no funds moved.
+    const payerBalanceBefore = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.payer.address],
+    })
+
     const replayHash = await payerClient.payment.authorize(
       paymentInfo,
       DEFAULT_AMOUNT,
@@ -272,5 +301,13 @@ describe('Edge case: double capture+void on same paymentInfo', () => {
 
     const amountsAfter = await merchant.payment.getAmounts(paymentInfo)
     expect(amountsAfter.capturableAmount).toBe(0n)
+
+    const payerBalanceAfter = await publicClient.readContract({
+      address: USDC,
+      abi: erc20Abi,
+      functionName: 'balanceOf',
+      args: [testRoles.payer.address],
+    })
+    expect(payerBalanceAfter).toBe(payerBalanceBefore)
   }, 60_000)
 })

--- a/packages/core/tests/integration/partial-refund.fork.test.ts
+++ b/packages/core/tests/integration/partial-refund.fork.test.ts
@@ -316,7 +316,7 @@ describe('Edge case: double capture+void on same paymentInfo', () => {
     // `packages/core/src/actions/{operator,refund-budget}/`). So the SDK
     // returns a tx hash without throwing; the on-chain revert surfaces only at
     // receipt-level. A merchant integration that trusts
-    // `await payment.voidPayment(...)` to throw on failure will silently miss
+    // `await payment.authorize(...)` to throw on failure will silently miss
     // reverts in production. The on-chain `authorize()` REVERTS in the
     // receipt — the replay-protection gate is USDC's ERC-3009
     // `authorizationState(payer, nonce)` mapping — the nonce was consumed


### PR DESCRIPTION
PR 2 of 3 in the `@x402r/sdk@0.3.0` publish-readiness series tracked at `x402r-notes/plans/PHASE_3_PUBLISH_READINESS.md`.

## Summary

Adds two new `describe` blocks to `packages/core/tests/integration/partial-refund.fork.test.ts` to pin down on-chain behavior at the partial-capture / void boundary. No new files, no new fixtures, no contract changes.

## What's pinned down, and why each matters

### (b) `voidPayment` after full capture

**Real-world failure mode:** a merchant calls `capture(full)` to claim the full authorized amount, then mistakenly (or defensively) calls `voidPayment()` afterward. The JSDoc on `voidPayment` (`packages/core/src/actions/refund-budget/voidPayment.ts:17-18`) says it "empties the authorization in one transaction" but does not specify what happens when `capturableAmount === 0` already.

**On-chain surprise class:** a future contract change could turn the current revert into a silent no-op success, or vice versa. Either direction would change the SDK's effective surface without an SDK-side code change.

**Observed behavior (pinned 2026-05-18 against the fixture-deployed `PaymentOperator` + `EscrowPeriod`):**
- The SDK's `voidPayment()` submits the tx and returns a tx hash WITHOUT throwing. This is because `walletClient.writeContract` on anvil does not simulate before sending, and the SDK's `wrapContractCall` error-wrapping only fires on thrown errors.
- The on-chain `void()` REVERTS in the receipt (`receipt.status === 'reverted'`).
- `capturableAmount` remains `0n` (no state corruption).

The test asserts the receipt-level revert + post-state, which is the contract-level guarantee that matters.

### (c) Double-application / replay protection

**Real-world failure mode:** an integration retries or re-applies a `paymentInfo + signature` after the original authorization was already `capture+void`'d. If the escrow nonce ever stopped rejecting this, an attacker (or a buggy retry loop) could re-collect tokens from a payer who thought their payment was fully consumed.

**On-chain surprise class:** the security boundary here is `computeEscrowNonce` at `packages/core/src/payment/hashing.ts:87-97` — derived from `(chainId, escrowAddress, paymentInfo with payer = address(0))`. ERC-3009 nonces are single-use, so a second `authorize` on the same `paymentInfo` (same salt) must fail.

**Observed behavior (pinned 2026-05-18):**
- Same shape as case (b): the SDK's `authorize()` returns a tx hash without throwing, but the on-chain tx REVERTS in the receipt.
- `capturableAmount` stays `0n` after the failed replay attempt, confirming nothing was re-collected.

The test re-uses the file-level `beforeAll` `paymentInfo` (`salt: 3n`) which the preceding `Scenario 3: Partial capture + void remainder` describe block has already consumed. Vitest runs describes in file order, so this dependency is well-defined; the test has a code comment documenting it.

## Out of scope

Edge case (a) — `merchantAmount === 0` — is deferred. It needs contracts-side investigation in `x402r-contracts` (whether the operator allows a zero-amount capture at all, and what the intended behavior is) before an SDK-level test can meaningfully pin it down.

## CI cost delta

~30s on the existing `test-fork` job (two new tests, each bounded at 60s but in practice each completes in ~2-3s once fixtures are warm). No new files, no new fixtures, no new CI lanes.

## Test plan

- [x] `pnpm --filter=@x402r/core exec vitest run tests/integration/partial-refund.fork.test.ts --project core:fork` — 4/4 pass (the existing 2 happy-path tests + the 2 new edge cases)
- [x] `pnpm check` (biome) — clean
- [x] `pnpm --filter=@x402r/core typecheck` — clean
- [x] Full `pnpm --filter=@x402r/core test:fork` shows no regressions vs origin/main baseline. The same 6-7 unrelated fork tests fail on both origin/main and this branch due to local anvil/prool RPC flakiness (`HttpRequestError` on `anvil_setCode`, not contract logic); the new tests are not among the flaky ones.
