### PR TITLE
ci(release): release.yml — Trusted Publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,72 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  release:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    # Required reviewer gate — see Settings -> Environments -> npm-publish.
+    # npm Trusted Publishing rules are scoped to this environment + workflow filename.
+    environment: npm-publish
+    permissions:
+      contents: write       # Push tags + Version PR commits
+      pull-requests: write  # Open/update the "Version Packages" PR
+      id-token: write       # OIDC handshake for npm Trusted Publishing
+    steps:
+      # Egress monitoring. Starts in audit mode so the first runs surface
+      # exactly which endpoints we actually hit; Phase 7 flips this to
+      # `block` with the observed allow-list.
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          # Full history so changesets can generate complete changelogs.
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      # npm >= 11.5.1 is required for Trusted Publishing OIDC support.
+      # Node 22 ships with npm 10.x; upgrade explicitly.
+      - name: Upgrade npm
+        run: npm install --global npm@latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build packages
+        run: pnpm build
+
+      # When there are unconsumed changesets in .changeset/, opens/updates
+      # the "Version Packages" PR. When that PR is merged (consuming the
+      # changesets), the next run takes the `publish` branch and publishes
+      # each changed package via OIDC with automatic provenance, then
+      # creates per-package GitHub releases (@x402r/core@1.2.3 style tags).
+      - name: Create Release PR or publish to npm
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b  # v1.8.0
+        with:
+          publish: pnpm exec changeset publish
+          version: pnpm exec changeset version
+          title: "chore: version packages"
+          commit: "chore: version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,9 +46,12 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       # npm >= 11.5.1 is required for Trusted Publishing OIDC support.
-      # Node 22 ships with npm 10.x; upgrade explicitly.
-      - name: Upgrade npm
-        run: npm install --global npm@latest
+      # Pin to a specific version (not @latest) — pulling latest on a
+      # privileged runner re-introduces the upstream-trust hole we close
+      # everywhere else. Dependabot or quarterly review bumps this.
+      # --ignore-scripts: don't run npm's own lifecycle scripts on install.
+      - name: Upgrade npm (Trusted Publishing requires >= 11.5.1)
+        run: npm install --global npm@11.14.1 --ignore-scripts
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
@@ -56,11 +59,23 @@ jobs:
       - name: Build packages
         run: pnpm build
 
+      # Upfront gate: publint + attw across all publishable packages.
+      # Without this, a per-package prepublishOnly failure can occur
+      # *after* earlier packages have already published, leaving a
+      # partial release.
+      - name: Validate package tarballs (publint + attw)
+        run: pnpm test:pkg
+
       # When there are unconsumed changesets in .changeset/, opens/updates
       # the "Version Packages" PR. When that PR is merged (consuming the
       # changesets), the next run takes the `publish` branch and publishes
-      # each changed package via OIDC with automatic provenance, then
-      # creates per-package GitHub releases (@x402r/core@1.2.3 style tags).
+      # each changed package via OIDC, then creates per-package GitHub
+      # releases (@x402r/core@1.2.3 style tags).
+      #
+      # Provenance: NPM_CONFIG_PROVENANCE=true plus the per-package
+      # publishConfig.provenance flag together guarantee Sigstore-backed
+      # attestations regardless of changesets/cli inference. Verify with
+      # `npm audit signatures @x402r/<pkg>` after a publish.
       - name: Create Release PR or publish to npm
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b  # v1.8.0
         with:
@@ -70,3 +85,4 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,10 @@
   "description": "One-shot CLI for paying x402 / x402r endpoints. Wallet-agnostic: raw key, JSON-RPC signer, or custom module.",
   "type": "module",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "bin": {
     "x402r": "./dist/bin.js"
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.0",
   "type": "module",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.0",
   "type": "module",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,6 +3,10 @@
   "version": "0.3.0",
   "type": "module",
   "license": "Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary

Phase 2 of the release-pipeline rollout (full plan: `x402r-notes/plans/RELEASE_PIPELINE.md`). Adds the stable-release workflow that publishes `@x402r/*` packages via npm Trusted Publishing on push-to-main, gated by the `npm-publish` GitHub environment.

**Replaces manual `npm publish` from a maintainer laptop.** No long-lived `NPM_TOKEN`.

## How it works

1. PRs add changesets (`.changeset/*.md`) describing version bumps + changelogs.
2. On merge to `main`, this workflow opens/updates a "Version Packages" PR that consumes pending changesets, bumps `package.json` versions, and regenerates `CHANGELOG.md`.
3. Merging that Version PR triggers a publish run.
4. The publish run pauses at the `npm-publish` environment for explicit maintainer approval.
5. On approval, npm authenticates via OIDC (no token), publishes packages with provenance attestations, and creates per-package GitHub releases (`@x402r/<pkg>@<version>` tags).

## Security posture

- Top-level `permissions: {}` default-deny; per-job permissions narrowed to `contents: write`, `pull-requests: write`, `id-token: write`.
- Every action SHA-pinned to immutable commits (mitigates tj-actions-style retroactive tag-move attacks). Dependabot will keep SHAs + trailing version comments current.
- `step-security/harden-runner` in audit mode initially — surfaces actual egress profile across the first runs; Phase 7 will flip to `block` with the observed allow-list.
- `pnpm install --ignore-scripts` blocks dependency lifecycle hooks (Shai-Hulud-style postinstall worms have nowhere to run).
- Explicit `npm install --global npm@latest` because Node 22 ships with npm 10.x and OIDC Trusted Publishing requires npm ≥ 11.5.1.

## Prerequisites (already complete)

- ✅ `npm-publish` GitHub environment created with required-reviewer rule (Phase 1).
- ✅ Trusted Publisher configured on each of `@x402r/{core,sdk,helpers,cli}` pointing at `release.yml` + `npm-publish` environment (Phase 1).
- ⏳ Phase 0 PR (#129) merged for CODEOWNERS to gate this file in future edits.

## Test plan

This workflow only runs on push-to-main, so this PR's CI only exercises the existing `ci.yml`. Real validation happens in Phase 4 (first CI-driven publish):

- [ ] CI checks pass on this PR (no changes to `ci.yml`).
- [ ] After merge, observe the workflow run shows the `npm-publish` environment gate.
- [ ] Phase 4 will exercise the full flow: consume changesets → Version PR → merge → environment approval → publish → verify provenance via `npm audit signatures`.

## Plan reference

Full multi-phase release pipeline plan: https://github.com/BackTrackCo/x402r-notes/blob/main/plans/RELEASE_PIPELINE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)