### PR TITLE
ci: unblock knip by registering scenarios:ci as an examples-workspace script

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -16,7 +16,8 @@
     "scenario:dispute": "tsx scenarios/dispute-resolution.ts",
     "scenario:atomic-charge": "tsx scenarios/atomic-charge.ts",
     "scenario:partial-refund-flow": "tsx scenarios/partial-refund-flow.ts",
-    "scenario:permit2-charge": "tsx scenarios/permit2-charge.ts"
+    "scenario:permit2-charge": "tsx scenarios/permit2-charge.ts",
+    "scenarios:ci": "tsx scripts/scenarios-ci.ts"
   },
   "dependencies": {
     "@x402r/core": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "example:arbiter:review-evidence": "pnpm --filter examples run arbiter:review-evidence",
     "scenario:release": "pnpm --filter examples run scenario:release",
     "scenario:dispute": "pnpm --filter examples run scenario:dispute",
-    "scenarios:ci": "pnpm --filter examples exec tsx scripts/scenarios-ci.ts"
+    "scenarios:ci": "pnpm --filter examples run scenarios:ci"
   },
   "engines": {
     "node": ">=22"


### PR DESCRIPTION
## Summary

Unblocks the `Publish Validation` CI job that's failing on main. `knip` was flagging `examples/scripts/scenarios-ci.ts` as an unused file because the root invoked it via `pnpm --filter examples exec tsx scripts/scenarios-ci.ts` — `exec` bypasses workspace `package.json` scripts, so knip's script-entry trace couldn't see it.

## Fix

- `examples/package.json`: add `"scenarios:ci": "tsx scripts/scenarios-ci.ts"` alongside the other `scenario:*` scripts.
- Root `package.json`: change `pnpm --filter examples exec tsx scripts/scenarios-ci.ts` → `pnpm --filter examples run scenarios:ci`.

This mirrors the existing scenario pattern (e.g. `"scenario:dispute": "pnpm --filter examples run scenario:dispute"`) and lets knip trace the script entry naturally. No changes to `knip.json` — the fix is in the wiring, not in knip suppression.

## Verification

- Before: `pnpm knip` reports `Unused files (1): examples/scripts/scenarios-ci.ts` and exits 1.
- After: `pnpm knip` reports clean and exits 0.
- `pnpm scenarios:ci` still runs both scenarios end-to-end (dispute + permit2-charge under shared prool).

## Why this matters

Every new PR's CI shows red on `Publish Validation` until this lands, because their CI runs against main where the failure exists. Phase-0 release-pipeline work (#129) is currently blocked by this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
