### PR TITLE
ci: skip Codecov upload on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,10 @@ jobs:
       - run: pnpm build
       - run: pnpm --filter=@x402r/core test:cov
       - name: Upload core coverage
+        # Dependabot PRs run without secret access, so CODECOV_TOKEN is empty
+        # and the upload fails with "Token required because branch is protected".
+        # Skip on dependabot — coverage uploads aren't useful on dep bumps anyway.
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -64,6 +68,7 @@ jobs:
           fail_ci_if_error: true
       - run: pnpm --filter=@x402r/helpers test:cov
       - name: Upload helpers coverage
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -72,6 +77,7 @@ jobs:
           fail_ci_if_error: true
       - run: pnpm --filter=@x402r/sdk test:cov
       - name: Upload SDK coverage
+        if: github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

- All 9 currently open Dependabot PRs are blocked on the `Test` required check.
- Root cause: codecov-action fails with `Token required because branch is protected` when `CODECOV_TOKEN` is empty, and Dependabot PRs run without secret access.
- Because `fail_ci_if_error: true`, the failed upload fails the whole `Test` job — even though the tests themselves pass.

## Fix

Gate the three coverage upload steps on `github.actor != 'dependabot[bot]'`. Dependabot PRs skip the upload entirely; coverage isn't useful on dep bumps anyway. Strict `fail_ci_if_error` is preserved for main pushes and regular contributor PRs, so a real Codecov outage still fails CI.

## Test plan

- [ ] CI on this PR passes `Test` (this PR is not from Dependabot, so the upload still runs and exercises the happy path).
- [ ] After merge, re-trigger CI on one of the open Dependabot PRs (e.g. #134) and verify `Test` is no longer failing on the upload step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)