### PR TITLE
ci: migrate Codecov upload to OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,13 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # id-token: write lets codecov-action mint a per-run OIDC JWT instead of
+    # using a long-lived CODECOV_TOKEN secret. The ternary on use_oidc falls
+    # back to Codecov's public-repo tokenless path for fork PRs, which can't
+    # mint OIDC tokens. Pattern matches microsoft/TypeScript's ci.yml.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
@@ -58,7 +65,7 @@ jobs:
       - name: Upload core coverage
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           files: packages/core/coverage/lcov.info
           flags: core
           fail_ci_if_error: true
@@ -66,7 +73,7 @@ jobs:
       - name: Upload helpers coverage
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           files: packages/helpers/coverage/lcov.info
           flags: helpers
           fail_ci_if_error: true
@@ -74,7 +81,7 @@ jobs:
       - name: Upload SDK coverage
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           files: packages/sdk/coverage/lcov.info
           flags: sdk
           fail_ci_if_error: true


### PR DESCRIPTION
## Problem

Token-based Codecov authentication breaks every PR that can't access repo secrets:

- **Dependabot PRs** (9 currently open and stuck): Dependabot runs without secret access by default, so `CODECOV_TOKEN` is empty. The upload fails with `Token required because branch is protected`, and `fail_ci_if_error: true` fails the whole `Test` job — even though the tests themselves pass.
- **External contributor PRs from forks**: same wall, by design (secrets aren't shared with forks).

This is structural, not specific to one PR. As we open the project to external contribution, every fork PR will hit this.

## Fix

Migrate to **OIDC-based authentication** (codecov-action's `use_oidc: true`). No long-lived secret needed. `codecov-action` mints a per-run JWT audience-bound to Codecov; Codecov verifies the JWT's `iss`/`repository`/`workflow_ref` claims against the registered repo.

- For non-fork PRs (Dependabot, internal contributor PRs, pushes to main): `use_oidc: true` → OIDC upload works.
- For fork PRs: GitHub restricts `id-token: write` on forks, so the ternary flips `use_oidc` to `false` and the action falls through to Codecov v5's public-repo tokenless path. Both contributor classes handled.

The diff:
- Adds `permissions: { contents: read, id-token: write }` scoped to the `test` job (least privilege — other jobs don't need OIDC).
- Replaces `token: ${{ secrets.CODECOV_TOKEN }}` with `use_oidc: ${{ !(... .fork) }}` on the three upload steps.

## Why this is the right answer

- **Industry standard**: `microsoft/TypeScript`'s `ci.yml` uses this exact `use_oidc: ${{ !(... .fork) }}` ternary today. Verified by reading their workflow file.
- **GitHub's own hardening guide** recommends OIDC over long-lived secrets for service auth.
- **OpenSSF Scorecard** rewards OIDC-based authentication.
- Eliminates the `CODECOV_TOKEN` secret as an attack surface entirely (per-run JWT, audience-bound, expires in minutes).
- Single workflow file, no `workflow_run` two-workflow choreography, no actor-string hardcoding.

## Test plan

- [ ] CI on this PR passes `Test` (this PR is non-fork, exercises the OIDC path).
- [ ] After merge, re-trigger CI on one of the open Dependabot PRs (e.g. #134) and verify `Test` is now green — confirms OIDC works for Dependabot.
- [ ] Once verified end-to-end, follow-up housekeeping: **delete `CODECOV_TOKEN` from repo Actions secrets** (Settings → Secrets and variables → Actions). This is the security cleanup that closes the long-lived-credential surface.

## Optional follow-ups

- Enable "tokenless uploads" toggle in Codecov UI so external fork PRs actually post coverage (vs the upload silently failing). Pure feature toggle; no security impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)