### PR TITLE
ci: add Dependabot cooldown to close supply-chain attack window

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 10
+    # Defer version bumps for N days after publish to close the supply-chain
+    # attack window (most malicious publishes are caught within 24-72h).
+    # Security updates (GHSA-driven) bypass cooldown and still PR immediately.
+    cooldown:
+      default-days: 7
+      semver-minor-days: 14
+      semver-major-days: 30
     groups:
       production-dependencies:
         dependency-type: production
@@ -25,6 +32,9 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     groups:
       actions:
         patterns:


### PR DESCRIPTION
## Why

Right now, Dependabot will happily PR you into a version published 30 minutes ago. Most supply-chain attacks (event-stream, ua-parser-js, polyfill.io, recent xz-style maintainer compromises) were detected and the bad versions unpublished within **24–72 hours** of publish. Without cooldown, we're exposed to that window every time Dependabot runs.

Concrete from this week's PRs: `viem 2.50.4` (#134) and `tsx 4.22.3` (#134) were both published <24h before Dependabot PR'd them. `@types/node 25.9.1` (#137, #140) the same day. Even though all three checked out clean in the triage, exposing ourselves to that timing has no upside — we don't need today's version when last week's is fine.

## What

Adds `cooldown:` blocks to both `updates:` entries in `.github/dependabot.yml`:

| Bump class | Wait before PR'ing |
|---|---|
| Patch | 7 days |
| Minor | 14 days |
| Major | 30 days |

**Security updates (GHSA advisories) bypass cooldown** — GitHub explicitly carves this out, so we still get critical patches as soon as they're available. This config only delays "newer version exists" bumps, not advisory-driven fixes.

## What this doesn't change

- We still get every version eventually — nothing is skipped.
- Lockfile-based pinning still works the same way.
- Existing 9 open Dependabot PRs are unaffected (cooldown applies to *future* Dependabot runs, not retroactively).

## References

- [GitHub docs — Dependabot cooldown reference](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown--)
- Industry-standard pattern; Renovate's `minimumReleaseAge` has done the same for years. Used by nextcloud, Cloudflare, others.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge, observe next Monday's Dependabot run: any version published in the prior week is held; older ones flow as PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)