### PR TITLE
ci: scope Dependabot to single root directory for pnpm workspace

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,12 @@
 version: 2
 updates:
-  # npm dependencies across root and all workspace packages.
+  # npm dependencies across the workspace. pnpm uses a single root lockfile
+  # for all workspace packages, so we run Dependabot from root only.
+  # Bumping per-directory (root + /packages/*) produces duplicate PRs and
+  # breaks --frozen-lockfile because the root lockfile isn't re-synced when
+  # an individual package.json is edited.
   - package-ecosystem: npm
-    directories:
-      - "/"
-      - "/packages/*"
+    directory: "/"
     schedule:
       interval: weekly
       day: monday


### PR DESCRIPTION
## Problem

`.github/dependabot.yml` currently runs Dependabot in both root and `/packages/*`:

```yaml
directories:
  - "/"
  - "/packages/*"
```

For npm + pnpm workspaces this is wrong, and we've now seen both failure modes it causes:

### 1. Duplicate PRs

Every workspace-referenced dep produces two PRs — one for the root `package.json` and one for the package directory that imports it. This week alone:
- **#139** (root) + **#141** (`/packages/sdk`) → both bump `@x402r/erc8004 0.1.0-alpha.1 → alpha.2`
- **#137** (root) + **#140** (`/packages/cli`) → both bump `@types/node 20 → 25`

That's 4 PRs for what should be 2.

### 2. Lockfile mismatch — CI fails at install

pnpm uses a **single root `pnpm-lock.yaml`** for all workspace packages. When Dependabot bumps `packages/sdk/package.json` without re-syncing the root lockfile, CI fails immediately:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile"
  because pnpm-lock.yaml is not up to date with <ROOT>/packages/sdk/package.json
  - @x402r/erc8004 (lockfile: ^0.1.0-alpha.1, manifest: ^0.1.0-alpha.2)
```

Confirmed today on PR #141. The Test job never runs because install dies first.

## Fix

```yaml
directory: "/"
```

pnpm's workspace resolver operates from root and updates all workspace `package.json` references plus the single root lockfile atomically. One PR per dep, lockfile always in sync.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: close the existing duplicate PRs (#139, #141, #137, #140) and the related ones — Dependabot will recreate them cleanly on the next run.
- [ ] Verify next Monday's Dependabot run produces single PRs per dep with lockfile updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)