### PR TITLE
core(tests): per-file Anvil snapshot/revert isolation for fork suite

### DIFF
--- a/packages/core/tests/integration/post-capture-refund.fork.test.ts
+++ b/packages/core/tests/integration/post-capture-refund.fork.test.ts
@@ -41,8 +41,14 @@ const REFUND_AMOUNT = 500_000n
 let paymentInfo: PaymentInfo
 
 beforeAll(async () => {
+  // salt 11n: distinct from every other fork test's salts. Fork tests share a
+  // single Anvil instance via globalSetup, so colliding salts across files
+  // share the same paymentInfoHash and bleed state. The "edge case: sequential
+  // overspend after partial capture" in partial-refund.fork.test.ts:636 also
+  // uses salt 7n and leaves capturableAmount = 500_000n, which then makes this
+  // file's first authorize+capture see 500_000n still capturable instead of 0n.
   ;({ publicClient, testClient, fixtures, paymentInfo } = await setupScenario({
-    salt: 7n,
+    salt: 11n,
   }))
 
   payerClient = createX402r({

--- a/packages/core/tests/integration/post-capture-refund.fork.test.ts
+++ b/packages/core/tests/integration/post-capture-refund.fork.test.ts
@@ -41,12 +41,6 @@ const REFUND_AMOUNT = 500_000n
 let paymentInfo: PaymentInfo
 
 beforeAll(async () => {
-  // salt 11n: distinct from every other fork test's salts. Fork tests share a
-  // single Anvil instance via globalSetup, so colliding salts across files
-  // share the same paymentInfoHash and bleed state. The "edge case: sequential
-  // overspend after partial capture" in partial-refund.fork.test.ts:636 also
-  // uses salt 7n and leaves capturableAmount = 500_000n, which then makes this
-  // file's first authorize+capture see 500_000n still capturable instead of 0n.
   ;({ publicClient, testClient, fixtures, paymentInfo } = await setupScenario({
     salt: 11n,
   }))

--- a/packages/core/tests/setup/snapshot-revert.ts
+++ b/packages/core/tests/setup/snapshot-revert.ts
@@ -1,0 +1,25 @@
+import { afterAll, beforeAll } from 'vitest'
+import { anvilBaseSepolia } from './anvil.js'
+
+// Per-file Anvil snapshot/revert isolation. vitest re-executes this module
+// once per test file (isolate: true), so `snapshotId` resets per file. Anvil
+// consumes the snapshot id on revert (HashMap.remove in revert_state_snapshot;
+// Hardhat docs document the same constraint on the same RPC), so no reuse
+// path is needed — the next file's beforeAll takes a fresh snapshot.
+//
+// `retry: 3` on the core:fork project reuses the same snapshot across retries
+// of a failed test — state mutations from a failed-then-retried test still
+// leak into the next attempt. Pre-existing; unchanged by this hook.
+let snapshotId: `0x${string}` | undefined
+
+beforeAll(async () => {
+  const testClient = anvilBaseSepolia.getTestClient()
+  snapshotId = await testClient.snapshot()
+})
+
+afterAll(async () => {
+  if (snapshotId === undefined) return
+  const testClient = anvilBaseSepolia.getTestClient()
+  await testClient.revert({ id: snapshotId })
+  snapshotId = undefined
+})

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -56,11 +56,20 @@ export default defineConfig({
           name: 'core:fork',
           include: ['tests/integration/**/*.fork.test.ts'],
           globalSetup: ['tests/setup/globalSetup.ts'],
+          setupFiles: ['tests/setup/snapshot-revert.ts'],
           testTimeout: 60_000,
           hookTimeout: 60_000,
           passWithNoTests: true,
           // Fork RPC (Alchemy) can be flaky — retry individual tests instead of restarting the suite
           retry: 3,
+          // Run fork-test files sequentially (one at a time). The setupFiles
+          // snapshot/revert above gives per-file state isolation structurally
+          // — we no longer need parallel workers each spawning their own
+          // Anvil child fork. Parallel cold-spawns rate-limit Base Sepolia's
+          // public RPC and make `evm_snapshot` 400 unreliably on fresh prool
+          // subpaths. Empirically the sequential run is also faster than
+          // multi-worker parallel runs because we save N-1 fork-startup costs.
+          fileParallelism: false,
         },
       },
     ],


### PR DESCRIPTION
## Summary

Structural fix for cross-file state pollution in the `core:fork` test suite. Per-file Anvil snapshot/revert via vitest `setupFiles` makes salt-collision-style pollution impossible regardless of which salt any test picks. The original `salt: 11n` rename (commit `cf22b2f`) stays as defense-in-depth.

### Root cause

Fork tests share a single Anvil instance via `globalSetup`. Vitest packs multiple test files into the same worker (same `VITEST_POOL_ID` → same prool subpath → same Anvil child). Files using identical salts (e.g., `7n` shared by `partial-refund.fork.test.ts:636` and `post-capture-refund.fork.test.ts:45`) collide on the same `paymentInfoHash` → cross-file state bleeds. The `poolId × shardId` subpath isolation that x402r copied from viem only isolates per *vitest worker*, not per *test file*.

PR #128's "edge case: sequential overspend after partial capture" (commit `242a2cb`) woke up the `7n` collision specifically. Five other latent collisions exist (`4n/5n/6n/8n/100n`).

### Mechanism

- New `packages/core/tests/setup/snapshot-revert.ts` registers a module-level `beforeAll`/`afterAll`: `evm_snapshot` before each file's tests, `evm_revert` after. vitest's `isolate: true` (default) re-executes the setupFiles module per file, so `snapshotId` resets — fresh snapshot per file. Anvil consumes the snapshot id on revert (verified against Anvil source: `HashMap.remove(&id)` in `revert_state_snapshot`; Hardhat documents the same single-use constraint on the same RPC).
- `vitest.config.ts` adds `setupFiles: ['tests/setup/snapshot-revert.ts']` + `fileParallelism: false` to the `core:fork` project (scoped, doesn't affect the `core` unit project). Sequential file execution shares one Anvil fork via `globalSetup`; snapshot/revert provides the isolation that previously came from each worker spawning its own forked Anvil child.

**Pattern source:** this is the per-file variant of Hardhat's `SnapshotRestorer` / `loadFixture` from `@nomicfoundation/hardhat-network-helpers`, adapted for vitest + viem + Anvil. The viem reference in this repo only supplied the prool subpath URL trick (per-worker isolation), not the snapshot/revert composition.

### Alternative considered: derive `salt` from `import.meta.url` per file

One line per file, zero runtime cost, structurally eliminates salt collisions (different files literally cannot hash to the same paymentInfoHash). Snapshot/revert was picked instead because it catches *any* future cross-file storage pollution — not just the salt-derived class — and matches the defense-in-depth approach already taken (`salt: 11n` kept as belt-and-suspenders). The per-file-salt alternative remains valid as a follow-up if snapshot/revert ever proves too coarse.

### Why `fileParallelism: false`

Root-caused by running with parallel mode + verbose diagnostics on the snapshot hook. The HTTP 400 from prool was wrapping an upstream rate-limit error: each Anvil child cold-spawns by calling `eth_blockNumber` and account-state queries against the configured fork URL. When 8 workers all spawn simultaneously against `https://sepolia.base.org`, the public RPC returns `HTTP 429 / over rate limit` (JSON-RPC error code `-32016`). Anvil's startup then fails with `failed to get fork block number` or `failed to create genesis`, and prool's HTTP handler wraps the spawn error as `HTTP 400 Bad Request` with the underlying 429 message in the body.

Adding the `setupFiles` snapshot hook synchronized the first RPC across workers, making the race deterministic rather than intermittent. The prior multi-worker config was implicitly tolerating the same rate limit because each file's `beforeAll` (setCode + deploys) was racing it too — failures were timing-hidden rather than caught by retry (`retry: 3` doesn't cover `beforeAll`).

Sequential execution does one fork bootstrap, makes one set of RPC calls to public Base Sepolia, and runs all tests against the single shared Anvil child. No rate-limit pressure.

**Escape hatch:** set `VITE_ANVIL_FORK_URL_BASE_SEPOLIA` to a private RPC URL (Alchemy / QuickNode / etc.) and parallel mode becomes viable again. Sequential remains the default for portability + zero-config CI.

**Runtime impact:**
- Local (snapshot/revert + sequential): **108.65s** (13 files, 93 tests).
- CI on the same commit: **5m21s** — slower than the prior multi-worker parallel baseline (4m27s) by ~50s. CI's GitHub Actions runner pays the per-test RPC roundtrip latency more than a local machine does, and the prior parallelism was hiding some of that. Trade-off accepted: reliability + structural correctness for a ~50s CI runtime increase.

### Verification against authoritative sources

| Question | Source | Answer |
|---|---|---|
| Anvil snapshot id consumed on revert? | Anvil source: `HashMap.remove(&id)` in `revert_state_snapshot` | YES |
| Same on the Hardhat RPC? | Hardhat docs: *"A snapshot can only be reverted once."* | YES |
| Pattern in viem's tests? | `viem/src/actions/test/revert.test.ts:17-42`: single snapshot+revert per scope | Confirms single-use |
| vitest setupFiles re-execute per file? | `@vitest/runner@4.0.18/dist/index.js:1378` (`runSetupFiles` called per spec) with `isolate: true` default | YES |
| Actual cause of `evm_snapshot` 400 in parallel? | Captured 400 body verbatim: `Failed to start process "anvil": ... HTTP error 429 ... over rate limit` from upstream RPC | Public RPC throttle |

### Test plan

- [x] `pnpm install --frozen-lockfile` clean
- [x] `pnpm --filter=@x402r/core build` clean
- [x] Local two-file repro (the original collision case): `partial-refund` + `post-capture-refund` together → 13/13 pass
- [x] Local full fork suite: 13/13 files, 93/93 tests, 108.65s
- [x] CI Fork Tests job green on `ec65fb9` (required check per ruleset 16663990) — 5m21s

### Notes

- `retry: 3` on the core:fork project reuses the same snapshot across retries of a failed test — pre-existing limitation unchanged by this hook.
- Latent salt collisions (`4n/5n/6n/8n/100n`) are no longer reachable. Salt-uniqueness becomes belt-and-suspenders.
