### PR TITLE
ci(release): rewrite release.yml as workflow_dispatch (kills auto-trigger noise)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,39 @@
 name: Release
 
+# Manually triggered only. Click "Run workflow" in the Actions UI when
+# you want to either open/update the Version Packages PR (if there are
+# pending changesets) or publish to npm (after the Version PR is merged).
+#
+# Changesets self-selects which mode to run via its `hasChangesets`
+# output — one click does the right thing.
+#
+# Industry pattern: changesets/changesets uses the same two-job split.
+# See x402r-notes/sdk/RELEASING.md for the operator runbook.
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
+  # Never cancel a mid-release run — a partial publish leaves npm in an
+  # inconsistent state. Queue subsequent dispatches instead.
+  cancel-in-progress: false
 
 jobs:
-  release:
-    name: Publish to npm
+  # Job 1: open/update the "Version Packages" PR if there are pending
+  # changesets. Doesn't publish anything. No publish secrets are needed
+  # so no OIDC scope and no env gate.
+  version:
+    name: Version
     runs-on: ubuntu-latest
-    # Required reviewer gate — see Settings -> Environments -> npm-publish.
-    # npm Trusted Publishing rules are scoped to this environment + workflow filename.
-    environment: npm-publish
+    timeout-minutes: 20
+    outputs:
+      hasChangesets: ${{ steps.changesets.outputs.hasChangesets }}
     permissions:
-      contents: write       # Push tags + Version PR commits
-      pull-requests: write  # Open/update the "Version Packages" PR
-      id-token: write       # OIDC handshake for npm Trusted Publishing
+      contents: write       # Push the version-bump commit
+      pull-requests: write  # Open/update the Version Packages PR
     steps:
-      # Egress monitoring. Starts in audit mode so the first runs surface
-      # exactly which endpoints we actually hit; Phase 7 flips this to
-      # `block` with the observed allow-list.
       - name: Harden runner
         uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
         with:
@@ -32,7 +42,72 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          persist-credentials: false
           # Full history so changesets can generate complete changelogs.
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      # Trusted Publishing needs npm >= 11.5.1. Pin a specific version
+      # rather than @latest so a compromised npm release can't auto-land
+      # on the privileged runner. Same defense as SHA-pinning actions.
+      - name: Pin npm
+        run: npm install --global npm@11.14.1 --ignore-scripts
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Create or update Version Packages PR
+        id: changesets
+        uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b  # v1.8.0
+        with:
+          version: pnpm exec changeset version
+          commit: "chore(release): version packages"
+          title: "chore(release): version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Job 2: publish to npm. Only runs when the version job found NO
+  # pending changesets (i.e., the Version PR was already merged on a
+  # previous dispatch and the workspace versions are bumped + clean).
+  publish:
+    name: Publish to npm
+    if: needs.version.outputs.hasChangesets == 'false'
+    needs: version
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Environment label matches the npm Trusted Publishing config on
+    # npmjs.com for each @x402r/* package. Required-reviewer protection
+    # on this environment is OPTIONAL — workflow_dispatch already gates
+    # on maintainer access. To eliminate the second click entirely,
+    # remove the required reviewer in Settings -> Environments ->
+    # npm-publish; the environment label stays for OIDC scoping.
+    environment: npm-publish
+    permissions:
+      contents: write    # Per-package release tags + GitHub releases
+      id-token: write    # OIDC handshake for npm Trusted Publishing
+    env:
+      # Belt-and-suspenders with per-package publishConfig.provenance.
+      # Either alone would work; together they guarantee Sigstore-backed
+      # attestations on every published artifact.
+      NPM_CONFIG_PROVENANCE: "true"
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5  # v2.19.3
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -45,12 +120,7 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      # npm >= 11.5.1 is required for Trusted Publishing OIDC support.
-      # Pin to a specific version (not @latest) — pulling latest on a
-      # privileged runner re-introduces the upstream-trust hole we close
-      # everywhere else. Dependabot or quarterly review bumps this.
-      # --ignore-scripts: don't run npm's own lifecycle scripts on install.
-      - name: Upgrade npm (Trusted Publishing requires >= 11.5.1)
+      - name: Pin npm
         run: npm install --global npm@11.14.1 --ignore-scripts
 
       - name: Install dependencies
@@ -66,23 +136,10 @@ jobs:
       - name: Validate package tarballs (publint + attw)
         run: pnpm test:pkg
 
-      # When there are unconsumed changesets in .changeset/, opens/updates
-      # the "Version Packages" PR. When that PR is merged (consuming the
-      # changesets), the next run takes the `publish` branch and publishes
-      # each changed package via OIDC, then creates per-package GitHub
-      # releases (@x402r/core@1.2.3 style tags).
-      #
-      # Provenance: NPM_CONFIG_PROVENANCE=true plus the per-package
-      # publishConfig.provenance flag together guarantee Sigstore-backed
-      # attestations regardless of changesets/cli inference. Verify with
-      # `npm audit signatures @x402r/<pkg>` after a publish.
-      - name: Create Release PR or publish to npm
+      - name: Publish to npm
         uses: changesets/action@63a615b9cd06ba9a3e6d13796c7fbcb080a60a0b  # v1.8.0
         with:
           publish: pnpm exec changeset publish
-          version: pnpm exec changeset version
-          title: "chore: version packages"
-          commit: "chore: version packages"
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,15 @@ jobs:
   # Job 1: open/update the "Version Packages" PR if there are pending
   # changesets. Doesn't publish anything. No publish secrets are needed
   # so no OIDC scope and no env gate.
+  #
+  # Ref guard: `workflow_dispatch` lets the operator pick any ref from
+  # the branch dropdown. Without binding to main, a dispatch from a
+  # stale feature branch could spend our `pull-requests: write` token
+  # opening Version PRs against arbitrary refs. Matches the 22/23
+  # upstream x402-ecosystem publish workflows that carry this guard.
   version:
     name: Version
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     outputs:
@@ -55,12 +62,10 @@ jobs:
           node-version-file: .nvmrc
           cache: pnpm
 
-      # Trusted Publishing needs npm >= 11.5.1. Pin a specific version
-      # rather than @latest so a compromised npm release can't auto-land
-      # on the privileged runner. Same defense as SHA-pinning actions.
-      - name: Pin npm
-        run: npm install --global npm@11.14.1 --ignore-scripts
-
+      # Note: no `Pin npm` step here. The version job only mutates files
+      # via `changeset version` + opens a PR via the action — it never
+      # calls `npm publish`, so the Trusted-Publishing-driven npm >= 11.5.1
+      # pin is unused. The publish job has the pin where it's needed.
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
 
@@ -77,9 +82,14 @@ jobs:
   # Job 2: publish to npm. Only runs when the version job found NO
   # pending changesets (i.e., the Version PR was already merged on a
   # previous dispatch and the workspace versions are bumped + clean).
+  #
+  # Ref guard: same defense as the version job — bind to main so a
+  # dispatch from a stale feature branch can't mint a valid OIDC token
+  # and publish from an unintended ref (`environment + workflow filename`
+  # alone doesn't restrict the ref).
   publish:
     name: Publish to npm
-    if: needs.version.outputs.hasChangesets == 'false'
+    if: github.ref == 'refs/heads/main' && needs.version.outputs.hasChangesets == 'false'
     needs: version
     runs-on: ubuntu-latest
     timeout-minutes: 20


### PR DESCRIPTION
## Why

Current `release.yml` triggers on every push to `main`, then pauses at a required-reviewer `npm-publish` environment gate. Result: every Dependabot bump, every unrelated commit creates a stale "Release" run sitting in the queue. Noise + no value.

**Research finding** (subagent on workflows from astro / vite / vuejs/core / changesets/changesets / turborepo / shadcn-ui / radix-ui / chakra-ui / trpc / react-router): **zero** popular projects use the "push + required-reviewer gate that pauses" pattern. Either no gate, or env gate only on the actual publish job. The pause-on-every-push was over-engineering on my part.

## What this PR does

**Two-job split** mirrors `changesets/changesets`'s `publish.yml` (their `version` + `publish` jobs gated by `hasChangesets == 'false'`). **Trigger** is `workflow_dispatch` rather than their `push: branches: [main, next]` — a deliberate deviation to eliminate the stale-auto-run problem from Dependabot pushes. Trade-off: an extra manual click per release in exchange for zero unsolicited workflow runs.

- **Trigger**: `workflow_dispatch:` only. Click "Run workflow" in the Actions UI when you want to release. Nothing else fires it.
- **`version` job**: no env, no OIDC, no publish secrets. Opens or updates the "Version Packages" PR. Outputs `hasChangesets` so the next job knows what to do.
- **`publish` job**: gated by `if: needs.version.outputs.hasChangesets == 'false'` — only runs after the Version PR was merged (on a previous dispatch). Has OIDC scope + provenance env.
- **One dispatch click does the right thing**: if changesets are pending, the version job updates the PR and publish skips. If no changesets pending, version exits as no-op and publish runs.

## Single-click experience (settings change you do once)

The `environment: npm-publish` label stays so npm Trusted Publishing's OIDC config still matches. **But** the required-reviewer protection rule on that environment can be removed — `workflow_dispatch` already gates on maintainer access; the env gate would just be a second confirmation click.

To go full single-click:
- Settings → Environments → `npm-publish` → uncheck Required reviewers → Save

Leave it on if you prefer belt-and-suspenders (two clicks per publish).

## What stays the same (security)

- All SHA-pinned actions (checkout v6.0.2, setup-node v6.4.0, pnpm-action-setup v6.0.8, harden-runner v2.19.3, changesets/action v1.8.0). Dependabot keeps SHA + version comment in sync.
- Top-level `permissions: {}` default-deny; per-job least-privilege.
- step-security/harden-runner in audit mode (Phase 7 flips to block once observed).
- `pnpm install --frozen-lockfile --ignore-scripts` blocks postinstall-worm class.
- `npm@11.14.1` pinned (no `@latest` on privileged runner).
- `persist-credentials: false` on every checkout — `GITHUB_TOKEN` doesn't leak into `.git/config` for downstream steps.
- OIDC Trusted Publishing (no `NPM_TOKEN`) + per-package `publishConfig.provenance: true` + `NPM_CONFIG_PROVENANCE: "true"` env. Belt-and-suspenders provenance.
- `pnpm test:pkg` upfront publint+attw gate before publish (prevents partial-publish hazard).
- `concurrency` without `cancel-in-progress` (never cancel mid-publish — leaves npm half-state).
- `timeout-minutes: 20` on every job.
- No `pull_request` trigger — fork PRs can't inject anything into this workflow, period.

## Reference

- Subagent research on 10 popular npm monorepo workflows (Option B from that triage).
- Plan: `x402r-notes/plans/RELEASE_PIPELINE.md`
- Operator runbook: `x402r-notes/sdk/RELEASING.md`

## Test plan

This workflow only runs on `workflow_dispatch`, so this PR's CI exercises just `ci.yml`. Real validation happens by **dispatching it manually after merge**:

- [ ] Merge this PR.
- [ ] Verify no auto-Release run fires on subsequent pushes (Dependabot PRs, your commits, etc.).
- [ ] Settings → Environments → `npm-publish` → decide whether to keep required-reviewer or drop it.
- [ ] When ready for first publish: do the prep work (workspace version reset + changeset reclassify + `pnpm changeset pre enter alpha`) in a separate PR, then click Run workflow → version → review the Version PR → merge it → click Run workflow → publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
