### PR TITLE
ci(release): drop cache: pnpm to close cache-poisoning path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,11 +56,15 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
 
+      # No `cache: pnpm` here: the privileged release runner must not
+      # deserialize the same cache that ci.yml writes to from
+      # untrusted PR runs (cache-poisoning vector). Upstream
+      # changesets/changesets uses `skip-cache: true` for the same
+      # reason. Cold install costs ~10s per release run.
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: .nvmrc
-          cache: pnpm
 
       # Note: no `Pin npm` step here. The version job only mutates files
       # via `changeset version` + opens a PR via the action — it never
@@ -123,11 +127,15 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8
 
+      # No `cache: pnpm` here: the privileged release runner must not
+      # deserialize the same cache that ci.yml writes to from
+      # untrusted PR runs (cache-poisoning vector). Upstream
+      # changesets/changesets uses `skip-cache: true` for the same
+      # reason. Cold install costs ~10s per release run.
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version-file: .nvmrc
-          cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - name: Pin npm


### PR DESCRIPTION
## Summary

Drops `cache: pnpm` from both setup-node steps in `.github/workflows/release.yml` to eliminate a cross-workflow cache-poisoning vector.

## Threat model

- `ci.yml` runs on PRs (low privilege, no secrets) and uses `cache: pnpm`. It writes to the shared GitHub Actions pnpm cache from untrusted PR inputs.
- `release.yml` runs on workflow_dispatch from main (high privilege: `contents: write`, `id-token: write` for npm Trusted Publishing OIDC) and previously also used `cache: pnpm` — it would deserialize the same cache that PR runs populated.

Per Adnan Khan's GitHub Actions cache-poisoning research (https://adnanthekhan.com/2024/05/06/the-monsters-in-your-build-cache-github-actions-cache-poisoning/), a low-privilege workflow can poison a cache that a privileged workflow later reads, giving an attacker a path to inject malicious bytes into a release artifact.

## Upstream pattern (related, not identical)

`changesets/changesets`'s `publish.yml` uses `skip-cache: true` on their `ci-setup` composite in both jobs, with the comment `# avoid cache poisoning attacks`. Their threat is internal lateral movement between their own privileged workflows; ours is external PR-run cache poisoning the privileged release runner. **Same defensive pattern, related class of attack.** Since our workflow calls `actions/setup-node` directly rather than through a composite, the equivalent is omitting `cache: pnpm`.

Each setup-node step now carries an explanatory comment so the omission isn't mistaken for an oversight.

## Tradeoff

~10s of cold pnpm install per release run. Release is workflow_dispatch-only and infrequent, so the safety wins.

## Test plan

- [ ] Lint/format passes (biome check) — covered by pre-commit hook
- [ ] Next manual release.yml dispatch completes (cold install path)
- [ ] No structural changes to setup-node — `node-version-file: .nvmrc` and `registry-url` are preserved
