### PR TITLE
chore(release): prep for 0.3.0-alpha cycle

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -10,5 +10,5 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["x402r-sdk"]
+  "ignore": []
 }

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,12 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "examples": "0.0.0",
+    "@x402r/cli": "0.2.0",
+    "@x402r/core": "0.2.0",
+    "@x402r/helpers": "0.2.1",
+    "@x402r/sdk": "0.2.1"
+  },
+  "changesets": []
+}

--- a/.changeset/sdk-authcapture-autocapture-wireformat.md
+++ b/.changeset/sdk-authcapture-autocapture-wireformat.md
@@ -1,7 +1,7 @@
 ---
-"@x402r/core": major
-"@x402r/helpers": major
-"@x402r/cli": major
+"@x402r/core": minor
+"@x402r/helpers": minor
+"@x402r/cli": minor
 ---
 
 authCapture wire format + autoCapture (PR 2/4 of authCapture migration).

--- a/.changeset/sdk-authcapture-lift.md
+++ b/.changeset/sdk-authcapture-lift.md
@@ -1,7 +1,7 @@
 ---
-"@x402r/core": major
-"@x402r/sdk": major
-"@x402r/helpers": major
+"@x402r/core": minor
+"@x402r/sdk": minor
+"@x402r/helpers": minor
 ---
 
 Lift SDK to the authCapture contract surface (BackTrackCo/x402r-contracts#34, merged at `9786579`).

--- a/.changeset/sdk-authcapture-reconstruct-payment-info.md
+++ b/.changeset/sdk-authcapture-reconstruct-payment-info.md
@@ -1,6 +1,6 @@
 ---
-"@x402r/core": major
-"@x402r/helpers": major
+"@x402r/core": minor
+"@x402r/helpers": minor
 ---
 
 Add the `PaymentInfo` namespace in `@x402r/core` (re-exported from `@x402r/sdk`) and add `reconstructPaymentInfoWire` in `@x402r/helpers`. Together they bridge the authCapture wire format to the bigint shape SDK actions accept.

--- a/.changeset/sdk-authcapture-topaymentinfo-relocation.md
+++ b/.changeset/sdk-authcapture-topaymentinfo-relocation.md
@@ -1,6 +1,6 @@
 ---
-"@x402r/core": major
-"@x402r/helpers": major
+"@x402r/core": minor
+"@x402r/helpers": minor
 ---
 
 `toPaymentInfo` relocation (PR 4 of authCapture migration).

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/core",
-  "version": "0.3.0",
+  "version": "0.2.0",
   "type": "module",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/helpers",
-  "version": "0.3.0",
+  "version": "0.2.1",
   "type": "module",
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@x402r/sdk",
-  "version": "0.3.0",
+  "version": "0.2.1",
   "type": "module",
   "license": "Apache-2.0",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Three coupled changes that together make the next "Run workflow → version" dispatch (after this PR merges) produce a Version PR for **0.3.0-alpha.0** — the first prerelease toward stable 0.3.0.

Per `x402r-notes/plans/RELEASE_PIPELINE.md` Phase 4.

## What changed

1. **Workspace versions reset to npm baseline** (3 files):
   - `packages/core/package.json`: `0.3.0` → `0.2.0`
   - `packages/sdk/package.json`: `0.3.0` → `0.2.1`
   - `packages/helpers/package.json`: `0.3.0` → `0.2.1`
   - `packages/cli/package.json`: untouched (already at npm baseline `0.2.0`)

   Reason: the workspace was on `0.3.0` locally but had never been published. Changesets computes new versions FROM `package.json`. Starting from `0.3.0 + minor` lands at `0.4.0` (skipping `0.3.0`). Starting from `0.2.x + minor` lands at `0.3.0` — what we want.

2. **5 pending changesets reclassified from `major` → `minor`** (4 of 5 actually edited; permit2 was already minor + patch and untouched):
   - `sdk-authcapture-autocapture-wireformat.md`
   - `sdk-authcapture-lift.md`
   - `sdk-authcapture-reconstruct-payment-info.md`
   - `sdk-authcapture-topaymentinfo-relocation.md`

   Reason: strict SemVer doesn't formally permit minor-as-breaking, but it's a common convention in 0.x packages and matches what these changes are. We're staying in 0.x for now; the changeset *bodies* (unchanged) document the breaking specifics that consumers depend on.

3. **Enter Changesets pre mode (alpha)** — adds `.changeset/pre.json` with `mode:pre, tag:alpha` and a snapshot of initial versions. While `pre.json` exists, every release goes to the npm `alpha` dist-tag with `-alpha.N` version suffix.

4. **Side: drop `"x402r-sdk"` from `.changeset/config.json` `ignore` list.** Changesets v2.29.8 errors with `ValidationError: The package or glob expression "x402r-sdk" is specified in the ignore option but it is not found in the project`. The root package is `private:true` and Changesets auto-skips it regardless. Required for `pnpm changeset status` to succeed.

## `pnpm changeset status` (verification)

```
🦋  info Packages to be bumped at patch:
🦋  info
🦋  - examples
🦋  ---
🦋  info Packages to be bumped at minor:
🦋  info
🦋  - @x402r/core
🦋  - @x402r/helpers
🦋  - @x402r/cli
🦋  - @x402r/sdk
🦋  ---
🦋  info NO packages to be bumped at major
```

All four publishable packages bump at `minor` → `0.3.0`. With `pre.json` present, the actual published version becomes `0.3.0-alpha.0`. `examples` bumps at patch but is `private: true` so won't be published.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: click Actions → Release → Run workflow on `main` → workflow opens the Version PR titled `chore(release): version packages` with `package.json` bumps to `0.3.0-alpha.0`.
- [ ] Review the Version PR; merge it.
- [ ] Click Run workflow again → publishes `@x402r/{core,sdk,helpers,cli}@0.3.0-alpha.0` to npm `alpha` dist-tag.
- [ ] Verify: `npm view @x402r/core@alpha`, `npm audit signatures @x402r/core`.

## Out of scope

- **Source code**: not touched. Only version metadata and changeset frontmatter.
- **Lockfile**: clean. The version field changes don't affect workspace dependency resolution (uses `workspace:^`).
- **`@x402r/cli` in test:pkg**: still tracked separately as #161; doesn't block this prep.
- **Cache scoping on release.yml**: separate small PR #168 (parallel to this one).

## Reference

- Plan: `x402r-notes/plans/RELEASE_PIPELINE.md` (Phase 4)
- Operator runbook: `x402r-notes/sdk/RELEASING.md` (just updated to reflect workflow_dispatch flow)
- Related: PR #166 (release.yml rewrite), PR #168 (cache scoping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
