### PR TITLE
docs(security): add SECURITY.md + per-package provenance notes

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,12 +4,7 @@ This policy covers the code in this repository and the `@x402r/*` packages it pu
 
 ## Supported Versions
 
-`@x402r/{core,sdk,helpers,cli}` are pre-1.0. Security fixes target the current `0.x` minor; older minors may not receive backports. We're a small team — please upgrade to the latest minor before reporting a vulnerability so we can confirm it still reproduces against supported code.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| Latest `0.x` minor | Yes |
-| Older `0.x` minors | Best-effort only |
+`@x402r/{core,sdk,helpers,cli}` are pre-1.0. Security fixes target the current `0.x` minor; older minors receive best-effort backports only. We're a small team — please upgrade to the latest minor before reporting a vulnerability so we can confirm it still reproduces against supported code.
 
 ## Reporting a Vulnerability
 
@@ -38,6 +33,8 @@ A useful report includes:
 - **Disclosure**: coordinated with the reporter. We'll credit you in the advisory unless you'd rather stay anonymous
 
 Soft commitments only — we'll do our best, but we don't have a 24/7 on-call rotation.
+
+We do not currently run a paid bug bounty program. Credit in the published advisory is the recognition we can offer.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+This policy covers the code in this repository and the `@x402r/*` packages it publishes to npm. Smart contract source lives in [`x402r-contracts`](https://github.com/BackTrackCo/x402r-contracts) and has its own security surface.
+
+## Supported Versions
+
+`@x402r/{core,sdk,helpers,cli}` are pre-1.0. Security fixes target the current `0.x` minor; older minors may not receive backports. We're a small team — please upgrade to the latest minor before reporting a vulnerability so we can confirm it still reproduces against supported code.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| Latest `0.x` minor | Yes |
+| Older `0.x` minors | Best-effort only |
+
+## Reporting a Vulnerability
+
+**Please do not file a public GitHub issue for security bugs.**
+
+Preferred channel — private GitHub Security Advisory:
+
+  https://github.com/BackTrackCo/x402r-sdk/security/advisories/new
+
+This routes directly to maintainers and lets us collaborate on a fix with you in private before disclosure.
+
+Fallback channel — if the advisory form is unavailable, contact a maintainer directly. Maintainer email addresses are on the public GitHub profiles for [@vraspar](https://github.com/vraspar) and [@A1igator](https://github.com/A1igator).
+
+A useful report includes:
+
+- A description of the vulnerability
+- Suggested impact (Critical / High / Medium / Low)
+- A minimal reproducible example, or at least the affected file/function and conditions to trigger
+- Affected package(s) and version(s)
+
+## What to Expect
+
+- **Acknowledgement**: within 72 hours of receipt (often sooner)
+- **Triage**: an initial assessment shared with you within ~1 week
+- **Fix and release**: cadence depends on severity. Critical issues get prioritized over feature work
+- **Disclosure**: coordinated with the reporter. We'll credit you in the advisory unless you'd rather stay anonymous
+
+Soft commitments only — we'll do our best, but we don't have a 24/7 on-call rotation.
+
+## Scope
+
+**In scope:**
+
+- Source code in this repository
+- The published `@x402r/core`, `@x402r/sdk`, `@x402r/helpers`, and `@x402r/cli` npm packages
+
+**Out of scope:**
+
+- Vulnerabilities in upstream dependencies — please report those to the upstream maintainers. If a dependency vulnerability has a non-obvious impact on our packages, we still want to hear about it
+- Smart contract vulnerabilities — these belong to [`x402r-contracts`](https://github.com/BackTrackCo/x402r-contracts) and any deployed addresses referenced in `@x402r/core/config`
+- Third-party integrations (facilitators, arbiters, wallet providers) that consume our SDK but live in their own repos
+- Issues that require an attacker to already control the user's machine, npm registry account, or private keys
+
+## Verifying Package Provenance
+
+Starting with `0.3.0-alpha.0`, the `@x402r/*` packages are published with [Sigstore-backed provenance attestations](https://docs.npmjs.com/generating-provenance-statements) via [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/). Earlier versions (`0.2.x` and below) predate this pipeline and do not carry attestations. After installing a provenance-enabled version, confirm the artifact came from this repository's release workflow:
+
+```sh
+npm audit signatures @x402r/core
+npm audit signatures @x402r/sdk
+npm audit signatures @x402r/helpers
+npm audit signatures @x402r/cli
+```
+
+The attestation bundle is also visible in the npm package metadata under `dist.attestations`. A provenance mismatch is itself a security finding — please report it through the channels above.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -133,3 +133,13 @@ facilitator.
   skill wrappers can wildcard-allow exact command shapes.
 - Supports Base and Base Sepolia out of the box. Any EVM chain known to
   `viem/chains` works; unknown chain IDs require `--rpc <url>`.
+
+## Provenance
+
+Starting with `0.3.0-alpha.0`, releases of `@x402r/cli` are published with [Sigstore-backed provenance attestations](https://docs.npmjs.com/generating-provenance-statements) via [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/). Earlier versions (`0.2.x` and below) do not carry attestations. Verify a provenance-enabled version after install:
+
+```sh
+npm audit signatures @x402r/cli
+```
+
+The attestation bundle is also visible in the npm package metadata under `dist.attestations`. See [`SECURITY.md`](../../SECURITY.md) for the full security policy and how to report vulnerabilities.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -4,6 +4,11 @@
   "description": "One-shot CLI for paying x402 / x402r endpoints. Wallet-agnostic: raw key, JSON-RPC signer, or custom module.",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BackTrackCo/x402r-sdk.git",
+    "directory": "packages/cli"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -127,6 +127,16 @@ Mirrors the ergonomics of `signReceiveAuthorization` (ERC-3009 path). The determ
 
 [docs.x402r.org](https://docs.x402r.org)
 
+## Provenance
+
+Starting with `0.3.0-alpha.0`, releases of `@x402r/core` are published with [Sigstore-backed provenance attestations](https://docs.npmjs.com/generating-provenance-statements) via [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/). Earlier versions (`0.2.x` and below) do not carry attestations. Verify a provenance-enabled version after install:
+
+```sh
+npm audit signatures @x402r/core
+```
+
+The attestation bundle is also visible in the npm package metadata under `dist.attestations`. See [`SECURITY.md`](../../SECURITY.md) for the full security policy and how to report vulnerabilities.
+
 ## License
 
 [Apache-2.0](../../LICENSE)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BackTrackCo/x402r-sdk.git",
+    "directory": "packages/core"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -127,6 +127,16 @@ forwardToArbiter('http://arbiter:3001', {
 
 [docs.x402r.org](https://docs.x402r.org)
 
+## Provenance
+
+Starting with `0.3.0-alpha.0`, releases of `@x402r/helpers` are published with [Sigstore-backed provenance attestations](https://docs.npmjs.com/generating-provenance-statements) via [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/). Earlier versions (`0.2.x` and below) do not carry attestations. Verify a provenance-enabled version after install:
+
+```sh
+npm audit signatures @x402r/helpers
+```
+
+The attestation bundle is also visible in the npm package metadata under `dist.attestations`. See [`SECURITY.md`](../../SECURITY.md) for the full security policy and how to report vulnerabilities.
+
 ## License
 
 [Apache-2.0](../../LICENSE)

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BackTrackCo/x402r-sdk.git",
+    "directory": "packages/helpers"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -128,6 +128,16 @@ Deeper protocol semantics live in [docs.x402r.org](https://docs.x402r.org).
 
 [docs.x402r.org](https://docs.x402r.org)
 
+## Provenance
+
+Starting with `0.3.0-alpha.0`, releases of `@x402r/sdk` are published with [Sigstore-backed provenance attestations](https://docs.npmjs.com/generating-provenance-statements) via [npm Trusted Publishing](https://docs.npmjs.com/trusted-publishers/). Earlier versions (`0.2.x` and below) do not carry attestations. Verify a provenance-enabled version after install:
+
+```sh
+npm audit signatures @x402r/sdk
+```
+
+The attestation bundle is also visible in the npm package metadata under `dist.attestations`. See [`SECURITY.md`](../../SECURITY.md) for the full security policy and how to report vulnerabilities.
+
 ## License
 
 [Apache-2.0](../../LICENSE)

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.1",
   "type": "module",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BackTrackCo/x402r-sdk.git",
+    "directory": "packages/sdk"
+  },
   "publishConfig": {
     "access": "public",
     "provenance": true


### PR DESCRIPTION
## Summary

Phase 8 of the release-pipeline rollout — adds the docs + metadata surface that consumers and security researchers need:

- **`SECURITY.md`** at repo root (new, 67 lines).
- **`## Provenance`** section appended to each of the 4 publishable package READMEs.
- **`repository` field** added to each publishable `package.json` (follow-up after review — required for npm to surface the SECURITY.md link).

Per `x402r-notes/plans/RELEASE_PIPELINE.md` Phase 8.

## SECURITY.md (new)

Sections:

- **Supported Versions** — pre-1.0 statement: only the latest `0.x` minor receives backports.
- **Reporting a Vulnerability** — primary channel is private GitHub Security Advisory (`https://github.com/BackTrackCo/x402r-sdk/security/advisories/new`); fallback is maintainer email via public profiles.
- **What to Expect** — 72h initial ack target, ~1wk triage. Explicitly soft commitments — disclaims 24/7 on-call for a small team.
- **Scope** — in: code in this repo + published `@x402r/*` packages. Out: upstream deps, the `x402r-contracts` repo (report there), third-party integrations, attacker-already-has-keys cases.
- **Verifying Package Provenance** — `npm audit signatures @x402r/<pkg>` workflow + note about earlier versions (`0.2.x` and below) predating the provenance pipeline.

Constructed from scratch using common SECURITY.md conventions (Supported Versions / Reporting / What to Expect / Scope structure). Not adapted from a specific upstream template — stands on its own.

Once this lands and the `repository` field (below) is in place, npm will surface a "Security Policy" link on each package page and OpenSSF Scorecard picks up the file.

## Per-package READMEs

Identical (modulo package name) `## Provenance` section added to each of `core`, `sdk`, `helpers`, `cli`. Placement:

- **core / sdk / helpers**: between existing `## Docs` and `## License` sections (matches sibling h2 structure).
- **cli**: final section after `## Notes` (cli's tail doesn't share the Docs/License structure of the other three — final-section placement is the natural fit).

Each section points readers at `[SECURITY.md](../../SECURITY.md)` and shows the `npm audit signatures` command for that specific package.

## `repository` field (follow-up commit `5b3ce90`)

Each of the four publishable `package.json` files now carries:

```json
"repository": {
  "type": "git",
  "url": "git+https://github.com/BackTrackCo/x402r-sdk.git",
  "directory": "packages/<name>"
}
```

This is what npm uses to display the "Security Policy" / "Repository" links on the npmjs.com package page. Without it, the SECURITY.md added by this PR exists in the repo but stays invisible to npm consumers. Standard monorepo shape — `directory` scopes to the package's subdirectory.

## Honesty note on the provenance language

The provenance claims are scoped to *"Starting with `0.3.0-alpha.0`"* rather than blanket present tense. Currently-published `0.2.x` versions on npm do **not** carry attestations — running `npm audit signatures` against them today would report missing signatures. The new flow (PR #166 + PR #168 + PR #169) ships provenance on the next publish. Stating this explicitly avoids misleading consumers who try the command before the new pipeline's first dispatch.

## What this PR does NOT touch

- No source code, tests, examples, or workflows.
- No changesets — this is docs + metadata, no package behavior change.
- No commit signing or other settings changes.

## Test plan

- [ ] CI green on this PR (covered by pre-commit hook + GitHub Actions CI).
- [ ] After merge: the `repository` field is now in place; visit `https://www.npmjs.com/package/@x402r/core` after the **next publish** (`0.3.0-alpha.0` or later) → the "Security Policy" link should resolve to `SECURITY.md`. (Currently-published `0.2.x` artifacts were published before the `repository` field existed; new versions will carry it.)
- [ ] OpenSSF Scorecard should reflect the new SECURITY.md on its next scan.
- [ ] Once the first `0.3.0-alpha.0` lands via the new pipeline, the `npm audit signatures @x402r/<pkg>` command in each README + SECURITY.md returns verified output.

## Review chain

- Initial review caught two issues: (1) the PR body fabricated an attribution to `wevm/viem`'s SECURITY.md, which doesn't exist — corrected to "common SECURITY.md conventions"; (2) missing `repository` field on the publishable packages — added in commit `5b3ce90`.
- Both fixes applied. Re-running review on the metadata-addition commit.

## Reference

- Plan: `x402r-notes/plans/RELEASE_PIPELINE.md` (Phase 8)
- Related: PR #166 (release.yml rewrite, merged), PR #168 (cache scoping, merged), PR #169 (Phase 4b prep, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
