### PR TITLE
changeset: unlink @x402r/{core,sdk,helpers} for independent versioning

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,7 @@
   ],
   "commit": false,
   "fixed": [],
-  "linked": [["@x402r/core", "@x402r/helpers", "@x402r/sdk"]],
+  "linked": [],
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",


### PR DESCRIPTION
## Summary

Set `linked` to `[]` in `.changeset/config.json`. Each `@x402r/*` package versions independently.

## Why

`@x402r/sdk` and `@x402r/helpers` don't import from each other. Their dep graphs share `@x402r/core` only:

- `@x402r/sdk` → `@x402r/core`, `@x402r/erc8004`, `viem`
- `@x402r/helpers` → `@x402r/core`, `@x402r/evm`

The previous linked group `[[core, sdk, helpers]]` enforced lockstep version bumps for no technical reason. It was added on Mar 9 (commit `a60bd32`) with the stated reason "version bumps stay in sync across packages" — a UX preference, not a correctness constraint.

Industry standard for TS monorepo SDKs is unlinked. Verified against wagmi, viem, vercel/ai, TanStack/query — all four use `linked: []`.

## Effect

After this lands:

- `@x402r/core` can ship a patch fix without bumping sdk/helpers.
- `@x402r/sdk` can ship a feature without bumping core/helpers.
- `@x402r/helpers` can ship a fix without bumping sdk.

Compatibility between packages is conveyed via `"@x402r/core": "workspace:^"` in sdk and helpers, resolved at publish time — same pattern peers use.

## No effect on pending Version PR #175

Every existing changeset under `.changeset/sdk-authcapture-*.md` explicitly names its affected packages in front-matter, so the linked grouping doesn't change the bump plan for the current alpha cycle. After #175 merges and `0.3.0-alpha.0` ships, future releases benefit from the unlinked configuration.

## Test plan

- [x] Pre-commit hook (biome + build + typecheck) passed locally.
- [ ] After merge, the next `changeset version` run recomputes bumps with `linked: []`. Existing pending changesets explicitly name each affected package, so behavior should be unchanged for the alpha cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)