### PR TITLE
deps(x402): bump @x402/* to ^2.12.0; adopt processResponse in cli

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -43,8 +43,11 @@ convention. The flag form is available when you want to avoid collisions.
 
 ## `--json` envelope
 
+The emitted JSON is a discriminated union — branch on `kind`:
+
 ```json
 {
+  "kind": "success",
   "body": "<merchant response body>",
   "status": 200,
   "tx": "0x…",
@@ -53,7 +56,30 @@ convention. The flag form is available when you want to avoid collisions.
 }
 ```
 
-`signer` is omitted when the URL returned non-402 (no payment was made).
+```json
+{
+  "kind": "passthrough",
+  "body": "<merchant response body>",
+  "status": 200,
+  "elapsedMs": 1234,
+  "signer": { "kind": "key", "address": "0x…" }
+}
+```
+
+```json
+{
+  "kind": "no_payment_required",
+  "body": "<merchant response body>",
+  "status": 200,
+  "elapsedMs": 1234
+}
+```
+
+- `kind: "success"` — paid request settled successfully; `tx` is the settlement transaction hash.
+- `kind: "passthrough"` — paid request returned ok with no settle header; merchant did not surface a settlement (`tx` absent).
+- `kind: "no_payment_required"` — first request returned non-402; no payment was made (`signer` and `tx` absent).
+
+Terminal failures (`settle_failed`, `payment_required` re-issued after payment, merchant 4xx/5xx after payment) throw and exit with code `5` rather than emitting a result envelope.
 
 ## Examples
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,8 +36,8 @@
     "prepublishOnly": "publint --strict && attw --pack --ignore-rules no-resolution cjs-resolves-to-esm"
   },
   "dependencies": {
-    "@x402/core": "^2.5.0",
-    "@x402/evm": "^2.5.0",
+    "@x402/core": "^2.12.0",
+    "@x402/evm": "^2.12.0",
     "@x402r/evm": ">=0.2.0-alpha.0 <0.3.0",
     "viem": "^2.46.3"
   },

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -107,8 +107,10 @@ function emit(result: PayResult, json: boolean): void {
   }
   process.stdout.write(result.body)
   if (!result.body.endsWith('\n')) process.stdout.write('\n')
-  if (result.tx) process.stderr.write(`tx: ${result.tx}\n`)
-  if (result.signer) {
+  if (result.kind === 'success') {
+    process.stderr.write(`tx: ${result.tx}\n`)
+  }
+  if (result.kind === 'success' || result.kind === 'passthrough') {
     process.stderr.write(
       `signer: ${result.signer.kind} (${result.signer.address})\n`,
     )

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,7 +7,7 @@ export {
   SettlementError,
   SignatureRejectedError,
 } from './errors.js'
-export type { PayFlags, PayResult } from './pay/index.js'
+export type { PayFlags, PayResult, SignerMeta } from './pay/index.js'
 export { pay } from './pay/index.js'
 export { resolveSigner, SignerResolutionError } from './signers/index.js'
 export type { ResolvedSigner, SignerFlags, SignerKind } from './types.js'

--- a/packages/cli/src/pay/index.ts
+++ b/packages/cli/src/pay/index.ts
@@ -28,14 +28,33 @@ export interface PayFlags extends SignerFlags {
   json?: boolean
 }
 
-export interface PayResult {
-  body: string
-  status: number
-  tx?: string
-  elapsedMs: number
-  /** Present only when a payment was made; omitted on non-402 short-circuits. */
-  signer?: { kind: SignerKind; address: string }
+export interface SignerMeta {
+  kind: SignerKind
+  address: string
 }
+
+export type PayResult =
+  | {
+      kind: 'success'
+      body: string
+      status: number
+      tx: string
+      elapsedMs: number
+      signer: SignerMeta
+    }
+  | {
+      kind: 'passthrough'
+      body: string
+      status: number
+      elapsedMs: number
+      signer: SignerMeta
+    }
+  | {
+      kind: 'no_payment_required'
+      body: string
+      status: number
+      elapsedMs: number
+    }
 
 export async function pay(flags: PayFlags): Promise<PayResult> {
   const started = Date.now()
@@ -44,6 +63,7 @@ export async function pay(flags: PayFlags): Promise<PayResult> {
 
   if (peek.status !== 402) {
     return {
+      kind: 'no_payment_required',
       body: await peek.text(),
       status: peek.status,
       elapsedMs: Date.now() - started,
@@ -91,29 +111,53 @@ export async function pay(flags: PayFlags): Promise<PayResult> {
     },
   })
 
-  const body = await paid.text()
-  if (paid.status >= 400) {
-    throw new SettlementError(
-      `merchant returned ${paid.status} after payment: ${truncate(body, 200)}`,
-    )
-  }
+  const result = await paymentHttpClient.processResponse(paid)
+  return applyPaymentResult(result, paid.status, started, {
+    kind: resolved.kind,
+    address: resolved.account.address,
+  })
+}
 
-  const settle = tryParseSettle(paid, paymentHttpClient)
-  if (settle && settle.success === false) {
-    throw new SettlementError(
-      `settlement failed: ${settle.errorReason ?? 'unknown'}`,
-    )
-  }
-
-  return {
-    body,
-    status: paid.status,
-    tx: settle?.transaction,
-    elapsedMs: Date.now() - started,
-    signer: {
-      kind: resolved.kind,
-      address: resolved.account.address,
-    },
+/**
+ * Maps upstream `x402PaymentResult` to a cli `PayResult`. Terminal failure
+ * variants throw `SettlementError`; success/passthrough return.
+ *
+ * Exported for tests.
+ */
+export function applyPaymentResult(
+  result: Awaited<ReturnType<x402HTTPClient['processResponse']>>,
+  paidStatus: number,
+  startedMs: number,
+  signer: SignerMeta,
+): PayResult {
+  switch (result.kind) {
+    case 'success':
+      return {
+        kind: 'success',
+        body: stringifyBody(result.body),
+        status: paidStatus,
+        tx: result.settleResponse.transaction,
+        elapsedMs: Date.now() - startedMs,
+        signer,
+      }
+    case 'passthrough':
+      return {
+        kind: 'passthrough',
+        body: stringifyBody(result.body),
+        status: paidStatus,
+        elapsedMs: Date.now() - startedMs,
+        signer,
+      }
+    case 'settle_failed':
+      throw new SettlementError(
+        `settlement failed: ${result.settleResponse.errorReason ?? 'unknown'}`,
+      )
+    case 'payment_required':
+      throw new SettlementError('merchant re-issued 402 after payment')
+    case 'error':
+      throw new SettlementError(
+        `merchant returned ${result.status} after payment: ${truncate(stringifyBody(result.body), 200)}`,
+      )
   }
 }
 
@@ -154,15 +198,8 @@ function parsePaymentRequired(
   }
 }
 
-function tryParseSettle(
-  res: Response,
-  httpClient: x402HTTPClient,
-): ReturnType<x402HTTPClient['getPaymentSettleResponse']> | undefined {
-  try {
-    return httpClient.getPaymentSettleResponse((name) => res.headers.get(name))
-  } catch {
-    return undefined
-  }
+function stringifyBody(body: unknown): string {
+  return typeof body === 'string' ? body : JSON.stringify(body)
 }
 
 function adaptAccount(

--- a/packages/cli/tests/pay.test.ts
+++ b/packages/cli/tests/pay.test.ts
@@ -185,7 +185,7 @@ describe('applyPaymentResult()', () => {
     expect(result.status).toBe(200)
     expect(result.body).toBe('{"ok":true}')
     expect(result.signer).toEqual(SIGNER)
-    expect(result.elapsedMs).toBeGreaterThanOrEqual(0)
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(90)
   })
 
   it('maps passthrough → kind:passthrough with no tx field', () => {

--- a/packages/cli/tests/pay.test.ts
+++ b/packages/cli/tests/pay.test.ts
@@ -1,8 +1,13 @@
 import { encodePaymentRequiredHeader } from '@x402/core/http'
 import type { PaymentRequired, PaymentRequirements } from '@x402/core/types'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { Malformed402Error, MaxAmountExceededError } from '../src/errors.js'
-import { pay } from '../src/pay/index.js'
+import {
+  Malformed402Error,
+  MaxAmountExceededError,
+  SettlementError,
+} from '../src/errors.js'
+import type { SignerMeta } from '../src/pay/index.js'
+import { applyPaymentResult, pay } from '../src/pay/index.js'
 
 const USDC = '0x036CbD53842c5426634e7929541eC2318f3dCF7e'
 const KEY = `0x${'1'.repeat(64)}`
@@ -65,9 +70,9 @@ describe('pay()', () => {
 
     const result = await pay({ url: URL, key: KEY })
 
+    expect(result.kind).toBe('no_payment_required')
     expect(result.status).toBe(200)
     expect(result.body).toBe('{"ok":true}')
-    expect(result.signer).toBeUndefined()
     expect(fetchSpy).toHaveBeenCalledTimes(1)
   })
 
@@ -147,5 +152,130 @@ describe('pay()', () => {
     await expect(
       pay({ url: URL, key: KEY, assetTransferMethod: 'gibberish' }),
     ).rejects.toThrow(/--asset-transfer-method must be 'eip3009' or 'permit2'/)
+  })
+})
+
+describe('applyPaymentResult()', () => {
+  const SIGNER: SignerMeta = {
+    kind: 'key',
+    address: '0xabCDef0123456789abcdef0123456789ABcdEF01',
+  }
+  const STARTED = Date.now() - 100
+
+  it('maps success → kind:success with tx from settleResponse', () => {
+    const result = applyPaymentResult(
+      {
+        kind: 'success',
+        response: new Response(null),
+        body: { ok: true },
+        settleResponse: {
+          success: true,
+          transaction: '0xdeadbeef',
+          network: 'eip155:84532',
+        } as never,
+      },
+      200,
+      STARTED,
+      SIGNER,
+    )
+
+    expect(result.kind).toBe('success')
+    if (result.kind !== 'success') throw new Error('unreachable')
+    expect(result.tx).toBe('0xdeadbeef')
+    expect(result.status).toBe(200)
+    expect(result.body).toBe('{"ok":true}')
+    expect(result.signer).toEqual(SIGNER)
+    expect(result.elapsedMs).toBeGreaterThanOrEqual(0)
+  })
+
+  it('maps passthrough → kind:passthrough with no tx field', () => {
+    const result = applyPaymentResult(
+      {
+        kind: 'passthrough',
+        response: new Response(null),
+        body: 'raw text body',
+      },
+      200,
+      STARTED,
+      SIGNER,
+    )
+
+    expect(result.kind).toBe('passthrough')
+    if (result.kind !== 'passthrough') throw new Error('unreachable')
+    expect(result.body).toBe('raw text body')
+    expect(result.status).toBe(200)
+    expect(result.signer).toEqual(SIGNER)
+    expect('tx' in result).toBe(false)
+  })
+
+  it('maps settle_failed → SettlementError with errorReason in message', () => {
+    expect(() =>
+      applyPaymentResult(
+        {
+          kind: 'settle_failed',
+          response: new Response(null),
+          body: null,
+          settleResponse: {
+            success: false,
+            errorReason: 'insufficient_funds',
+            network: 'eip155:84532',
+          } as never,
+        },
+        402,
+        STARTED,
+        SIGNER,
+      ),
+    ).toThrowError(new SettlementError('settlement failed: insufficient_funds'))
+  })
+
+  it('maps settle_failed without errorReason → "unknown"', () => {
+    expect(() =>
+      applyPaymentResult(
+        {
+          kind: 'settle_failed',
+          response: new Response(null),
+          body: null,
+          settleResponse: {
+            success: false,
+            network: 'eip155:84532',
+          } as never,
+        },
+        402,
+        STARTED,
+        SIGNER,
+      ),
+    ).toThrowError(new SettlementError('settlement failed: unknown'))
+  })
+
+  it('maps payment_required → SettlementError re-issued message', () => {
+    expect(() =>
+      applyPaymentResult(
+        {
+          kind: 'payment_required',
+          response: new Response(null),
+          paymentRequired: {} as never,
+        },
+        402,
+        STARTED,
+        SIGNER,
+      ),
+    ).toThrowError(new SettlementError('merchant re-issued 402 after payment'))
+  })
+
+  it('maps error → SettlementError with truncated body', () => {
+    const longBody = 'x'.repeat(500)
+    expect(() =>
+      applyPaymentResult(
+        {
+          kind: 'error',
+          response: new Response(null),
+          status: 503,
+          body: longBody,
+        },
+        503,
+        STARTED,
+        SIGNER,
+      ),
+    ).toThrow(/merchant returned 503 after payment: x{200}…/)
   })
 })

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -35,11 +35,11 @@
     "@x402r/core": "workspace:^"
   },
   "peerDependencies": {
-    "@x402/core": ">=2.5.0",
+    "@x402/core": ">=2.12.0",
     "@x402r/evm": ">=0.2.0-alpha.0 <0.3.0"
   },
   "devDependencies": {
-    "@x402/core": "2.5.0",
+    "@x402/core": "2.12.0",
     "@x402r/core": "workspace:^",
     "@x402r/evm": "0.2.0-alpha.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,14 +108,14 @@ importers:
   packages/cli:
     dependencies:
       '@x402/core':
-        specifier: ^2.5.0
-        version: 2.5.0
+        specifier: ^2.12.0
+        version: 2.12.0
       '@x402/evm':
-        specifier: ^2.5.0
-        version: 2.5.0(ethers@6.16.0)(typescript@5.9.3)
+        specifier: ^2.12.0
+        version: 2.12.0(typescript@5.9.3)
       '@x402r/evm':
         specifier: '>=0.2.0-alpha.0 <0.3.0'
-        version: 0.2.0-alpha.0(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))
+        version: 0.2.0-alpha.0(@x402/core@2.12.0)(@x402/evm@2.12.0(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))
       viem:
         specifier: ^2.46.3
         version: 2.47.1(typescript@5.9.3)(zod@4.3.6)
@@ -141,11 +141,11 @@ importers:
         version: link:../core
     devDependencies:
       '@x402/core':
-        specifier: 2.5.0
-        version: 2.5.0
+        specifier: 2.12.0
+        version: 2.12.0
       '@x402r/evm':
         specifier: 0.2.0-alpha.0
-        version: 0.2.0-alpha.0(@x402/core@2.5.0)(@x402/evm@2.12.0(typescript@5.9.3))(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))
+        version: 0.2.0-alpha.0(@x402/core@2.12.0)(@x402/evm@2.12.0(typescript@5.9.3))(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))
 
   packages/sdk:
     dependencies:
@@ -1094,21 +1094,6 @@ packages:
     peerDependencies:
       size-limit: 12.1.0
 
-  '@spruceid/siwe-parser@2.1.2':
-    resolution: {integrity: sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==}
-
-  '@stablelib/binary@1.0.1':
-    resolution: {integrity: sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==}
-
-  '@stablelib/int@1.0.1':
-    resolution: {integrity: sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==}
-
-  '@stablelib/random@1.0.2':
-    resolution: {integrity: sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==}
-
-  '@stablelib/wipe@1.0.1':
-    resolution: {integrity: sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==}
-
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -1252,14 +1237,8 @@ packages:
   '@x402/core@2.12.0':
     resolution: {integrity: sha512-dLae9AbZRN/W7GsKe9ngqGsflnP+esE72s0GjmqDZbPihM/tlHCA6UnDdgM0qfOiDOf9iL+mmCs1OyLWpwnGLQ==}
 
-  '@x402/core@2.5.0':
-    resolution: {integrity: sha512-nUr8HW8WhkU1DvrpUfsRvALy5NF8UWKoFezZOtX61mohxp2lWZpJ2GnvscxDM8nmBAbtIollmksd5z5pj8InXw==}
-
   '@x402/evm@2.12.0':
     resolution: {integrity: sha512-kZUoHPVdBS8wlTg5K1eoh/1V0+5n9ABGRPC5DOQwRlkAwIrAFOEi2pQE+jgvOx0iM5ib2xj9gJjpldRbasX12w==}
-
-  '@x402/evm@2.5.0':
-    resolution: {integrity: sha512-MBSTQZwLobMVcmYO7itOMJRkxfHstsDyr7F94o9Rk/Oinz0kjvCe4DFgZmFXyz3nQUgQFmDVgTK5KIzfYR5uIA==}
 
   '@x402/express@2.12.0':
     resolution: {integrity: sha512-bPc6jpRr4iCh7KRJETK/2/bVTKHy/EeybQd9s+Mz4Ab+C64F1IH20GeW4gyj27dtAd2YgOiFrk8uyxSbZPKhkQ==}
@@ -1272,9 +1251,6 @@ packages:
 
   '@x402/extensions@2.12.0':
     resolution: {integrity: sha512-1B6a/ubCiAoNrVbrZ4btUcWXjM5e71fB2rxSrtW+mINGVonW4w7QDjAKdOlKzi6xqRSoGRVQm5ajL9hIGvkE2A==}
-
-  '@x402/extensions@2.5.0':
-    resolution: {integrity: sha512-e7IQShbGUM/XQmzI8DQh2tX/k2XDUGI9DNF+ij2NHUyPEqAt5/mJCwOlaxS/60FWFdfFRfWjTsqaoS7Z8WLi+A==}
 
   '@x402/fetch@2.12.0':
     resolution: {integrity: sha512-lkN/fzkZjnbJreLwI3fessKAaTKsOrrc0mFPGHWwZy0W/s8KFusLwdHuS8ul/XdUyNcYYrwcV6z0faGGSWNUNA==}
@@ -2278,10 +2254,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  punycode@2.3.1:
-    resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
-    engines: {node: '>=6'}
-
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
@@ -2405,11 +2377,6 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
-
-  siwe@2.3.2:
-    resolution: {integrity: sha512-aSf+6+Latyttbj5nMu6GF3doMfv2UYj83hhwZgUF20ky6fTS83uVhkQABdIVnEuS8y1bBdk7p6ltb9SmlhTTlA==}
-    peerDependencies:
-      ethers: ^5.6.8 || ^6.0.8
 
   size-limit@12.1.0:
     resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
@@ -2621,12 +2588,6 @@ packages:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
 
-  uri-js@4.4.1:
-    resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  valid-url@1.0.9:
-    resolution: {integrity: sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA==}
-
   validate-npm-package-name@5.0.1:
     resolution: {integrity: sha512-OljLrQ9SQdOUqTaQxqL5dEfZWrXExyyWsozYlAWFawPVNuD83igl7uJD2RTkNMbniIYgt8l81eCJGIdQF7avLQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
@@ -2826,7 +2787,8 @@ packages:
 
 snapshots:
 
-  '@adraffy/ens-normalize@1.10.1': {}
+  '@adraffy/ens-normalize@1.10.1':
+    optional: true
 
   '@adraffy/ens-normalize@1.11.1': {}
 
@@ -3320,12 +3282,14 @@ snapshots:
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
+    optional: true
 
   '@noble/curves@1.9.1':
     dependencies:
       '@noble/hashes': 1.8.0
 
-  '@noble/hashes@1.3.2': {}
+  '@noble/hashes@1.3.2':
+    optional: true
 
   '@noble/hashes@1.8.0': {}
 
@@ -3568,26 +3532,6 @@ snapshots:
     dependencies:
       size-limit: 12.1.0(jiti@2.6.1)
 
-  '@spruceid/siwe-parser@2.1.2':
-    dependencies:
-      '@noble/hashes': 1.8.0
-      apg-js: 4.4.0
-      uri-js: 4.4.1
-      valid-url: 1.0.9
-
-  '@stablelib/binary@1.0.1':
-    dependencies:
-      '@stablelib/int': 1.0.1
-
-  '@stablelib/int@1.0.1': {}
-
-  '@stablelib/random@1.0.2':
-    dependencies:
-      '@stablelib/binary': 1.0.1
-      '@stablelib/wipe': 1.0.1
-
-  '@stablelib/wipe@1.0.1': {}
-
   '@standard-schema/spec@1.1.0': {}
 
   '@turbo/darwin-64@2.9.14':
@@ -3658,6 +3602,7 @@ snapshots:
   '@types/node@22.7.5':
     dependencies:
       undici-types: 6.19.8
+    optional: true
 
   '@types/node@25.6.2':
     dependencies:
@@ -3771,10 +3716,6 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
-  '@x402/core@2.5.0':
-    dependencies:
-      zod: 3.25.76
-
   '@x402/evm@2.12.0(typescript@5.9.3)':
     dependencies:
       '@x402/core': 2.12.0
@@ -3782,18 +3723,6 @@ snapshots:
       zod: 3.25.76
     transitivePeerDependencies:
       - bufferutil
-      - typescript
-      - utf-8-validate
-
-  '@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3)':
-    dependencies:
-      '@x402/core': 2.5.0
-      '@x402/extensions': 2.5.0(ethers@6.16.0)(typescript@5.9.3)
-      viem: 2.47.1(typescript@5.9.3)(zod@3.25.76)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - bufferutil
-      - ethers
       - typescript
       - utf-8-validate
 
@@ -3825,21 +3754,6 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402/extensions@2.5.0(ethers@6.16.0)(typescript@5.9.3)':
-    dependencies:
-      '@scure/base': 1.2.6
-      '@x402/core': 2.5.0
-      ajv: 8.18.0
-      siwe: 2.3.2(ethers@6.16.0)
-      tweetnacl: 1.0.3
-      viem: 2.47.1(typescript@5.9.3)(zod@3.25.76)
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - bufferutil
-      - ethers
-      - typescript
-      - utf-8-validate
-
   '@x402/fetch@2.12.0':
     dependencies:
       '@x402/core': 2.12.0
@@ -3854,17 +3768,17 @@ snapshots:
       '@x402/evm': 2.12.0(typescript@5.9.3)
       viem: 2.47.1(typescript@5.9.3)(zod@3.25.76)
 
-  '@x402r/evm@0.2.0-alpha.0(@x402/core@2.5.0)(@x402/evm@2.12.0(typescript@5.9.3))(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))':
+  '@x402r/evm@0.2.0-alpha.0(@x402/core@2.12.0)(@x402/evm@2.12.0(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))':
     dependencies:
-      '@x402/core': 2.5.0
+      '@x402/core': 2.12.0
+      '@x402/evm': 2.12.0(typescript@5.9.3)
+      viem: 2.47.1(typescript@5.9.3)(zod@4.3.6)
+
+  '@x402r/evm@0.2.0-alpha.0(@x402/core@2.12.0)(@x402/evm@2.12.0(typescript@5.9.3))(viem@2.50.4(typescript@5.9.3)(zod@4.3.6))':
+    dependencies:
+      '@x402/core': 2.12.0
       '@x402/evm': 2.12.0(typescript@5.9.3)
       viem: 2.50.4(typescript@5.9.3)(zod@4.3.6)
-
-  '@x402r/evm@0.2.0-alpha.0(@x402/core@2.5.0)(@x402/evm@2.5.0(ethers@6.16.0)(typescript@5.9.3))(viem@2.47.1(typescript@5.9.3)(zod@4.3.6))':
-    dependencies:
-      '@x402/core': 2.5.0
-      '@x402/evm': 2.5.0(ethers@6.16.0)(typescript@5.9.3)
-      viem: 2.47.1(typescript@5.9.3)(zod@4.3.6)
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):
     optionalDependencies:
@@ -3883,7 +3797,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
-  aes-js@4.0.0-beta.5: {}
+  aes-js@4.0.0-beta.5:
+    optional: true
 
   ajv@8.18.0:
     dependencies:
@@ -4191,6 +4106,7 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+    optional: true
 
   eventemitter3@4.0.7: {}
 
@@ -4872,8 +4788,6 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
 
-  punycode@2.3.1: {}
-
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
@@ -5053,14 +4967,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  siwe@2.3.2(ethers@6.16.0):
-    dependencies:
-      '@spruceid/siwe-parser': 2.1.2
-      '@stablelib/random': 1.0.2
-      ethers: 6.16.0
-      uri-js: 4.4.1
-      valid-url: 1.0.9
-
   size-limit@12.1.0(jiti@2.6.1):
     dependencies:
       bytes-iec: 3.1.1
@@ -5179,7 +5085,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
-  tslib@2.7.0: {}
+  tslib@2.7.0:
+    optional: true
 
   tslib@2.8.1:
     optional: true
@@ -5242,7 +5149,8 @@ snapshots:
 
   ufo@1.6.3: {}
 
-  undici-types@6.19.8: {}
+  undici-types@6.19.8:
+    optional: true
 
   undici-types@7.19.2: {}
 
@@ -5253,12 +5161,6 @@ snapshots:
   universalify@0.1.2: {}
 
   unpipe@1.0.0: {}
-
-  uri-js@4.4.1:
-    dependencies:
-      punycode: 2.3.1
-
-  valid-url@1.0.9: {}
 
   validate-npm-package-name@5.0.1: {}
 
@@ -5400,7 +5302,8 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.17.1: {}
+  ws@8.17.1:
+    optional: true
 
   ws@8.18.3: {}
 


### PR DESCRIPTION
## Summary

- Bumps `@x402/core` and `@x402/evm` declared floors from `^2.5.0` to `^2.12.0` in `@x402r/cli`, and helpers' peer/dev `@x402/core` from `>=2.5.0`/`2.5.0` to `>=2.12.0`/`2.12.0`. Collapses the 2.5/2.10/2.12 skew currently in `node_modules/.pnpm/`.
- Replaces hand-rolled settle parsing in `packages/cli/src/pay/index.ts` (`tryParseSettle` + manual `paid.status >= 400` branch) with upstream's `x402HTTPClient.processResponse()` (new in `@x402/core@2.12`). Switch over the 5-variant `x402PaymentResult` discriminated union.
- **Breaking** (cli only): `PayResult` becomes a discriminated union (`success | passthrough | no_payment_required`); terminal-failure variants (`settle_failed`, `payment_required`, `error`) throw `SettlementError` instead of being returned. Aligns cli's surface with upstream ecosystem semantics; cli is experimental and unpublished.
- Adds 6 unit tests for the new exported `applyPaymentResult` helper covering all 5 upstream variants — the cli's first paid-path test coverage.

## Why now

Upstream shipped 2.5 → 2.12 over ~6 weeks. The cli was hand-rolling settle response classification that `processResponse()` now subsumes, and the declared-floor skew was causing multiple `@x402/core` versions to coexist in `node_modules/.pnpm/`. Scoped to upstream-driven changes only — no `@x402r/scheme`-side catch-up, no new SDK abstractions.

## Out of scope (deliberate)

- No `pnpm.overrides` for `@x402/*` (let pnpm dedupe per declared ranges)
- No new abstractions in `@x402r/sdk` or `@x402r/helpers` (no `onSettleResult` wrapper, no client-hook layer)
- No adoption of `SettlementOverrides`, `onPaymentResponse` recovery, or batch-settlement scheme — no concrete consumer in current x402r flows
- No publishing / changesets / version bumps
- Catch-up to unpublished `@x402r/evm` commits stays deferred (separate phase when scheme cuts a new alpha)

## Test plan

- [x] `pnpm typecheck` green workspace-wide
- [x] `pnpm --filter @x402r/cli test` — 48/48 (was 42; +6 for `applyPaymentResult`)
- [x] `pnpm --filter @x402r/helpers test` — 28/28
- [x] `pnpm --filter @x402r/cli build` + `publint --strict` + `attw --pack` clean
- [x] `pnpm --filter @x402r/helpers build` + `publint --strict` clean
- [x] `pnpm install` resolves single `@x402/core@2.12.0` + `@x402/evm@2.12.0` per `pnpm why`
- [ ] `pnpm test:fork` (`@x402r/core` integration) — pre-existing flakiness against the public `https://sepolia.base.org` RPC; `@x402r/core` has zero `@x402/*` deps so this bump can't affect it

🤖 Generated with [Claude Code](https://claude.com/claude-code)