### PR TITLE
helpers: drop duplicate @x402r/core from devDependencies

### DIFF
--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -40,7 +40,6 @@
   },
   "devDependencies": {
     "@x402/core": "2.5.0",
-    "@x402r/core": "workspace:^",
     "@x402r/evm": "0.2.0-alpha.0"
   },
   "size-limit": [


### PR DESCRIPTION
## Summary

- `packages/helpers/package.json` listed `@x402r/core` in both `dependencies` (line 35) and `devDependencies` (line 43). Removed the redundant `devDependencies` entry.
- This unblocks the `knip 5.85.0 → 6.5.0` Dependabot bump in #152, whose CI fails on exactly this finding.

## Why this exists

The duplicate landed in #95 (2026-03-30, commit `a252048` — a feature PR for `forward paymentPayload and improve error context`). That commit introduced a brand-new `"dependencies"` block and simultaneously added `@x402r/core` to the existing `"devDependencies"` block. The PR description didn't mention dep changes; it looks like an unintentional copy-paste during the refactor.

Audited every workspace package — this is the only file with the pattern. Sibling `@x402r/sdk` consumes `@x402r/core` via `dependencies` only, establishing the correct convention.

## Why knip catches it now

- knip 5.85 didn't cross-check `devDependencies` against `dependencies` for duplicate workspace package names, so the redundant line went unflagged for ~2 months.
- knip 6.x rewrote the unused-dep detection pass and correctly reports the `devDependencies` entry as unused (the runtime/build path is satisfied by the `dependencies` line).

This is a knip correctness improvement, not a regression.

## Safety check

- `@x402r/core` resolution unchanged — still satisfied by `dependencies: workspace:^`.
- Lockfile unchanged (pnpm already had a single resolved entry; the devDeps line was a no-op spec).
- `publint --strict` / `attw` in `prepublishOnly` source from `dependencies` + `peerDependencies`; the devDeps removal is invisible to them.

## Test plan

- [x] `pnpm install` — no lockfile delta
- [x] `pnpm build` — turbo all packages green
- [x] `pnpm typecheck` — green
- [x] `pnpm knip` — exits 0, no "Unused devDependencies" finding
- [ ] After merge: comment `@dependabot recreate` on #152 so it rebases on the new `main` and CI goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)