### PR TITLE
fix(helpers): gate forwardToArbiter on AUTH_CAPTURE_SCHEME; align to renamed auth-capture graph

### DIFF
--- a/.changeset/helpers-forwardtoarbiter-scheme-rename.md
+++ b/.changeset/helpers-forwardtoarbiter-scheme-rename.md
@@ -1,0 +1,15 @@
+---
+"@x402r/helpers": minor
+---
+
+Gate `forwardToArbiter` on the `AUTH_CAPTURE_SCHEME` constant from `@x402r/evm` instead of a hardcoded `'authCapture'` literal, and align `@x402r/helpers` to the renamed auth-capture scheme graph.
+
+**Why:** the scheme literal was renamed `authCapture` → `auth-capture`. The hardcoded gate matched nothing once helpers consumed the renamed scheme, so the merchant→arbiter forwarding would silently early-return on every settlement.
+
+**Breaking (peer requirements):**
+
+- `@x402/core` peer raised `>=2.5.0` → `^2.14.0`.
+- `@x402/evm ^2.14.0` and `viem ^2.48.11` added as peers.
+- `@x402r/evm` peer floor raised to `>=0.2.0-alpha.1` — the renamed build that exposes `AUTH_CAPTURE_SCHEME = "auth-capture"` and drops the local client subpath (the client is now consumed from `@x402/evm/auth-capture/client`).
+
+`forwardToArbiter` now fires only when `requirements.scheme === AUTH_CAPTURE_SCHEME` (`"auth-capture"`); it no longer matches the legacy `"authCapture"` literal.

--- a/examples/package.json
+++ b/examples/package.json
@@ -30,11 +30,11 @@
   "devDependencies": {
     "@types/express": "^5.0.0",
     "@types/node": "^25.9.0",
-    "@x402/core": "2.12.0",
-    "@x402/evm": "2.12.0",
-    "@x402/express": "2.12.0",
-    "@x402/fetch": "2.12.0",
-    "@x402r/evm": "0.2.0-alpha.0",
+    "@x402/core": "2.14.0",
+    "@x402/evm": "2.14.0",
+    "@x402/express": "2.14.0",
+    "@x402/fetch": "2.14.0",
+    "@x402r/evm": "0.2.0-alpha.1",
     "express": "^5.0.0"
   }
 }

--- a/examples/scenarios/README.md
+++ b/examples/scenarios/README.md
@@ -39,7 +39,7 @@ Demonstrates the atomic settlement path. In production the merchant advertises t
 
 2-role flow: authorize → capture(partial) → voidPayment().
 
-The new authCapture partial-refund pattern. Replaces the old single-tx `refundInEscrow(amount)` with a two-tx flow: merchant captures the amount they keep, then `voidPayment()` returns the remainder to the payer. No allowance setup, no ReceiverRefundCollector — the escrow handles it. Asserts payer net loss equals merchant-keep, receiver delta + fee delta equals merchant-keep.
+The new auth-capture partial-refund pattern. Replaces the old single-tx `refundInEscrow(amount)` with a two-tx flow: merchant captures the amount they keep, then `voidPayment()` returns the remainder to the payer. No allowance setup, no ReceiverRefundCollector — the escrow handles it. Asserts payer net loss equals merchant-keep, receiver delta + fee delta equals merchant-keep.
 
 ### permit2-charge
 
@@ -51,7 +51,7 @@ Demonstrates the two payer-side moves Permit2 requires: a one-time `ERC20.approv
 
 Cross-package integration test exercising the real HTTP 402 wire end-to-end against an in-process facilitator and resource server.
 
-Boots `@x402/express`'s `paymentMiddleware` + `x402ResourceServer` (with `AuthCaptureServerScheme` from `@x402r/evm/authCapture/server`) on one port, `@x402/core`'s `x402Facilitator` (with `AuthCaptureFacilitatorScheme` from `@x402r/evm/authCapture/facilitator`) on another, and a payer client using `@x402/fetch`'s `wrapFetchWithPayment` + `AuthCaptureEvmScheme` from `@x402r/evm/authCapture/client`. The payer's `fetch` returns HTTP 402, the wrapper signs an authorization, retries, and the facilitator settles on-chain. Asserts the settle tx targets the canonical AuthCaptureEscrow, payer ↓ amount, receiver unchanged (autoCapture left unset), the `PaymentAuthorized` event's `paymentInfo` fields match the resource server's published requirements, and `paymentState(paymentInfoHash)` on the escrow has `hasCollectedPayment === true` and `capturableAmount === amount`.
+Boots `@x402/express`'s `paymentMiddleware` + `x402ResourceServer` (with `AuthCaptureEvmScheme` from `@x402r/evm/auth-capture/server`) on one port, `@x402/core`'s `x402Facilitator` (with `AuthCaptureEvmScheme` from `@x402r/evm/auth-capture/facilitator`) on another, and a payer client using `@x402/fetch`'s `wrapFetchWithPayment` + `AuthCaptureEvmScheme` from `@x402/evm/auth-capture/client`. The payer's `fetch` returns HTTP 402, the wrapper signs an authorization, retries, and the facilitator settles on-chain. Asserts the settle tx targets the canonical AuthCaptureEscrow, payer ↓ amount, receiver unchanged (autoCapture left unset), the `PaymentAuthorized` event's `paymentInfo` fields match the resource server's published requirements, and `paymentState(paymentInfoHash)` on the escrow has `hasCollectedPayment === true` and `capturableAmount === amount`.
 
 This is the only scenario that exercises the `@x402/express` ↔ `@x402r/evm` integration seam — wire-format mismatches, scheme registration drift, or signer-interface changes between the upstream packages and `@x402r/evm` surface here and nowhere else in the suite.
 

--- a/examples/scenarios/http-wire-capture.ts
+++ b/examples/scenarios/http-wire-capture.ts
@@ -4,12 +4,13 @@ import { x402Facilitator } from '@x402/core/facilitator'
 import { HTTPFacilitatorClient, x402HTTPClient } from '@x402/core/http'
 import type { PaymentPayload, PaymentRequirements } from '@x402/core/types'
 import { toFacilitatorEvmSigner } from '@x402/evm'
+import { AuthCaptureEvmScheme as AuthCaptureEvmClient } from '@x402/evm/auth-capture/client'
 import { paymentMiddleware, x402ResourceServer } from '@x402/express'
 import { wrapFetchWithPayment } from '@x402/fetch'
 import { authCaptureEscrowAbi, getChainConfig } from '@x402r/core'
-import { AuthCaptureEvmScheme as AuthCaptureEvmClient } from '@x402r/evm/authCapture/client'
-import { AuthCaptureFacilitatorScheme } from '@x402r/evm/authCapture/facilitator'
-import { AuthCaptureServerScheme } from '@x402r/evm/authCapture/server'
+import { AUTH_CAPTURE_SCHEME } from '@x402r/evm'
+import { AuthCaptureEvmScheme as AuthCaptureFacilitatorScheme } from '@x402r/evm/auth-capture/facilitator'
+import { AuthCaptureEvmScheme as AuthCaptureServerScheme } from '@x402r/evm/auth-capture/server'
 import express from 'express'
 import {
   type Address,
@@ -51,7 +52,7 @@ import { StepRunner } from './runner.js'
 //   Anvil fork (shared prool subpath or self-spawned)
 //
 // Catches integration-seam bugs between upstream @x402/{core,evm,express,fetch}
-// at 2.12.0 and our @x402r/evm at 0.2.0-alpha.0. autoCapture is intentionally
+// at 2.14.0 and our @x402r/evm at 0.2.0-alpha.1. autoCapture is intentionally
 // left unset (authorize-only path) so the receiver should NOT see any token
 // inflow; the post-conditions check tx-target + payer-debit + receiver-flat.
 // ---------------------------------------------------------------------------
@@ -69,11 +70,11 @@ const chainConfig = getChainConfig(CHAIN_ID)
 const USDC: Address = chainConfig.usdc
 const AUTH_CAPTURE_ESCROW: Address = chainConfig.authCaptureEscrow
 
-// Canonical EIP-3009 token collector for the authCapture scheme — same
-// address on every chain commerce-payments is deployed to. Source:
-// @x402r/evm/authCapture/constants.ts (EIP3009_TOKEN_COLLECTOR_ADDRESS).
-// Hard-coded here rather than re-imported because that module isn't on
-// @x402r/evm's public export surface; only the schemes are.
+// Canonical EIP-3009 token collector for the auth-capture scheme — same
+// address on every chain commerce-payments is deployed to. Mirrors
+// `EIP3009_TOKEN_COLLECTOR_ADDRESS`, now a root export of @x402r/evm. Pinned
+// here as a literal so the scenario's tokenCollector assertion locks the
+// expected value independently of what the package re-exports.
 const EIP3009_TOKEN_COLLECTOR: Address =
   '0x0E3dF9510de65469C4518D7843919c0b8C7A7757'
 
@@ -196,7 +197,7 @@ async function bootstrapAnvil(): Promise<{
 
 // ---------------------------------------------------------------------------
 // 2. Facilitator setup (mirrors upstream
-// examples/typescript/facilitator/authCapture/index.ts).
+// examples/typescript/facilitator/auth-capture/index.ts).
 // ---------------------------------------------------------------------------
 async function startFacilitator(rpcUrl: string): Promise<{
   url: string
@@ -266,7 +267,7 @@ async function startFacilitator(rpcUrl: string): Promise<{
 
 // ---------------------------------------------------------------------------
 // 3. Resource server setup (mirrors upstream
-// examples/typescript/servers/authCapture/index.ts).
+// examples/typescript/servers/auth-capture/index.ts).
 // ---------------------------------------------------------------------------
 async function startResourceServer(
   facilitatorUrl: string,
@@ -297,7 +298,7 @@ async function startResourceServer(
       {
         'GET /widget': {
           accepts: {
-            scheme: 'authCapture',
+            scheme: AUTH_CAPTURE_SCHEME,
             // Custom AssetAmount: pin USDC + base-unit amount directly so we
             // don't rely on getDefaultAsset (which would also work but couples
             // the scenario to an extra default-asset lookup). EIP-712 domain
@@ -426,7 +427,7 @@ async function main(): Promise<void> {
     runner.log(`settle tx: ${settleResponse.transaction}`)
 
     runner.step('Verify on-chain settle landed (authorize-only)')
-    // The authCapture escrow is the canonical CREATE2-deployed AuthCaptureEscrow
+    // The auth-capture escrow is the canonical CREATE2-deployed AuthCaptureEscrow
     // singleton. Funds for an authorized-but-not-captured payment don't sit at
     // the singleton — the escrow creates a per-payment vault via internal
     // accounting (commerce-payments uses a paymentInfoHash-indexed mapping).
@@ -514,8 +515,8 @@ async function main(): Promise<void> {
     )
     // tokenCollector is the canonical EIP-3009 collector for the default
     // assetTransferMethod ('eip3009') the scheme uses when the merchant
-    // doesn't override it. Source: @x402r/evm/authCapture/constants.ts
-    // (EIP3009_TOKEN_COLLECTOR_ADDRESS). Pinning the value here catches a
+    // doesn't override it. Source: @x402r/evm EIP3009_TOKEN_COLLECTOR_ADDRESS.
+    // Pinning the value here catches a
     // scheme regression that silently switched the collector (e.g.,
     // accidentally routed through Permit2's collector).
     runner.assert(

--- a/examples/scenarios/partial-refund-flow.ts
+++ b/examples/scenarios/partial-refund-flow.ts
@@ -12,7 +12,7 @@ import { StepRunner } from './runner.js'
 // ---------------------------------------------------------------------------
 // Scenario: Partial Refund Flow
 //
-// The new authCapture partial-refund pattern: capture(merchantKeep) then
+// The new auth-capture partial-refund pattern: capture(merchantKeep) then
 // voidPayment() returns the remainder to the payer. Replaces the old
 // single-tx refundInEscrow(amount) — two transactions, no allowance setup,
 // no ReceiverRefundCollector. Asserts real balance deltas: payer recovers

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -11,10 +11,11 @@ pnpm add @x402r/helpers
 ## Usage
 
 ```ts
+import { AuthCaptureEvmScheme } from '@x402r/evm/auth-capture/server'
 import { forwardToArbiter } from '@x402r/helpers'
 
 const resourceServer = new x402ResourceServer(facilitatorClient)
-  .register(networkId, new AuthCaptureServerScheme())
+  .register(networkId, new AuthCaptureEvmScheme())
   .onAfterSettle(forwardToArbiter('http://arbiter:3001'))
 ```
 
@@ -35,7 +36,7 @@ See JSDoc on `X402rDefaultsInput` for per-field overrides and production-footgun
 
 ## Reconstructing PaymentInfo after settlement
 
-The authCapture wire format omits the on-chain `PaymentInfo` struct (it's derivable from `requirements + payload.salt + payer`). Merchants needing to call escrow actions later (`payment.capture`, `payment.voidPayment`, `payment.refund`) use two pieces to bridge the wire format to the runtime form SDK actions accept:
+The auth-capture wire format omits the on-chain `PaymentInfo` struct (it's derivable from `requirements + payload.salt + payer`). Merchants needing to call escrow actions later (`payment.capture`, `payment.voidPayment`, `payment.refund`) use two pieces to bridge the wire format to the runtime form SDK actions accept:
 
 - **`reconstructPaymentInfoWire(context)`** — from `@x402r/helpers`. Builds the JSON-form `PaymentInfoWire` from a verified `SettleResultContext`. Handles the wire→struct field renames and the EIP-3009 vs Permit2 branch internally.
 - **`PaymentInfo.fromWire(wire)`** — from `@x402r/sdk` (or `@x402r/core`). Converts the JSON-form `PaymentInfoWire` to the bigint-form `PaymentInfo` SDK actions accept.
@@ -75,7 +76,7 @@ async function processJob(job) {
 
 For in-process synchronous use, chain them in one expression: `PaymentInfo.fromWire(reconstructPaymentInfoWire(context))`.
 
-`reconstructPaymentInfoWire` throws `ValidationError` if the context isn't a verified authCapture settlement (`requirements.extra` not an `AuthCaptureExtra`, payload not an `AuthCapturePayload`, or `result.payer` missing). `PaymentInfo.fromWire` throws `ValidationError` on malformed `maxAmount` (non-decimal) or `salt` (non-hex).
+`reconstructPaymentInfoWire` throws `ValidationError` if the context isn't a verified auth-capture settlement (`requirements.extra` not an `AuthCaptureExtra`, payload not an `AuthCapturePayload`, or `result.payer` missing). `PaymentInfo.fromWire` throws `ValidationError` on malformed `maxAmount` (non-decimal) or `salt` (non-hex).
 
 ## API
 
@@ -83,7 +84,7 @@ For in-process synchronous use, chain them in one expression: `PaymentInfo.fromW
 
 Creates an `onAfterSettle` hook that forwards the response body to an arbiter service for evaluation. Fire-and-forget — does not block the response to the client.
 
-- Only fires for successful authCapture scheme settlements
+- Only fires for successful auth-capture scheme settlements
 - Calls `reconstructPaymentInfoWire` internally; POSTs `{ responseBody, transaction, paymentInfoWire }` to `{arbiterUrl}/verify`
 - `paymentInfoWire` is the JSON-form `PaymentInfoWire` — arbiters run it through `PaymentInfo.fromWire` (from `@x402r/sdk`) to get bigints for SDK actions
 - Errors silently caught (arbiter being down shouldn't break payment flow); if reconstruction itself fails, the POST is skipped and `onError` is invoked
@@ -109,7 +110,7 @@ app.post('/verify', async (req) => {
 
 #### Migration note
 
-Prior versions shipped `paymentPayload` (the raw wire payload) instead of `paymentInfoWire`. That worked under the legacy `commerce` scheme where the payload carried the struct directly, but the authCapture wire format omits it. Update your arbiter to read `req.body.paymentInfoWire` and run it through `PaymentInfo.fromWire` to get bigints; remove any legacy `paymentPayload.payload.paymentInfo` access path. The deleted `toPaymentInfo` helper is replaced by `PaymentInfo.fromWire` — same conversion logic, new home.
+Prior versions shipped `paymentPayload` (the raw wire payload) instead of `paymentInfoWire`. That worked under the legacy `commerce` scheme where the payload carried the struct directly, but the auth-capture wire format omits it. Update your arbiter to read `req.body.paymentInfoWire` and run it through `PaymentInfo.fromWire` to get bigints; remove any legacy `paymentPayload.payload.paymentInfo` access path. The deleted `toPaymentInfo` helper is replaced by `PaymentInfo.fromWire` — same conversion logic, new home.
 
 #### Options
 

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -35,12 +35,16 @@
     "@x402r/core": "workspace:^"
   },
   "peerDependencies": {
-    "@x402/core": ">=2.12.0",
-    "@x402r/evm": ">=0.2.0-alpha.0 <0.3.0"
+    "@x402/core": "^2.14.0",
+    "@x402/evm": "^2.14.0",
+    "@x402r/evm": ">=0.2.0-alpha.1 <0.3.0",
+    "viem": "^2.48.11"
   },
   "devDependencies": {
-    "@x402/core": "2.12.0",
-    "@x402r/evm": "0.2.0-alpha.0"
+    "@x402/core": "2.14.0",
+    "@x402/evm": "2.14.0",
+    "@x402r/evm": "0.2.0-alpha.1",
+    "viem": "^2.48.11"
   },
   "size-limit": [
     {

--- a/packages/helpers/src/forward-to-arbiter.ts
+++ b/packages/helpers/src/forward-to-arbiter.ts
@@ -1,5 +1,6 @@
 import type { SettleResultContext } from '@x402/core/server'
 import { X402rError } from '@x402r/core'
+import { AUTH_CAPTURE_SCHEME } from '@x402r/evm'
 import { reconstructPaymentInfoWire } from './reconstruct-payment-info.js'
 
 export interface ForwardToArbiterOptions {
@@ -12,8 +13,9 @@ export interface ForwardToArbiterOptions {
  * arbiter service for evaluation. Fire-and-forget — does not block the
  * response to the client.
  *
- * Only fires for authCapture scheme settlements. Non-authCapture schemes
- * are skipped. The hook reconstructs the JSON-form `PaymentInfoWire`
+ * Only fires for `auth-capture` scheme settlements (gated on the
+ * `AUTH_CAPTURE_SCHEME` constant from `@x402r/evm`). Other schemes are
+ * skipped. The hook reconstructs the JSON-form `PaymentInfoWire`
  * from the verified context and ships it as `paymentInfoWire` in the
  * POST body — arbiters consume `req.body.paymentInfoWire`, run it
  * through `PaymentInfo.fromWire` (from `@x402r/sdk` or `@x402r/core`)
@@ -31,9 +33,10 @@ export interface ForwardToArbiterOptions {
  * @example
  * ```ts
  * import { forwardToArbiter } from '@x402r/helpers'
+ * import { AuthCaptureEvmScheme } from '@x402r/evm/auth-capture/server'
  *
  * const resourceServer = new x402ResourceServer(facilitatorClient)
- *   .register(networkId, new AuthCaptureServerScheme())
+ *   .register(networkId, new AuthCaptureEvmScheme())
  *   .onAfterSettle(
  *     forwardToArbiter('http://arbiter:3001', {
  *       onError: (err) => sentry.captureException(err),
@@ -51,7 +54,7 @@ export function forwardToArbiter(
 
   return async (context: SettleResultContext): Promise<void> => {
     if (!context.result.success) return
-    if (context.requirements.scheme !== 'authCapture') return
+    if (context.requirements.scheme !== AUTH_CAPTURE_SCHEME) return
 
     const transportCtx = context.transportContext as
       | { responseBody?: { toString(encoding: string): string } }

--- a/packages/helpers/src/reconstruct-payment-info.ts
+++ b/packages/helpers/src/reconstruct-payment-info.ts
@@ -25,7 +25,7 @@ export type ReconstructPaymentInfoWireReturnType = PaymentInfoWire
  *
  * Throws `ValidationError` when:
  * - `context.requirements.extra` isn't a valid `AuthCaptureExtra`
- *   (typically because the hook fired on a non-authCapture scheme)
+ *   (typically because the hook fired on a non-`auth-capture` scheme)
  * - `context.paymentPayload.payload` isn't a valid `AuthCapturePayload`
  * - `context.result.payer` is missing
  */

--- a/packages/helpers/tests/forward-to-arbiter.test.ts
+++ b/packages/helpers/tests/forward-to-arbiter.test.ts
@@ -1,4 +1,5 @@
 import { X402rError } from '@x402r/core'
+import { AUTH_CAPTURE_SCHEME } from '@x402r/evm'
 import { describe, expect, it, vi } from 'vitest'
 import { forwardToArbiter } from '../src/forward-to-arbiter.js'
 
@@ -36,7 +37,7 @@ const EIP3009_PAYLOAD = {
 
 const MOCK_PAYMENT_PAYLOAD = {
   x402Version: 2,
-  accepted: { scheme: 'authCapture', network: 'eip155:84532' },
+  accepted: { scheme: AUTH_CAPTURE_SCHEME, network: 'eip155:84532' },
   payload: EIP3009_PAYLOAD,
 }
 
@@ -55,7 +56,7 @@ function makeContext(overrides: {
       payer: TEST_ADDRESSES.payer,
     },
     requirements: {
-      scheme: overrides.scheme ?? 'authCapture',
+      scheme: overrides.scheme ?? AUTH_CAPTURE_SCHEME,
       network: 'eip155:84532',
       payTo: TEST_ADDRESSES.payTo,
       asset: TEST_ADDRESSES.asset,
@@ -66,14 +67,15 @@ function makeContext(overrides: {
       ...MOCK_PAYMENT_PAYLOAD,
       payload: overrides.payload ?? EIP3009_PAYLOAD,
     },
+    declaredExtensions: {},
     transportContext: overrides.responseBody
       ? { responseBody: Buffer.from(overrides.responseBody) }
       : undefined,
-  }
+  } as Parameters<ReturnType<typeof forwardToArbiter>>[0]
 }
 
 describe('forwardToArbiter', () => {
-  it('POSTs reconstructed paymentInfoWire on successful authCapture settlement', async () => {
+  it('POSTs reconstructed paymentInfoWire on successful auth-capture settlement', async () => {
     let capturedUrl = ''
     let capturedBody = ''
     const original = globalThis.fetch
@@ -131,7 +133,28 @@ describe('forwardToArbiter', () => {
     }
   })
 
-  it('skips on non-authCapture scheme', async () => {
+  it('fires when scheme === AUTH_CAPTURE_SCHEME', async () => {
+    const original = globalThis.fetch
+    const spy = vi.fn(async () => new Response('ok'))
+    globalThis.fetch = spy as any
+
+    try {
+      const hook = forwardToArbiter('http://localhost:3001')
+      await hook(
+        makeContext({
+          scheme: AUTH_CAPTURE_SCHEME,
+          responseBody: '{"data": true}',
+        }),
+      )
+      await new Promise((r) => setTimeout(r, 50))
+
+      expect(spy).toHaveBeenCalledTimes(1)
+    } finally {
+      globalThis.fetch = original
+    }
+  })
+
+  it('skips a clearly-different scheme (exact)', async () => {
     const original = globalThis.fetch
     const spy = vi.fn()
     globalThis.fetch = spy as any
@@ -140,6 +163,28 @@ describe('forwardToArbiter', () => {
       const hook = forwardToArbiter('http://localhost:3001')
       await hook(
         makeContext({ scheme: 'exact', responseBody: '{"data": true}' }),
+      )
+      await new Promise((r) => setTimeout(r, 50))
+
+      expect(spy).not.toHaveBeenCalled()
+    } finally {
+      globalThis.fetch = original
+    }
+  })
+
+  it('skips the legacy camelCase "authCapture" literal (rename regression guard)', async () => {
+    // Guards against the pre-rename bug: the gate must compare against the
+    // 'auth-capture' constant, so the dropped camelCase literal must NOT match.
+    expect(AUTH_CAPTURE_SCHEME).toBe('auth-capture')
+
+    const original = globalThis.fetch
+    const spy = vi.fn()
+    globalThis.fetch = spy as any
+
+    try {
+      const hook = forwardToArbiter('http://localhost:3001')
+      await hook(
+        makeContext({ scheme: 'authCapture', responseBody: '{"data": true}' }),
       )
       await new Promise((r) => setTimeout(r, 50))
 

--- a/packages/helpers/tests/reconstruct-payment-info-wire.test.ts
+++ b/packages/helpers/tests/reconstruct-payment-info-wire.test.ts
@@ -1,4 +1,5 @@
 import { ValidationError } from '@x402r/core/errors'
+import { AUTH_CAPTURE_SCHEME } from '@x402r/evm'
 import { describe, expect, it } from 'vitest'
 import { reconstructPaymentInfoWire } from '../src/reconstruct-payment-info.js'
 
@@ -22,7 +23,7 @@ const BASE_EXTRA = {
 }
 
 const BASE_REQUIREMENTS = {
-  scheme: 'authCapture',
+  scheme: AUTH_CAPTURE_SCHEME,
   network: 'eip155:84532',
   payTo: TEST_ADDRESSES.payTo,
   asset: TEST_ADDRESSES.asset,
@@ -67,7 +68,7 @@ function makeContext(overrides: {
   return {
     paymentPayload: {
       x402Version: 2,
-      accepted: { scheme: 'authCapture', network: 'eip155:84532' },
+      accepted: { scheme: AUTH_CAPTURE_SCHEME, network: 'eip155:84532' },
       payload: overrides.payload ?? EIP3009_PAYLOAD,
     },
     requirements: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,20 +87,20 @@ importers:
         specifier: ^25.9.0
         version: 25.9.0
       '@x402/core':
-        specifier: 2.12.0
-        version: 2.12.0
+        specifier: 2.14.0
+        version: 2.14.0
       '@x402/evm':
-        specifier: 2.12.0
-        version: 2.12.0(typescript@5.9.3)
+        specifier: 2.14.0
+        version: 2.14.0(typescript@5.9.3)
       '@x402/express':
-        specifier: 2.12.0
-        version: 2.12.0(ethers@6.16.0)(express@5.2.1)(typescript@5.9.3)
+        specifier: 2.14.0
+        version: 2.14.0(ethers@6.16.0)(express@5.2.1)(typescript@5.9.3)
       '@x402/fetch':
-        specifier: 2.12.0
-        version: 2.12.0
+        specifier: 2.14.0
+        version: 2.14.0
       '@x402r/evm':
-        specifier: 0.2.0-alpha.0
-        version: 0.2.0-alpha.0(@x402/core@2.12.0)(@x402/evm@2.12.0(typescript@5.9.3))(viem@2.52.0(typescript@5.9.3)(zod@4.4.3))
+        specifier: 0.2.0-alpha.1
+        version: 0.2.0-alpha.1(@x402/core@2.14.0)(@x402/evm@2.14.0(typescript@5.9.3))(viem@2.52.0(typescript@5.9.3)(zod@4.4.3))
       express:
         specifier: ^5.0.0
         version: 5.2.1
@@ -141,11 +141,17 @@ importers:
         version: link:../core
     devDependencies:
       '@x402/core':
-        specifier: 2.12.0
-        version: 2.12.0
+        specifier: 2.14.0
+        version: 2.14.0
+      '@x402/evm':
+        specifier: 2.14.0
+        version: 2.14.0(typescript@5.9.3)
       '@x402r/evm':
-        specifier: 0.2.0-alpha.0
-        version: 0.2.0-alpha.0(@x402/core@2.12.0)(@x402/evm@2.12.0(typescript@5.9.3))(viem@2.52.0(typescript@5.9.3)(zod@4.4.3))
+        specifier: 0.2.0-alpha.1
+        version: 0.2.0-alpha.1(@x402/core@2.14.0)(@x402/evm@2.14.0(typescript@5.9.3))(viem@2.52.0(typescript@5.9.3)(zod@4.4.3))
+      viem:
+        specifier: ^2.48.11
+        version: 2.52.0(typescript@5.9.3)(zod@4.4.3)
 
   packages/sdk:
     dependencies:
@@ -1498,23 +1504,29 @@ packages:
   '@x402/core@2.12.0':
     resolution: {integrity: sha512-dLae9AbZRN/W7GsKe9ngqGsflnP+esE72s0GjmqDZbPihM/tlHCA6UnDdgM0qfOiDOf9iL+mmCs1OyLWpwnGLQ==}
 
+  '@x402/core@2.14.0':
+    resolution: {integrity: sha512-+xTM6hfGduYvFcQ7QwKvCwommL6+zqzqmr5IuPojbt+RZjo4QUjSkHW+arMtPoIKRLxWAI+e6P4UJMMblwG+Dw==}
+
   '@x402/evm@2.12.0':
     resolution: {integrity: sha512-kZUoHPVdBS8wlTg5K1eoh/1V0+5n9ABGRPC5DOQwRlkAwIrAFOEi2pQE+jgvOx0iM5ib2xj9gJjpldRbasX12w==}
 
-  '@x402/express@2.12.0':
-    resolution: {integrity: sha512-bPc6jpRr4iCh7KRJETK/2/bVTKHy/EeybQd9s+Mz4Ab+C64F1IH20GeW4gyj27dtAd2YgOiFrk8uyxSbZPKhkQ==}
+  '@x402/evm@2.14.0':
+    resolution: {integrity: sha512-Qrm0+hN1gMK1vrX4vW4sdcx5txYTx8J2uDNulcNoIdtz15kTU5hjNUyZaCpI3i6x0MXnUBGfyar9Ut9uoAoPMw==}
+
+  '@x402/express@2.14.0':
+    resolution: {integrity: sha512-dkM4A1EanDciS2iJwxl5B/Qsz+ENWmL5O8jt5i+hRc8w+rQ6Loj04C4cIN3RCAIwmD91NTCmivGsIJ+4WrdEwQ==}
     peerDependencies:
-      '@x402/paywall': ^2.12.0
+      '@x402/paywall': ^2.14.0
       express: ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       '@x402/paywall':
         optional: true
 
-  '@x402/extensions@2.12.0':
-    resolution: {integrity: sha512-1B6a/ubCiAoNrVbrZ4btUcWXjM5e71fB2rxSrtW+mINGVonW4w7QDjAKdOlKzi6xqRSoGRVQm5ajL9hIGvkE2A==}
+  '@x402/extensions@2.14.0':
+    resolution: {integrity: sha512-2zu8hxf0j4BRvSWNPRKziQLdubnQpzzmU9xopKK5ZyXa434hvmGEUPMBOA2NIYvaTkyZjQH3JZ3GPDyzjBvFqA==}
 
-  '@x402/fetch@2.12.0':
-    resolution: {integrity: sha512-lkN/fzkZjnbJreLwI3fessKAaTKsOrrc0mFPGHWwZy0W/s8KFusLwdHuS8ul/XdUyNcYYrwcV6z0faGGSWNUNA==}
+  '@x402/fetch@2.14.0':
+    resolution: {integrity: sha512-GSCnxdrbmtuKeki2MTy2vnJq4e6PrA7XfF1yX23VxKvASIYaXUioW1HtRzNYU7imeMe13YcwefRH1jO7Ei7Tyg==}
 
   '@x402r/erc8004@0.1.0-alpha.2':
     resolution: {integrity: sha512-OXOz8xSlVzNEcBoV4V6Gl9uB/HFKNbDvA4PHgwTEKXsU71N3NynfuRMXAQCvwle/SfFIFy3ndGdkC/Vi2+Su3Q==}
@@ -1528,6 +1540,13 @@ packages:
       '@x402/core': ^2.4.0
       '@x402/evm': ^2.0.0
       viem: ^2.0.0
+
+  '@x402r/evm@0.2.0-alpha.1':
+    resolution: {integrity: sha512-GZJNucUAiV4yjorlERdLNOKmCPdVSBx7EsUIE6FivjvWipPc1k0+leAaBwD+/rwW6JFhieD11GjXRaCpOo//Sg==}
+    peerDependencies:
+      '@x402/core': ^2.14.0
+      '@x402/evm': ^2.14.0
+      viem: ^2.48.11
 
   abitype@1.2.3:
     resolution: {integrity: sha512-Ofer5QUnuUdTFsBRwARMoWKOH1ND5ehwYhJ3OJ/BQO+StkwQjHw0XyVh4vDttzHB7QOFhPHa/o413PJ82gU/Tg==}
@@ -4102,6 +4121,10 @@ snapshots:
     dependencies:
       zod: 3.25.76
 
+  '@x402/core@2.14.0':
+    dependencies:
+      zod: 3.25.76
+
   '@x402/evm@2.12.0(typescript@5.9.3)':
     dependencies:
       '@x402/core': 2.12.0
@@ -4112,10 +4135,20 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402/express@2.12.0(ethers@6.16.0)(express@5.2.1)(typescript@5.9.3)':
+  '@x402/evm@2.14.0(typescript@5.9.3)':
     dependencies:
-      '@x402/core': 2.12.0
-      '@x402/extensions': 2.12.0(ethers@6.16.0)(typescript@5.9.3)
+      '@x402/core': 2.14.0
+      viem: 2.52.0(typescript@5.9.3)(zod@3.25.76)
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@x402/express@2.14.0(ethers@6.16.0)(express@5.2.1)(typescript@5.9.3)':
+    dependencies:
+      '@x402/core': 2.14.0
+      '@x402/extensions': 2.14.0(ethers@6.16.0)(typescript@5.9.3)
       express: 5.2.1
     transitivePeerDependencies:
       - bufferutil
@@ -4123,12 +4156,12 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402/extensions@2.12.0(ethers@6.16.0)(typescript@5.9.3)':
+  '@x402/extensions@2.14.0(ethers@6.16.0)(typescript@5.9.3)':
     dependencies:
       '@noble/curves': 1.9.1
       '@scure/base': 1.2.6
       '@signinwithethereum/siwe': 4.2.0(ethers@6.16.0)(viem@2.52.0(typescript@5.9.3)(zod@4.4.3))
-      '@x402/core': 2.12.0
+      '@x402/core': 2.14.0
       ajv: 8.18.0
       jose: 5.10.0
       tweetnacl: 1.0.3
@@ -4140,9 +4173,9 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@x402/fetch@2.12.0':
+  '@x402/fetch@2.14.0':
     dependencies:
-      '@x402/core': 2.12.0
+      '@x402/core': 2.14.0
 
   '@x402r/erc8004@0.1.0-alpha.2(viem@2.52.0(typescript@5.9.3)(zod@4.4.3))':
     dependencies:
@@ -4152,6 +4185,12 @@ snapshots:
     dependencies:
       '@x402/core': 2.12.0
       '@x402/evm': 2.12.0(typescript@5.9.3)
+      viem: 2.52.0(typescript@5.9.3)(zod@4.4.3)
+
+  '@x402r/evm@0.2.0-alpha.1(@x402/core@2.14.0)(@x402/evm@2.14.0(typescript@5.9.3))(viem@2.52.0(typescript@5.9.3)(zod@4.4.3))':
+    dependencies:
+      '@x402/core': 2.14.0
+      '@x402/evm': 2.14.0(typescript@5.9.3)
       viem: 2.52.0(typescript@5.9.3)(zod@4.4.3)
 
   abitype@1.2.3(typescript@5.9.3)(zod@3.25.76):


### PR DESCRIPTION
## What

`@x402r/helpers`' `forwardToArbiter` hook gated on the pre-rename `'authCapture'` scheme literal. The scheme was renamed `authCapture` → `auth-capture`, so once helpers consume the renamed `@x402r/evm`, the gate `requirements.scheme !== 'authCapture'` matched nothing and the merchant→arbiter forwarding would **silently early-return on every settlement**. CI didn't catch it because the test fixtures hardcoded the same old literal.

This gates on the imported `AUTH_CAPTURE_SCHEME` constant instead, so the comparison tracks the package's scheme constant rather than a hardcoded string.

## Why the dep bump is in the same PR

Importing `AUTH_CAPTURE_SCHEME` is only possible against `@x402r/evm@0.2.0-alpha.1` — the renamed build exposes the constant; `0.2.0-alpha.0` does not and still emits `'authCapture'`. And bumping to the renamed scheme *without* the literal fix is exactly what breaks the bridge. So the fix and the bump are one atomic change. The renamed `@x402r/evm` peer-requires the 2.14 graph, hence the peer/devDep bumps.

## Changes

**`@x402r/helpers`**
- `forwardToArbiter`: gate on `AUTH_CAPTURE_SCHEME` (imported from `@x402r/evm`) instead of `'authCapture'`.
- peerDeps: `@x402/core` `>=2.5.0` → `^2.14.0`; add `@x402/evm ^2.14.0` + `viem ^2.48.11`; `@x402r/evm` floor → `>=0.2.0-alpha.1`. devDeps bumped to match.
- JSDoc + README: `AuthCaptureServerScheme` → `AuthCaptureEvmScheme` (the real class), `authCapture` → `auth-capture` prose.
- Tests: fixtures migrated to the imported constant; **3 new regression cases** — fires for `AUTH_CAPTURE_SCHEME`, skips a different scheme, and skips the legacy `'authCapture'` literal (guards against a reintroduced hardcode).

**examples**
- Repair the auth-capture example: kebab `@x402r/evm/auth-capture/*` subpaths, upstream client from `@x402/evm/auth-capture/client`, `scheme: AUTH_CAPTURE_SCHEME`; bump example deps to the 2.14 graph.

## Validation

- `@x402r/helpers`: 30/30 tests pass (incl. the 3 regression cases), typecheck clean.
- Full-workspace `turbo build` + `typecheck` green; biome clean.
- The regression suite was verified to genuinely fail (7/10 cases) when the gate is reverted to the old hardcoded literal — it is not tautological.

## Note on examples typecheck

The `examples` package has pre-existing `tsc` errors (a viem 2.47↔2.50 dual-version split + unrelated SDK-API drift in files this PR does not touch). Examples run via `tsx` and are not in the typecheck CI gate. This PR *reduces* `http-wire-capture.ts` from 5 → 2 errors; the 2 residual are the pre-existing viem split. Fully reconciling that split means bumping the `@x402r/core`/`@x402r/sdk` viem pins — a separate step in the broader 2.14 alignment.

First step of aligning the SDK to the upstreamed auth-capture scheme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
