### PR TITLE
docs(sdk): scrub upstream-org cross-refs from published source comments

### DIFF
--- a/packages/sdk/src/actions/erc8004-helpers.ts
+++ b/packages/sdk/src/actions/erc8004-helpers.ts
@@ -54,15 +54,15 @@ export function extractArbiterIdentity(
 /**
  * Extract agent registrations from the upstream x402 reputation extension.
  *
- * Parses `extensions["reputation"].info.registrations` per the upstream spec
- * (x402-foundation/x402 PR #1024). Returns validated registrations as an array.
+ * Parses `extensions["reputation"].info.registrations` per the upstream x402
+ * reputation extension spec. Returns validated registrations as an array.
  *
  * Agents can have multiple registrations across chains (EVM + Solana).
  * Each registration has a CAIP-10 `agentRegistry` and a string `agentId`.
  *
  * @experimental The upstream x402 reputation extension is not merged.
- * The shape of `extensions["reputation"]` may change.
- * See x402-foundation/x402#931.
+ * The shape of `extensions["reputation"]` may change; see the related
+ * upstream x402 reputation extension discussion.
  *
  * @param extensions - Extensions object from PaymentRequired or PaymentPayload
  * @returns Array of validated registrations, or empty array if extension is absent

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -251,10 +251,10 @@ export interface ArbiterIdentity {
 
 /**
  * A single agent registration from the upstream x402 reputation extension.
- * Matches the `AgentRegistration` object in the upstream spec (PR #1024).
+ * Matches the `AgentRegistration` object in the upstream reputation extension spec.
  *
  * @experimental Upstream x402 reputation extension is not merged.
- * The shape may change. See x402-foundation/x402#931.
+ * The shape may change; see the related upstream x402 reputation extension discussion.
  */
 export interface AgentRegistration {
   agentId: bigint


### PR DESCRIPTION
Removes the forbidden `x402-foundation/x402#…` cross-reference strings from `@x402r/sdk` source comments (they create sticky timeline events in the upstream repo) and rewrites them as plain prose that preserves the technical meaning.

- `sdk/src/types.ts` and `sdk/src/actions/erc8004-helpers.ts`: the `#931` / `#1024` refs (both about the same upstream x402 reputation extension) → "the upstream x402 reputation extension spec / discussion".
- Comment-only — no code, type, or behavior change; `tsc` clean. Diffstat: 2 files, +6/-6.

Per the repo convention of never embedding `org/repo#N` to non-BackTrackCo orgs in committed artifacts. No changeset (no user-facing change).
