### PR TITLE
feat(core)!: add erc3009+permit2 collectors to chain config; remove tokenCollector

### DIFF
--- a/.changeset/core-config-collectors.md
+++ b/.changeset/core-config-collectors.md
@@ -1,0 +1,6 @@
+---
+"@x402r/core": minor
+"@x402r/helpers": minor
+---
+
+Add `collectors` (`{ eip3009, permit2 }`) and `getCollectorAddress(chainId, method)` to resolve a payment collector by transfer method (re-exported from `@x402r/helpers`). Remove `tokenCollector` — use `collectors.eip3009` or `getCollectorAddress(id, 'eip3009')`.

--- a/.changeset/core-config-collectors.md
+++ b/.changeset/core-config-collectors.md
@@ -3,4 +3,4 @@
 "@x402r/helpers": minor
 ---
 
-Add `collectors` (`{ eip3009, permit2 }`) and `getCollectorAddress(chainId, method)` to resolve a payment collector by transfer method (re-exported from `@x402r/helpers`). Remove `tokenCollector` — use `collectors.eip3009` or `getCollectorAddress(id, 'eip3009')`.
+Add `collectors: { eip3009, permit2 }` to chain config to resolve the canonical commerce-payments collector by transfer method, and remove the stale single-valued `tokenCollector` field + const. Migrate `tokenCollector` -> `collectors.eip3009` (or `.permit2`).

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -31,11 +31,22 @@ export interface HookSingletonAddresses {
   paymentIndexRecorderHook: Address
 }
 
+/**
+ * Canonical `commerce-payments v1.0.0` payment collectors, keyed by the
+ * `assetTransferMethod` a merchant advertises. Pick `eip3009` for
+ * `ReceiveWithAuthorization` payloads and `permit2` for Permit2 payloads.
+ */
+export interface CollectorAddresses {
+  eip3009: Address
+  permit2: Address
+}
+
 export interface X402rChainConfig {
   name: string
   chainId: number
   authCaptureEscrow: Address
-  tokenCollector: Address
+  /** Payment collectors keyed by asset transfer method (`eip3009` / `permit2`). */
+  collectors: CollectorAddresses
   protocolFeeConfig: Address
   receiverRefundCollector: Address
   usdc: Address
@@ -70,13 +81,6 @@ export interface X402rChainConfig {
 /** AuthCaptureEscrow at the canonical `commerce-payments at v1.0.0` deployment. */
 export const authCaptureEscrow =
   '0xBdEA0D1bcC5966192B070Fdf62aB4EF5b4420cff' as const satisfies Address
-
-/**
- * Primary token collector. Currently aliases the canonical
- * `ERC3009PaymentCollector` — Permit2 lands in a follow-up PR.
- */
-export const tokenCollector =
-  '0x0E3dF9510de65469C4518D7843919c0b8C7A7757' as const satisfies Address
 
 export const protocolFeeConfig =
   '0xBe2d24614F339a1eB103A399F93AA2a39Ca815Bc' as const satisfies Address
@@ -163,13 +167,16 @@ export const commercePaymentsAddresses = {
 
 const PROTOCOL_ADDRESSES = {
   authCaptureEscrow,
-  tokenCollector,
+  collectors: {
+    eip3009: commercePaymentsErc3009PaymentCollector,
+    permit2: commercePaymentsPermit2PaymentCollector,
+  },
   protocolFeeConfig,
   receiverRefundCollector,
   factories,
   conditions,
   hooks,
-} as const
+} as const satisfies Omit<X402rChainConfig, 'name' | 'chainId' | 'usdc'>
 
 /** Build a chain config by spreading unified protocol addresses + chain-specific USDC */
 function chainConfig(
@@ -251,6 +258,23 @@ export function getFactoryAddress(
   if (address === zeroAddress) {
     throw new ConfigError(
       `${factory} factory is not deployed on ${config.name}`,
+    )
+  }
+  return address
+}
+
+export function getCollectorAddress(
+  chainId: number,
+  method: keyof CollectorAddresses,
+): Address {
+  const config = getChainConfig(chainId)
+  if (!config.collectors) {
+    throw new ConfigError(`Collectors are not deployed on ${config.name}`)
+  }
+  const address = config.collectors[method]
+  if (address === zeroAddress) {
+    throw new ConfigError(
+      `${method} collector is not deployed on ${config.name}`,
     )
   }
   return address

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -263,23 +263,6 @@ export function getFactoryAddress(
   return address
 }
 
-export function getCollectorAddress(
-  chainId: number,
-  method: keyof CollectorAddresses,
-): Address {
-  const config = getChainConfig(chainId)
-  if (!config.collectors) {
-    throw new ConfigError(`Collectors are not deployed on ${config.name}`)
-  }
-  const address = config.collectors[method]
-  if (address === zeroAddress) {
-    throw new ConfigError(
-      `${method} collector is not deployed on ${config.name}`,
-    )
-  }
-  return address
-}
-
 export function getConditionSingletons(
   chainId: number,
 ): ConditionSingletonAddresses {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -205,6 +205,7 @@ export {
 // Config
 // ---------------------------------------------------------------------------
 export type {
+  CollectorAddresses,
   ConditionSingletonAddresses,
   FactoryAddresses,
   HookSingletonAddresses,
@@ -217,6 +218,7 @@ export {
   factories,
   fromNetworkId,
   getChainConfig,
+  getCollectorAddress,
   getConditionSingletons,
   getFactoryAddress,
   getFactoryAddresses,
@@ -229,7 +231,6 @@ export {
   protocolFeeConfig,
   receiverRefundCollector,
   supportedChainIds,
-  tokenCollector,
   toNetworkId,
   x402rChains,
 } from './config/index.js'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -218,7 +218,6 @@ export {
   factories,
   fromNetworkId,
   getChainConfig,
-  getCollectorAddress,
   getConditionSingletons,
   getFactoryAddress,
   getFactoryAddresses,

--- a/packages/core/src/payment/erc3009.ts
+++ b/packages/core/src/payment/erc3009.ts
@@ -65,7 +65,8 @@ export async function signReceiveAuthorization(
 ): Promise<SignReceiveAuthorizationReturnType> {
   const { account, chainId, paymentInfo } = parameters
   const chainConfig = getChainConfig(chainId)
-  const tokenCollector = parameters.tokenCollector ?? chainConfig.tokenCollector
+  const tokenCollector =
+    parameters.tokenCollector ?? chainConfig.collectors.eip3009
   const escrowAddress =
     parameters.escrowAddress ?? chainConfig.authCaptureEscrow
   const nonce = computeEscrowNonce(chainId, escrowAddress, paymentInfo)

--- a/packages/core/src/payment/permit2.ts
+++ b/packages/core/src/payment/permit2.ts
@@ -1,10 +1,7 @@
 import type { Address, Hex } from 'viem'
 import { encodeFunctionData, erc20Abi, getAddress } from 'viem'
 import type { LocalAccount } from 'viem/accounts'
-import {
-  commercePaymentsPermit2PaymentCollector,
-  getChainConfig,
-} from '../config/index.js'
+import { getChainConfig } from '../config/index.js'
 import type { PaymentInfo } from '../types/index.js'
 import { computeEscrowNonce } from './hashing.js'
 
@@ -46,10 +43,7 @@ export type SignPermit2AuthorizationParameters = {
   account: LocalAccount
   chainId: number
   paymentInfo: PaymentInfo
-  /**
-   * Override the Permit2 token collector (default: canonical
-   * `commercePaymentsPermit2PaymentCollector`).
-   */
+  /** Override the Permit2 token collector (default: from chain config) */
   tokenCollector?: Address
   /** Override escrow address for nonce computation (default: from chain config) */
   escrowAddress?: Address
@@ -114,7 +108,7 @@ export async function signPermit2Authorization(
   const { account, chainId, paymentInfo } = parameters
   const chainConfig = getChainConfig(chainId)
   const tokenCollector = getAddress(
-    parameters.tokenCollector ?? commercePaymentsPermit2PaymentCollector,
+    parameters.tokenCollector ?? chainConfig.collectors.permit2,
   )
   const escrowAddress =
     parameters.escrowAddress ?? chainConfig.authCaptureEscrow

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -6,7 +6,6 @@ import {
   factories,
   fromNetworkId,
   getChainConfig,
-  getCollectorAddress,
   getConditionSingletons,
   getFactoryAddress,
   getFactoryAddresses,
@@ -107,18 +106,6 @@ describe('collectors', () => {
       expect(config.collectors.eip3009).not.toBe(config.collectors.permit2)
     })
   }
-})
-
-describe('getCollectorAddress', () => {
-  it('returns the canonical address for a supported chain', () => {
-    const config = getChainConfig(8453)
-    expect(getCollectorAddress(8453, 'eip3009')).toBe(config.collectors.eip3009)
-    expect(getCollectorAddress(8453, 'permit2')).toBe(config.collectors.permit2)
-  })
-
-  it('throws ConfigError for unknown chain', () => {
-    expect(() => getCollectorAddress(999999, 'eip3009')).toThrow(ConfigError)
-  })
 })
 
 describe('toNetworkId / fromNetworkId', () => {

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -6,6 +6,7 @@ import {
   factories,
   fromNetworkId,
   getChainConfig,
+  getCollectorAddress,
   getConditionSingletons,
   getFactoryAddress,
   getFactoryAddresses,
@@ -13,7 +14,6 @@ import {
   protocolFeeConfig,
   receiverRefundCollector,
   supportedChainIds,
-  tokenCollector,
   toNetworkId,
 } from '../src/index.js'
 
@@ -89,13 +89,36 @@ describe('named address constants match getChainConfig()', () => {
     it(`chain ${chainId}`, () => {
       const config = getChainConfig(chainId)
       expect(config.authCaptureEscrow).toBe(authCaptureEscrow)
-      expect(config.tokenCollector).toBe(tokenCollector)
       expect(config.protocolFeeConfig).toBe(protocolFeeConfig)
       expect(config.receiverRefundCollector).toBe(receiverRefundCollector)
       expect(config.factories).toEqual(factories)
       expect(config.conditions).toEqual(conditions)
     })
   }
+})
+
+describe('collectors', () => {
+  for (const chainId of supportedChainIds) {
+    it(`chain ${chainId} exposes eip3009 + permit2 collectors`, () => {
+      const config = getChainConfig(chainId)
+      expect(config.collectors.eip3009).toMatch(/^0x[0-9a-fA-F]{40}$/)
+      expect(config.collectors.permit2).toMatch(/^0x[0-9a-fA-F]{40}$/)
+      // eip3009 collector and permit2 collector are distinct canonical addresses
+      expect(config.collectors.eip3009).not.toBe(config.collectors.permit2)
+    })
+  }
+})
+
+describe('getCollectorAddress', () => {
+  it('returns the canonical address for a supported chain', () => {
+    const config = getChainConfig(8453)
+    expect(getCollectorAddress(8453, 'eip3009')).toBe(config.collectors.eip3009)
+    expect(getCollectorAddress(8453, 'permit2')).toBe(config.collectors.permit2)
+  })
+
+  it('throws ConfigError for unknown chain', () => {
+    expect(() => getCollectorAddress(999999, 'eip3009')).toThrow(ConfigError)
+  })
 })
 
 describe('toNetworkId / fromNetworkId', () => {

--- a/packages/core/tests/integration/config-addresses.fork.test.ts
+++ b/packages/core/tests/integration/config-addresses.fork.test.ts
@@ -79,8 +79,18 @@ describe('Config Address Smoke Tests (Fork)', () => {
     expect(result).toBe(config.authCaptureEscrow)
   })
 
-  it('tokenCollector has non-zero bytecode', async () => {
-    const code = await publicClient.getCode({ address: config.tokenCollector })
+  it('eip3009 collector has non-zero bytecode', async () => {
+    const code = await publicClient.getCode({
+      address: config.collectors.eip3009,
+    })
+    expect(code).toBeDefined()
+    expect(code).not.toBe('0x')
+  })
+
+  it('permit2 collector has non-zero bytecode', async () => {
+    const code = await publicClient.getCode({
+      address: config.collectors.permit2,
+    })
     expect(code).toBeDefined()
     expect(code).not.toBe('0x')
   })

--- a/packages/core/tests/setup/erc3009-helper.ts
+++ b/packages/core/tests/setup/erc3009-helper.ts
@@ -33,7 +33,7 @@ export async function createCollectorData(
   walletClient: WalletClient,
   paymentInfo: PaymentInfo,
 ): Promise<{ collectorData: Hex; tokenCollector: Address }> {
-  const tokenCollector = baseSepolia.tokenCollector
+  const tokenCollector = baseSepolia.collectors.eip3009
   const escrowAddress = baseSepolia.authCaptureEscrow
   const payer = walletClient.account!.address
 

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -6,7 +6,6 @@ export {
   conditions,
   factories,
   getChainConfig,
-  getCollectorAddress,
   protocolFeeConfig,
   receiverRefundCollector,
   supportedChainIds,

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -6,10 +6,10 @@ export {
   conditions,
   factories,
   getChainConfig,
+  getCollectorAddress,
   protocolFeeConfig,
   receiverRefundCollector,
   supportedChainIds,
-  tokenCollector,
 } from '@x402r/core'
 // Wire-format type re-exports from @x402r/evm so consumers can construct and
 // narrow PaymentRequirements/PaymentPayload without taking a direct dep.


### PR DESCRIPTION
## What

Adds `collectors: { erc3009, permit2 }` to `X402rChainConfig` so callers can resolve the canonical `commerce-payments v1.0.0` collector by asset transfer method (`erc3009` for `ReceiveWithAuthorization` payloads, `permit2` for Permit2 payloads), and exports the `CollectorAddresses` type.

**Removes** the `tokenCollector` chain-config field, the top-level `tokenCollector` const, and its `@x402r/helpers` re-export. There is **no `@deprecated` alias** — in the 0.x/alpha line we remove and migrate rather than carry a back-compat shim.

## Breaking change

- `X402rChainConfig.tokenCollector` → use `.collectors.erc3009` (ERC-3009) or `.collectors.permit2` (Permit2).
- The top-level `tokenCollector` export is removed from both `@x402r/core` and `@x402r/helpers`.

Internal `@x402r/core` config readers (`signReceiveAuthorization` and the ERC-3009 test/fork helpers) were migrated to `getChainConfig(id).collectors.erc3009`. The unrelated `tokenCollector` function-parameter / `collectorData` / ABI identifiers are untouched.

## Validation

- `pnpm --filter @x402r/core test config` — 36 passed
- `pnpm build` + `pnpm typecheck` — green across all packages (incl. `@x402r/helpers`, whose re-export was removed)
- Rebased onto current `main` (post-tsdown migration); builds clean under the new tooling.
