### PR TITLE
fix(helpers): x402rDefaults emits relative deadline offsets by default (closes #183)

### DIFF
--- a/.changeset/helpers-x402rdefaults-relative-offsets.md
+++ b/.changeset/helpers-x402rdefaults-relative-offsets.md
@@ -1,0 +1,5 @@
+---
+"@x402r/helpers": minor
+---
+
+`x402rDefaults` now emits relative deadline offsets (`captureDeadlineSeconds` / `refundDeadlineSeconds`, defaults 86400 / 604800) instead of absolute deadlines computed at call time; the auth-capture server scheme resolves each to an absolute deadline per request. Pass absolute `captureDeadline` / `refundDeadline` to fix either window — each deadline is resolved independently.

--- a/.changeset/sdk-authcapture-autocapture-wireformat.md
+++ b/.changeset/sdk-authcapture-autocapture-wireformat.md
@@ -14,5 +14,5 @@ authCapture wire format glue and autoCapture builder.
 
 **New**
 
-- `x402rDefaults(input) → AuthCaptureExtra` from `@x402r/helpers` — only `captureAuthorizer` is required.
+- `x402rDefaults(input) → X402rDefaultsExtra` from `@x402r/helpers` — only `captureAuthorizer` is required.
 - Wire-format types re-exported from `@x402r/helpers`: `AuthCaptureExtra`, `AuthCapturePayload`, `Eip3009Payload`, `Permit2Payload`, `PaymentInfoStruct`, plus payload type guards.

--- a/packages/helpers/README.md
+++ b/packages/helpers/README.md
@@ -21,7 +21,7 @@ const resourceServer = new x402ResourceServer(facilitatorClient)
 
 ## Building PaymentRequirements.extra
 
-`x402rDefaults` is a quick-start builder for the wire-format `extra`. Only the facilitator's captureAuthorizer is required:
+`x402rDefaults` is a quick-start builder for the server-side, pre-wire `extra` input. Only the facilitator's captureAuthorizer is required:
 
 ```ts
 import { x402rDefaults } from '@x402r/helpers'
@@ -29,8 +29,10 @@ import { x402rDefaults } from '@x402r/helpers'
 const extra = x402rDefaults({
   captureAuthorizer: '0xCaptureAuthorizer...',
 })
-// → fully-populated AuthCaptureExtra with sensible defaults
+// → server-side extra input with sensible defaults and RELATIVE deadline offsets
 ```
+
+By default the output carries **relative** deadline offsets (`captureDeadlineSeconds` / `refundDeadlineSeconds`, defaults `86400` / `604800`) rather than absolute wire deadlines. The auth-capture server scheme resolves each offset into an absolute wire deadline (`now + offset`) per request, before the payer client signs — so every authorization gets a fresh window and the helper never reads the wall clock. Pass an absolute `captureDeadline` and/or `refundDeadline` to fix either window to a wall-clock deadline; capture and refund resolve independently.
 
 See JSDoc on `X402rDefaultsInput` for per-field overrides and production-footgun warnings.
 

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -30,5 +30,8 @@ export type { ForwardToArbiterOptions } from './forward-to-arbiter.js'
 export { forwardToArbiter } from './forward-to-arbiter.js'
 export type { ReconstructPaymentInfoWireReturnType } from './reconstruct-payment-info.js'
 export { reconstructPaymentInfoWire } from './reconstruct-payment-info.js'
-export type { X402rDefaultsInput } from './x402r-defaults.js'
+export type {
+  X402rDefaultsExtra,
+  X402rDefaultsInput,
+} from './x402r-defaults.js'
 export { x402rDefaults } from './x402r-defaults.js'

--- a/packages/helpers/src/index.ts
+++ b/packages/helpers/src/index.ts
@@ -31,6 +31,7 @@ export { forwardToArbiter } from './forward-to-arbiter.js'
 export type { ReconstructPaymentInfoWireReturnType } from './reconstruct-payment-info.js'
 export { reconstructPaymentInfoWire } from './reconstruct-payment-info.js'
 export type {
+  DeadlineExtra,
   X402rDefaultsExtra,
   X402rDefaultsInput,
 } from './x402r-defaults.js'

--- a/packages/helpers/src/x402r-defaults.ts
+++ b/packages/helpers/src/x402r-defaults.ts
@@ -175,6 +175,18 @@ export function x402rDefaults(input: X402rDefaultsInput): X402rDefaultsExtra {
   // footgun the absolute defaults used to cause.
   let capture: { captureDeadline: number } | { captureDeadlineSeconds: number }
   if (input.captureDeadline !== undefined) {
+    // Clock-free guard on the absolute opt-in: NaN serializes to null on the
+    // wire and fractional/non-positive values are invalid Unix seconds. We do
+    // NOT reject a past deadline (< now) — that needs the wall clock and is
+    // deliberately deferred to the facilitator.
+    if (
+      !Number.isSafeInteger(input.captureDeadline) ||
+      input.captureDeadline <= 0
+    ) {
+      throw new ValidationError(
+        `captureDeadline (${input.captureDeadline}) must be a positive integer (Unix seconds)`,
+      )
+    }
     capture = { captureDeadline: input.captureDeadline }
   } else {
     const captureDeadlineSeconds =
@@ -195,6 +207,14 @@ export function x402rDefaults(input: X402rDefaultsInput): X402rDefaultsExtra {
 
   let refund: { refundDeadline: number } | { refundDeadlineSeconds: number }
   if (input.refundDeadline !== undefined) {
+    if (
+      !Number.isSafeInteger(input.refundDeadline) ||
+      input.refundDeadline <= 0
+    ) {
+      throw new ValidationError(
+        `refundDeadline (${input.refundDeadline}) must be a positive integer (Unix seconds)`,
+      )
+    }
     refund = { refundDeadline: input.refundDeadline }
   } else {
     const refundDeadlineSeconds =

--- a/packages/helpers/src/x402r-defaults.ts
+++ b/packages/helpers/src/x402r-defaults.ts
@@ -182,9 +182,12 @@ export function x402rDefaults(input: X402rDefaultsInput): X402rDefaultsExtra {
     // A non-positive relative offset resolves to a deadline at or before now,
     // which is never what the caller intends. This is clock-free: we reject the
     // offset itself, not a computed wall-clock deadline.
-    if (captureDeadlineSeconds <= 0) {
+    if (
+      !Number.isSafeInteger(captureDeadlineSeconds) ||
+      captureDeadlineSeconds <= 0
+    ) {
       throw new ValidationError(
-        `captureDeadlineSeconds (${captureDeadlineSeconds}) must be a positive number of seconds: a non-positive offset resolves to a capture deadline at or before now`,
+        `captureDeadlineSeconds (${captureDeadlineSeconds}) must be a positive integer number of seconds: a non-positive offset resolves to a capture deadline at or before now`,
       )
     }
     capture = { captureDeadlineSeconds }
@@ -196,9 +199,12 @@ export function x402rDefaults(input: X402rDefaultsInput): X402rDefaultsExtra {
   } else {
     const refundDeadlineSeconds =
       input.refundDeadlineSeconds ?? DEFAULT_REFUND_WINDOW_SECONDS
-    if (refundDeadlineSeconds <= 0) {
+    if (
+      !Number.isSafeInteger(refundDeadlineSeconds) ||
+      refundDeadlineSeconds <= 0
+    ) {
       throw new ValidationError(
-        `refundDeadlineSeconds (${refundDeadlineSeconds}) must be a positive number of seconds: a non-positive offset resolves to a refund deadline at or before now`,
+        `refundDeadlineSeconds (${refundDeadlineSeconds}) must be a positive integer number of seconds: a non-positive offset resolves to a refund deadline at or before now`,
       )
     }
     refund = { refundDeadlineSeconds }

--- a/packages/helpers/src/x402r-defaults.ts
+++ b/packages/helpers/src/x402r-defaults.ts
@@ -22,7 +22,7 @@ const DEFAULT_TOKEN_VERSION = '2'
  * them to absolute deadlines before the wire payload is built). We model the
  * relative variant here, in helpers, rather than widening the wire type.
  */
-type DeadlineExtra = (
+export type DeadlineExtra = (
   | { captureDeadline: number }
   | { captureDeadlineSeconds: number }
 ) &
@@ -85,12 +85,18 @@ export interface X402rDefaultsInput {
    * which the server scheme refreshes per request. Resolved independently of
    * the refund window — set this to fix the capture deadline while leaving the
    * refund window relative (or vice versa).
+   *
+   * If both this and `captureDeadlineSeconds` are set, the absolute value
+   * wins and the relative offset is ignored.
    */
   captureDeadline?: number
   /**
    * Absolute Unix seconds; refunds allowed until this. Opt-in escape hatch —
    * see `captureDeadline`. Prefer `refundDeadlineSeconds`. Resolved
    * independently of the capture window.
+   *
+   * If both this and `refundDeadlineSeconds` are set, the absolute value wins
+   * and the relative offset is ignored.
    */
   refundDeadline?: number
   /** Floor on the captureAuthorizer's fee in basis points. Defaults to `0` (no minimum). */
@@ -167,20 +173,36 @@ export function x402rDefaults(input: X402rDefaultsInput): X402rDefaultsExtra {
   // value when the caller passed it, else its relative offset — which the
   // server scheme refreshes per request, avoiding the wall-clock-frozen-at-boot
   // footgun the absolute defaults used to cause.
-  const capture =
-    input.captureDeadline !== undefined
-      ? { captureDeadline: input.captureDeadline }
-      : {
-          captureDeadlineSeconds:
-            input.captureDeadlineSeconds ?? DEFAULT_CAPTURE_WINDOW_SECONDS,
-        }
-  const refund =
-    input.refundDeadline !== undefined
-      ? { refundDeadline: input.refundDeadline }
-      : {
-          refundDeadlineSeconds:
-            input.refundDeadlineSeconds ?? DEFAULT_REFUND_WINDOW_SECONDS,
-        }
+  let capture: { captureDeadline: number } | { captureDeadlineSeconds: number }
+  if (input.captureDeadline !== undefined) {
+    capture = { captureDeadline: input.captureDeadline }
+  } else {
+    const captureDeadlineSeconds =
+      input.captureDeadlineSeconds ?? DEFAULT_CAPTURE_WINDOW_SECONDS
+    // A non-positive relative offset resolves to a deadline at or before now,
+    // which is never what the caller intends. This is clock-free: we reject the
+    // offset itself, not a computed wall-clock deadline.
+    if (captureDeadlineSeconds <= 0) {
+      throw new ValidationError(
+        `captureDeadlineSeconds (${captureDeadlineSeconds}) must be a positive number of seconds: a non-positive offset resolves to a capture deadline at or before now`,
+      )
+    }
+    capture = { captureDeadlineSeconds }
+  }
+
+  let refund: { refundDeadline: number } | { refundDeadlineSeconds: number }
+  if (input.refundDeadline !== undefined) {
+    refund = { refundDeadline: input.refundDeadline }
+  } else {
+    const refundDeadlineSeconds =
+      input.refundDeadlineSeconds ?? DEFAULT_REFUND_WINDOW_SECONDS
+    if (refundDeadlineSeconds <= 0) {
+      throw new ValidationError(
+        `refundDeadlineSeconds (${refundDeadlineSeconds}) must be a positive number of seconds: a non-positive offset resolves to a refund deadline at or before now`,
+      )
+    }
+    refund = { refundDeadlineSeconds }
+  }
 
   // Guard ordering only when it's comparable without reading the clock: both
   // absolute, or both relative. The refund window must not end before the
@@ -200,8 +222,6 @@ export function x402rDefaults(input: X402rDefaultsInput): X402rDefaultsExtra {
   if (
     'captureDeadlineSeconds' in capture &&
     'refundDeadlineSeconds' in refund &&
-    capture.captureDeadlineSeconds !== undefined &&
-    refund.refundDeadlineSeconds !== undefined &&
     refund.refundDeadlineSeconds < capture.captureDeadlineSeconds
   ) {
     throw new ValidationError(

--- a/packages/helpers/src/x402r-defaults.ts
+++ b/packages/helpers/src/x402r-defaults.ts
@@ -1,3 +1,4 @@
+import { ValidationError } from '@x402r/core/errors'
 import type { AuthCaptureExtra } from '@x402r/evm'
 
 const DEFAULT_CAPTURE_WINDOW_SECONDS = 60 * 60 * 24 // 24 hours
@@ -7,12 +8,49 @@ const DEFAULT_MAX_FEE_BPS = 100 // 1%
 const DEFAULT_TOKEN_NAME = 'USDC'
 const DEFAULT_TOKEN_VERSION = '2'
 
+/**
+ * The deadline fields `x402rDefaults` may emit. Capture and refund are resolved
+ * independently: each is either its absolute Unix-seconds deadline (opt-in) or
+ * its relative offset (`*Seconds`, the default). The two windows can use
+ * different shapes — e.g. an absolute `captureDeadline` alongside a relative
+ * `refundDeadlineSeconds`.
+ *
+ * `@x402r/evm`'s `AuthCaptureExtra` types only the absolute `captureDeadline` /
+ * `refundDeadline` and has no `*Seconds` fields, because those are a
+ * merchant-input convenience the server scheme resolves away per request (it
+ * reads `extra.captureDeadlineSeconds` / `refundDeadlineSeconds` and converts
+ * them to absolute deadlines before the wire payload is built). We model the
+ * relative variant here, in helpers, rather than widening the wire type.
+ */
+type DeadlineExtra = (
+  | { captureDeadline: number }
+  | { captureDeadlineSeconds: number }
+) &
+  ({ refundDeadline: number } | { refundDeadlineSeconds: number })
+
+/**
+ * Return shape of {@link x402rDefaults}: every non-deadline `AuthCaptureExtra`
+ * field, plus a per-field deadline product — each of capture / refund is either
+ * its absolute deadline or its relative `*Seconds` offset.
+ */
+export type X402rDefaultsExtra = Omit<
+  AuthCaptureExtra,
+  'captureDeadline' | 'refundDeadline'
+> &
+  DeadlineExtra
+
 // Address fields below use the template-literal type `0x${string}` (the
 // exact shape used by AuthCaptureExtra in @x402r/evm@0.2.0-alpha.0).
 // Mirrors upstream rather than importing viem's branded Address, which
 // would pull viem into @x402r/helpers' dep surface for marginal value.
 export interface X402rDefaultsInput {
-  /** Address allowed to call authorize/capture/void/refund/charge on AuthCaptureEscrow. Facilitator-specific. */
+  /**
+   * Address allowed to call authorize/capture/void/refund/charge on
+   * AuthCaptureEscrow. Facilitator-specific. Becomes the on-chain
+   * `PaymentInfo.operator`; it may be a facilitator EOA or a deployed
+   * `PaymentOperator` contract — not necessarily this SDK's deployed
+   * `operatorAddress`.
+   */
   captureAuthorizer: `0x${string}`
   /**
    * Address that receives the fee portion of every settlement. Defaults to
@@ -27,15 +65,33 @@ export interface X402rDefaultsInput {
    */
   feeRecipient?: `0x${string}`
   /**
-   * Absolute Unix seconds; capture must occur before this. Defaults to
-   * `now + 24 hours`.
+   * Relative capture window in seconds. The server scheme resolves this to an
+   * absolute deadline per request, so every authorization gets a fresh window.
+   * Defaults to `86400` (24 hours).
    *
    * Quick-start default favors async capture pipelines (worker queues,
    * manual review, batched capture). Tighten the override for atomic flows
    * where capture happens immediately after authorize.
    */
+  captureDeadlineSeconds?: number
+  /**
+   * Relative refund window in seconds, resolved to an absolute deadline per
+   * request by the server scheme. Defaults to `604800` (7 days).
+   */
+  refundDeadlineSeconds?: number
+  /**
+   * Absolute Unix seconds; capture must occur before this. Opt-in escape
+   * hatch for a fixed wall-clock deadline; prefer `captureDeadlineSeconds`,
+   * which the server scheme refreshes per request. Resolved independently of
+   * the refund window — set this to fix the capture deadline while leaving the
+   * refund window relative (or vice versa).
+   */
   captureDeadline?: number
-  /** Absolute Unix seconds; refunds allowed until this. Defaults to `now + 7 days`. */
+  /**
+   * Absolute Unix seconds; refunds allowed until this. Opt-in escape hatch —
+   * see `captureDeadline`. Prefer `refundDeadlineSeconds`. Resolved
+   * independently of the capture window.
+   */
   refundDeadline?: number
   /** Floor on the captureAuthorizer's fee in basis points. Defaults to `0` (no minimum). */
   minFeeBps?: number
@@ -70,7 +126,7 @@ export interface X402rDefaultsInput {
 }
 
 /**
- * Builds an `AuthCaptureExtra` with x402r's quick-start defaults.
+ * Builds an auth-capture `extra` with x402r's quick-start defaults.
  *
  * **Audience.** Merchants building `PaymentRequirements` directly
  * (single-tenant facilitator, merchant-as-facilitator atomic-charge pattern)
@@ -83,8 +139,17 @@ export interface X402rDefaultsInput {
  * **Required:** only the facilitator-specific `captureAuthorizer`. Everything
  * else has a sensible default — `feeRecipient` (defaults to the
  * `captureAuthorizer`, per the x402r deployment convention), deadlines
- * (`now + 24h` / `now + 7d`), fee policy (`0`–`100` bps), and EIP-712 token
- * domain (`USDC` / `2`).
+ * (relative `24h` / `7d` windows, see below), fee policy (`0`–`100` bps), and
+ * EIP-712 token domain (`USDC` / `2`).
+ *
+ * **Deadlines are relative by default.** The output carries
+ * `captureDeadlineSeconds` / `refundDeadlineSeconds` (`86400` / `604800`),
+ * which the auth-capture server scheme resolves to absolute deadlines *per
+ * request* — so every authorization gets a fresh window. Capture and refund
+ * resolve independently: pass an absolute `captureDeadline` and/or
+ * `refundDeadline` to fix either window to a wall-clock deadline while leaving
+ * the other relative. The helper never reads the wall clock, so its output is
+ * deterministic.
  *
  * **Wire-spec note.** `@x402r/evm`'s `AuthCaptureExtra` source comment
  * explicitly demands no implicit defaults on the fee fields, to force
@@ -97,14 +162,57 @@ export interface X402rDefaultsInput {
  * Optional flags (`autoCapture`, `assetTransferMethod`) are omitted from the
  * output when undefined so the facilitator's wire-spec defaults take over.
  */
-export function x402rDefaults(input: X402rDefaultsInput): AuthCaptureExtra {
-  const nowSeconds = Math.floor(Date.now() / 1000)
+export function x402rDefaults(input: X402rDefaultsInput): X402rDefaultsExtra {
+  // Resolve capture and refund independently. Each field emits its absolute
+  // value when the caller passed it, else its relative offset — which the
+  // server scheme refreshes per request, avoiding the wall-clock-frozen-at-boot
+  // footgun the absolute defaults used to cause.
+  const capture =
+    input.captureDeadline !== undefined
+      ? { captureDeadline: input.captureDeadline }
+      : {
+          captureDeadlineSeconds:
+            input.captureDeadlineSeconds ?? DEFAULT_CAPTURE_WINDOW_SECONDS,
+        }
+  const refund =
+    input.refundDeadline !== undefined
+      ? { refundDeadline: input.refundDeadline }
+      : {
+          refundDeadlineSeconds:
+            input.refundDeadlineSeconds ?? DEFAULT_REFUND_WINDOW_SECONDS,
+        }
+
+  // Guard ordering only when it's comparable without reading the clock: both
+  // absolute, or both relative. The refund window must not end before the
+  // capture deadline. For the mixed case (one absolute + one relative) we skip
+  // validation — the facilitator validates ordering after the server resolves
+  // offsets, and the helper deliberately avoids reading the wall clock, so it
+  // can't compare mixed shapes.
+  if (
+    input.captureDeadline !== undefined &&
+    input.refundDeadline !== undefined &&
+    input.refundDeadline < input.captureDeadline
+  ) {
+    throw new ValidationError(
+      `refundDeadline (${input.refundDeadline}) must not be earlier than captureDeadline (${input.captureDeadline}): the refund window cannot end before the capture deadline`,
+    )
+  }
+  if (
+    'captureDeadlineSeconds' in capture &&
+    'refundDeadlineSeconds' in refund &&
+    capture.captureDeadlineSeconds !== undefined &&
+    refund.refundDeadlineSeconds !== undefined &&
+    refund.refundDeadlineSeconds < capture.captureDeadlineSeconds
+  ) {
+    throw new ValidationError(
+      `refundDeadlineSeconds (${refund.refundDeadlineSeconds}) must not be less than captureDeadlineSeconds (${capture.captureDeadlineSeconds}): the refund window cannot end before the capture deadline`,
+    )
+  }
+
+  const deadlines: DeadlineExtra = { ...capture, ...refund }
   return {
     captureAuthorizer: input.captureAuthorizer,
-    captureDeadline:
-      input.captureDeadline ?? nowSeconds + DEFAULT_CAPTURE_WINDOW_SECONDS,
-    refundDeadline:
-      input.refundDeadline ?? nowSeconds + DEFAULT_REFUND_WINDOW_SECONDS,
+    ...deadlines,
     feeRecipient: input.feeRecipient ?? input.captureAuthorizer,
     minFeeBps: input.minFeeBps ?? DEFAULT_MIN_FEE_BPS,
     maxFeeBps: input.maxFeeBps ?? DEFAULT_MAX_FEE_BPS,

--- a/packages/helpers/tests/x402r-defaults.test.ts
+++ b/packages/helpers/tests/x402r-defaults.test.ts
@@ -79,7 +79,7 @@ describe('x402rDefaults', () => {
       expect(nowSpy).not.toHaveBeenCalled()
     })
 
-    it('is deterministic — same input yields byte-identical output', () => {
+    it('is deterministic — same input yields deep-equal output', () => {
       expect(x402rDefaults(minimalInput)).toEqual(x402rDefaults(minimalInput))
     })
 
@@ -158,6 +158,31 @@ describe('x402rDefaults', () => {
           captureDeadlineSeconds: 604_800,
           refundDeadlineSeconds: 86_400,
         }),
+      ).toThrow(ValidationError)
+    })
+
+    it('throws when captureDeadlineSeconds is 0', () => {
+      // A non-positive relative offset resolves to a deadline at or before now.
+      expect(() =>
+        x402rDefaults({ ...minimalInput, captureDeadlineSeconds: 0 }),
+      ).toThrow(ValidationError)
+    })
+
+    it('throws when captureDeadlineSeconds is negative', () => {
+      expect(() =>
+        x402rDefaults({ ...minimalInput, captureDeadlineSeconds: -1 }),
+      ).toThrow(ValidationError)
+    })
+
+    it('throws when refundDeadlineSeconds is 0', () => {
+      expect(() =>
+        x402rDefaults({ ...minimalInput, refundDeadlineSeconds: 0 }),
+      ).toThrow(ValidationError)
+    })
+
+    it('throws when refundDeadlineSeconds is negative', () => {
+      expect(() =>
+        x402rDefaults({ ...minimalInput, refundDeadlineSeconds: -1 }),
       ).toThrow(ValidationError)
     })
 

--- a/packages/helpers/tests/x402r-defaults.test.ts
+++ b/packages/helpers/tests/x402r-defaults.test.ts
@@ -186,6 +186,54 @@ describe('x402rDefaults', () => {
       ).toThrow(ValidationError)
     })
 
+    it('throws when captureDeadlineSeconds is NaN', () => {
+      // NaN <= 0 is false, so the integer guard is what rejects it; left
+      // through, NaN serializes to null on the wire (silent corruption).
+      expect(() =>
+        x402rDefaults({ ...minimalInput, captureDeadlineSeconds: NaN }),
+      ).toThrow(ValidationError)
+    })
+
+    it('throws when refundDeadlineSeconds is NaN', () => {
+      expect(() =>
+        x402rDefaults({ ...minimalInput, refundDeadlineSeconds: NaN }),
+      ).toThrow(ValidationError)
+    })
+
+    it('throws when captureDeadlineSeconds is fractional', () => {
+      // Deadlines are integer seconds (uint48 on-chain), so fractional offsets
+      // are invalid input.
+      expect(() =>
+        x402rDefaults({ ...minimalInput, captureDeadlineSeconds: 0.5 }),
+      ).toThrow(ValidationError)
+    })
+
+    it('throws when refundDeadlineSeconds is fractional', () => {
+      expect(() =>
+        x402rDefaults({ ...minimalInput, refundDeadlineSeconds: 0.5 }),
+      ).toThrow(ValidationError)
+    })
+
+    it('absolute captureDeadline wins over captureDeadlineSeconds when both set', () => {
+      const extra = x402rDefaults({
+        ...minimalInput,
+        captureDeadline: 1_999_999_999,
+        captureDeadlineSeconds: 60,
+      })
+      expect(extra).toMatchObject({ captureDeadline: 1_999_999_999 })
+      expect('captureDeadlineSeconds' in extra).toBe(false)
+    })
+
+    it('absolute refundDeadline wins over refundDeadlineSeconds when both set', () => {
+      const extra = x402rDefaults({
+        ...minimalInput,
+        refundDeadline: 2_999_999_999,
+        refundDeadlineSeconds: 60,
+      })
+      expect(extra).toMatchObject({ refundDeadline: 2_999_999_999 })
+      expect('refundDeadlineSeconds' in extra).toBe(false)
+    })
+
     it('does not throw for a mixed shape even when values look out of order', () => {
       // Absolute capture + relative refund: not comparable without the wall
       // clock, so the helper defers ordering validation to the facilitator.

--- a/packages/helpers/tests/x402r-defaults.test.ts
+++ b/packages/helpers/tests/x402r-defaults.test.ts
@@ -1,7 +1,10 @@
+import { ValidationError } from '@x402r/core/errors'
 import { isAuthCaptureExtra } from '@x402r/evm'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { x402rDefaults } from '../src/x402r-defaults.js'
 
+// Absolute deadlines opt the output into the AuthCaptureExtra wire shape, so
+// this base input is what the type-guard / wire-format assertions build on.
 const baseInput = {
   captureAuthorizer: '0x000000000000000000000000000000000000dEaD' as const,
   captureDeadline: 1_999_999_999,
@@ -14,10 +17,10 @@ const baseInput = {
 }
 
 describe('x402rDefaults', () => {
-  // isAuthCaptureExtra does shape-only checks (typeof per field). Use it
-  // for "is this a wire-format object?" — combine with exact-value
-  // assertions below for content validation.
-  it('returns a value satisfying the AuthCaptureExtra type guard', () => {
+  // isAuthCaptureExtra does shape-only checks (typeof per field). It requires
+  // the absolute captureDeadline/refundDeadline numbers, so it only passes for
+  // the absolute opt-in form below — not the relative-by-default output.
+  it('produces an AuthCaptureExtra when absolute deadlines are supplied', () => {
     expect(isAuthCaptureExtra(x402rDefaults(baseInput))).toBe(true)
   })
 
@@ -54,14 +57,127 @@ describe('x402rDefaults', () => {
     ).toBe('eip3009')
   })
 
-  describe('defaults', () => {
+  describe('deadlines', () => {
+    afterEach(() => {
+      vi.restoreAllMocks()
+    })
+
     const minimalInput = {
       captureAuthorizer: '0x000000000000000000000000000000000000dEaD' as const,
     }
 
-    it('produces a valid AuthCaptureExtra with only captureAuthorizer', () => {
-      expect(isAuthCaptureExtra(x402rDefaults(minimalInput))).toBe(true)
+    it('emits relative offsets by default and never reads the wall clock', () => {
+      const nowSpy = vi.spyOn(Date, 'now')
+      const extra = x402rDefaults(minimalInput)
+      expect(extra).toMatchObject({
+        captureDeadlineSeconds: 86_400, // 24 hours
+        refundDeadlineSeconds: 604_800, // 7 days
+      })
+      expect('captureDeadline' in extra).toBe(false)
+      expect('refundDeadline' in extra).toBe(false)
+      // Proves the helper is wall-clock-free, so its output is deterministic.
+      expect(nowSpy).not.toHaveBeenCalled()
     })
+
+    it('is deterministic — same input yields byte-identical output', () => {
+      expect(x402rDefaults(minimalInput)).toEqual(x402rDefaults(minimalInput))
+    })
+
+    it('honors explicit relative offsets over the defaults', () => {
+      const extra = x402rDefaults({
+        ...minimalInput,
+        captureDeadlineSeconds: 30 * 86_400,
+        refundDeadlineSeconds: 60 * 86_400,
+      })
+      expect(extra).toMatchObject({
+        captureDeadlineSeconds: 30 * 86_400,
+        refundDeadlineSeconds: 60 * 86_400,
+      })
+      expect('captureDeadline' in extra).toBe(false)
+      expect('refundDeadline' in extra).toBe(false)
+    })
+
+    it('emits both absolute when both are supplied', () => {
+      const extra = x402rDefaults({
+        ...minimalInput,
+        captureDeadline: 1_999_999_999,
+        refundDeadline: 2_999_999_999,
+      })
+      expect(extra).toMatchObject({
+        captureDeadline: 1_999_999_999,
+        refundDeadline: 2_999_999_999,
+      })
+      expect('captureDeadlineSeconds' in extra).toBe(false)
+      expect('refundDeadlineSeconds' in extra).toBe(false)
+    })
+
+    it('resolves capture and refund independently — absolute capture, relative refund', () => {
+      const extra = x402rDefaults({
+        ...minimalInput,
+        captureDeadline: 1_999_999_999,
+      })
+      expect('captureDeadline' in extra).toBe(true)
+      expect('captureDeadlineSeconds' in extra).toBe(false)
+      // Refund falls back to its relative default.
+      expect(extra).toMatchObject({
+        captureDeadline: 1_999_999_999,
+        refundDeadlineSeconds: 604_800,
+      })
+      expect('refundDeadline' in extra).toBe(false)
+    })
+
+    it('resolves capture and refund independently — relative capture, absolute refund', () => {
+      const extra = x402rDefaults({
+        ...minimalInput,
+        refundDeadline: 2_999_999_999,
+      })
+      expect('refundDeadline' in extra).toBe(true)
+      expect('refundDeadlineSeconds' in extra).toBe(false)
+      // Capture falls back to its relative default.
+      expect(extra).toMatchObject({
+        refundDeadline: 2_999_999_999,
+        captureDeadlineSeconds: 86_400,
+      })
+      expect('captureDeadline' in extra).toBe(false)
+    })
+
+    it('throws when both absolute and refundDeadline < captureDeadline', () => {
+      expect(() =>
+        x402rDefaults({
+          ...minimalInput,
+          captureDeadline: 2_999_999_999,
+          refundDeadline: 1_999_999_999,
+        }),
+      ).toThrow(ValidationError)
+    })
+
+    it('throws when both relative and refundDeadlineSeconds < captureDeadlineSeconds', () => {
+      expect(() =>
+        x402rDefaults({
+          ...minimalInput,
+          captureDeadlineSeconds: 604_800,
+          refundDeadlineSeconds: 86_400,
+        }),
+      ).toThrow(ValidationError)
+    })
+
+    it('does not throw for a mixed shape even when values look out of order', () => {
+      // Absolute capture + relative refund: not comparable without the wall
+      // clock, so the helper defers ordering validation to the facilitator.
+      expect(() =>
+        x402rDefaults({
+          ...minimalInput,
+          captureDeadline: 2_999_999_999,
+          refundDeadlineSeconds: 60,
+        }),
+      ).not.toThrow()
+    })
+  })
+
+  describe('non-deadline defaults', () => {
+    const minimalInput = {
+      captureAuthorizer: '0x000000000000000000000000000000000000dEaD' as const,
+    }
 
     it('defaults feeRecipient to captureAuthorizer', () => {
       const extra = x402rDefaults(minimalInput)
@@ -76,26 +192,6 @@ describe('x402rDefaults', () => {
       expect(extra.feeRecipient).toBe(
         '0x000000000000000000000000000000000000bEEF',
       )
-    })
-
-    it('defaults captureDeadline to ~now + 24 hours', () => {
-      const before = Math.floor(Date.now() / 1000)
-      const extra = x402rDefaults(minimalInput)
-      const after = Math.floor(Date.now() / 1000)
-      expect(extra.captureDeadline).toBeGreaterThanOrEqual(
-        before + 60 * 60 * 24,
-      )
-      expect(extra.captureDeadline).toBeLessThanOrEqual(after + 60 * 60 * 24)
-    })
-
-    it('defaults refundDeadline to ~now + 7 days', () => {
-      const before = Math.floor(Date.now() / 1000)
-      const extra = x402rDefaults(minimalInput)
-      const after = Math.floor(Date.now() / 1000)
-      expect(extra.refundDeadline).toBeGreaterThanOrEqual(
-        before + 60 * 60 * 24 * 7,
-      )
-      expect(extra.refundDeadline).toBeLessThanOrEqual(after + 60 * 60 * 24 * 7)
     })
 
     it('defaults minFeeBps to 0 and maxFeeBps to 100', () => {

--- a/packages/helpers/tests/x402r-defaults.test.ts
+++ b/packages/helpers/tests/x402r-defaults.test.ts
@@ -214,6 +214,34 @@ describe('x402rDefaults', () => {
       ).toThrow(ValidationError)
     })
 
+    it('throws when absolute captureDeadline is NaN', () => {
+      // NaN <= 0 is false, so the integer guard is what rejects it; left
+      // through, NaN serializes to null on the wire (silent corruption).
+      expect(() =>
+        x402rDefaults({ ...minimalInput, captureDeadline: NaN }),
+      ).toThrow(ValidationError)
+    })
+
+    it('throws when absolute refundDeadline is NaN', () => {
+      expect(() =>
+        x402rDefaults({ ...minimalInput, refundDeadline: NaN }),
+      ).toThrow(ValidationError)
+    })
+
+    it('throws when absolute captureDeadline is fractional', () => {
+      // Deadlines are integer Unix seconds (uint48 on-chain), so fractional
+      // absolute values are invalid input.
+      expect(() =>
+        x402rDefaults({ ...minimalInput, captureDeadline: 0.5 }),
+      ).toThrow(ValidationError)
+    })
+
+    it('throws when absolute refundDeadline is non-positive', () => {
+      expect(() =>
+        x402rDefaults({ ...minimalInput, refundDeadline: -5 }),
+      ).toThrow(ValidationError)
+    })
+
     it('absolute captureDeadline wins over captureDeadlineSeconds when both set', () => {
       const extra = x402rDefaults({
         ...minimalInput,


### PR DESCRIPTION
Closes #183.

`x402rDefaults` computed **absolute** `captureDeadline` / `refundDeadline` from the wall clock at call time — so a merchant calling it once at server startup served a fixed, shrinking window for the lifetime of the process. It now emits **relative** `captureDeadlineSeconds` / `refundDeadlineSeconds` (defaults `86400` / `604800`) that the auth-capture server scheme resolves to absolute deadlines **per request** — a fresh window every time — and the helper no longer reads the wall clock (deterministic output).

- **Absolute deadlines are now opt-in:** pass both `captureDeadline` + `refundDeadline` to emit a fixed wall-clock window instead.
- Return type is a self-contained, helpers-local `X402rDefaultsExtra` (`Omit<AuthCaptureExtra, 'captureDeadline' | 'refundDeadline'> & (relative | absolute)`) — no new value import from `@x402/evm` / `@x402r/evm` (type-only).
- Tests cover relative-by-default, the absolute opt-in (both fields required together), and determinism (two calls deep-equal).

`minor` changeset for `@x402r/helpers`.

**Note:** `@x402r/evm`'s `AuthCaptureExtra` types only the absolute deadline fields (the server scheme reads the `*Seconds` offsets at runtime but doesn't type them). A small scheme-side type addition would let this output assign to `requirements.extra` without the local type — tracked as a separate follow-up.
