### PR TITLE
fix(cli): declare types: ["node"] for TS 6 compatibility

### DIFF
--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -4,6 +4,7 @@
   "exclude": ["tests"],
   "compilerOptions": {
     "outDir": "dist",
-    "lib": ["ES2022", "DOM"]
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
   }
 }


### PR DESCRIPTION
## Why

TypeScript 6.0 no longer auto-includes every `@types/*` package in the global scope. `@x402r/cli` uses Node built-ins (`process`, `node:util`/`node:path`/`node:url`) and relied on that implicit inclusion of `@types/node` (it's installed + linked, just never declared) — so its typecheck fails under TS 6 with 29× `TS2591` (e.g. `Cannot find name 'process'`).

This is the *only* remaining red check on the TS-6 bump (#154): Build + Publish Validation already pass under tsdown; just Typecheck, and only for cli.

## Fix

Declare the dependency explicitly — `"types": ["node"]` in `packages/cli/tsconfig.build.json`. It's the TS-recommended resolution (the error message itself suggests it), deterministic (no reliance on which `@types` happen to be hoisted), and explicit > implicit auto-inclusion is the better default anyway.

## Impact

- **No published change** — cli's `dist` (`.js` + `.d.ts`) is byte-identical with and without this (verified), so no changeset.
- **Green under both TS 5.9.3 (current main) and TS 6.0.3** (verified): cli typecheck 0 errors, full `pnpm typecheck` 6/6, `test:pkg` (publint + attw) clean.
- Unblocks #154 — once merged, the TS-6 bump rebases green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)