### PR TITLE
ci: pin foundry-toolchain to v1.7.1 (#159)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d  # v1.8.0
+        with:
+          version: v1.7.1
       - name: Clone x402r-contracts (with submodules)
         run: git clone --depth 1 --recurse-submodules https://github.com/BackTrackCo/x402r-contracts.git ../x402r-contracts
       - name: Build contracts
@@ -208,6 +210,8 @@ jobs:
         run: git clone --depth 1 --recurse-submodules https://github.com/BackTrackCo/x402r-contracts.git ../x402r-contracts
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d  # v1.8.0
+        with:
+          version: v1.7.1
       - name: Build contracts
         run: cd ../x402r-contracts && forge build
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  # Single source of truth for the Foundry toolchain version installed by
+  # foundry-rs/foundry-toolchain in the test-fork and abi-drift jobs.
+  FOUNDRY_VERSION: v1.7.1
+
 # Default-deny: per-job permissions opt in to only what they need.
 permissions: {}
 
@@ -118,7 +123,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d  # v1.8.0
         with:
-          version: v1.7.1
+          version: ${{ env.FOUNDRY_VERSION }}
       - name: Clone x402r-contracts (with submodules)
         run: git clone --depth 1 --recurse-submodules https://github.com/BackTrackCo/x402r-contracts.git ../x402r-contracts
       - name: Build contracts
@@ -211,7 +216,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@c7450ba673e133f5ee30098b3b54f444d3a2ca2d  # v1.8.0
         with:
-          version: v1.7.1
+          version: ${{ env.FOUNDRY_VERSION }}
       - name: Build contracts
         run: cd ../x402r-contracts && forge build
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093  # v6.0.8


### PR DESCRIPTION
## What
Pins the Foundry version installed by `foundry-rs/foundry-toolchain` to `v1.7.1` on both invocations in `ci.yml` (the `test-fork` and `abi-drift` jobs).

## Why
The action is SHA-pinned, but without a `version:` it installs whatever `stable` resolves to at workflow-run time. A breaking Foundry stable release could fail `abi-drift` (ABI output changes) or `test-fork` (Anvil behavior changes) for reasons unrelated to our code. Pinning the installed toolchain — not just the installer — closes that failure mode.

## Version choice
`v1.7.1` is the current latest stable Foundry release and matches what recent green `main` CI installs via `stable`, so this freezes the toolchain at its current state with no behavioral change today. Future bumps are deliberate.

Closes #159
