### PR TITLE
ci(deps): add Dependabot labels and commit-message prefixes (#160)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
       default-days: 7
       semver-minor-days: 14
       semver-major-days: 30
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(deps)"
     groups:
       production-dependencies:
         dependency-type: production
@@ -26,6 +30,10 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 30
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "chore(actions)"
     groups:
       actions:
         patterns:


### PR DESCRIPTION
## What
Adds `labels` and `commit-message.prefix` to both `updates:` entries in `.github/dependabot.yml`:
- npm → `chore(deps)`
- github-actions → `chore(actions)`
- both → `labels: [dependencies]`

## Why
- Dependabot PRs become filterable with `label:dependencies`.
- Squash-merges land as `chore(deps): bump foo from x to y (#N)` instead of `Bump foo ...`, keeping merge history conventional-commit consistent.

## Notes
`dependencies` is an existing repo label; listing it explicitly preserves Dependabot's default labeling (specifying `labels:` replaces the default set). Config-only change — no changeset.

Closes #160