### PR TITLE
feat(core): add formatError(err) utility (#118)

### DIFF
--- a/.changeset/core-format-viem-error.md
+++ b/.changeset/core-format-viem-error.md
@@ -1,0 +1,5 @@
+---
+"@x402r/core": minor
+---
+
+Add `formatViemError(err)` for flattening viem/contract errors to a string.

--- a/.changeset/core-format-viem-error.md
+++ b/.changeset/core-format-viem-error.md
@@ -1,5 +1,6 @@
 ---
 "@x402r/core": minor
+"@x402r/sdk": minor
 ---
 
 Add `formatError(err)` for flattening any error (viem/contract, `X402rError`, or unknown) to a human-readable string.

--- a/.changeset/core-format-viem-error.md
+++ b/.changeset/core-format-viem-error.md
@@ -2,4 +2,4 @@
 "@x402r/core": minor
 ---
 
-Add `formatViemError(err)` for flattening viem/contract errors to a string.
+Add `formatError(err)` for flattening any error (viem/contract, `X402rError`, or unknown) to a human-readable string.

--- a/packages/core/src/errors/format.ts
+++ b/packages/core/src/errors/format.ts
@@ -1,0 +1,21 @@
+import { X402rError } from './base.js'
+
+/**
+ * Flatten any thrown value to a human-readable string.
+ *
+ * @example
+ * try { await capture(client, args) } catch (err) { res.status(500).json({ error: formatViemError(err) }) }
+ */
+export function formatViemError(err: unknown): string {
+  if (err instanceof X402rError) return err.message
+  if (
+    err !== null &&
+    typeof err === 'object' &&
+    'shortMessage' in err &&
+    typeof (err as { shortMessage: unknown }).shortMessage === 'string'
+  ) {
+    return (err as { shortMessage: string }).shortMessage
+  }
+  if (err instanceof Error) return err.message
+  return String(err)
+}

--- a/packages/core/src/errors/format.ts
+++ b/packages/core/src/errors/format.ts
@@ -4,9 +4,9 @@ import { X402rError } from './base.js'
  * Flatten any thrown value to a human-readable string.
  *
  * @example
- * try { await capture(client, args) } catch (err) { res.status(500).json({ error: formatViemError(err) }) }
+ * try { await capture(client, args) } catch (err) { console.error(formatError(err)) }
  */
-export function formatViemError(err: unknown): string {
+export function formatError(err: unknown): string {
   if (err instanceof X402rError) return err.message
   if (
     err !== null &&

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -1,5 +1,6 @@
 export { X402rError, type X402rErrorArgs } from './base.js'
 export { ConfigError } from './config.js'
 export { ContractCallError } from './contract.js'
+export { formatViemError } from './format.js'
 export { NotImplementedError } from './not-implemented.js'
 export { ValidationError } from './validation.js'

--- a/packages/core/src/errors/index.ts
+++ b/packages/core/src/errors/index.ts
@@ -1,6 +1,6 @@
 export { X402rError, type X402rErrorArgs } from './base.js'
 export { ConfigError } from './config.js'
 export { ContractCallError } from './contract.js'
-export { formatViemError } from './format.js'
+export { formatError } from './format.js'
 export { NotImplementedError } from './not-implemented.js'
 export { ValidationError } from './validation.js'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -342,6 +342,7 @@ export type { X402rErrorArgs } from './errors/index.js'
 export {
   ConfigError,
   ContractCallError,
+  formatViemError,
   NotImplementedError,
   ValidationError,
   X402rError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -342,7 +342,7 @@ export type { X402rErrorArgs } from './errors/index.js'
 export {
   ConfigError,
   ContractCallError,
-  formatViemError,
+  formatError,
   NotImplementedError,
   ValidationError,
   X402rError,

--- a/packages/core/tests/format-error.test.ts
+++ b/packages/core/tests/format-error.test.ts
@@ -13,6 +13,13 @@ describe('formatError', () => {
     expect(formatError(viemLike)).toBe('The contract function reverted.')
   })
 
+  it('prefers shortMessage over .message for an Error that carries both (viem BaseError shape)', () => {
+    const err = Object.assign(new Error('long verbose message'), {
+      shortMessage: 'short',
+    })
+    expect(formatError(err)).toBe('short')
+  })
+
   it('returns .message for a plain Error', () => {
     const err = new Error('something went wrong')
     expect(formatError(err)).toBe('something went wrong')

--- a/packages/core/tests/format-error.test.ts
+++ b/packages/core/tests/format-error.test.ts
@@ -1,37 +1,37 @@
 import { describe, expect, it } from 'vitest'
 import { X402rError } from '../src/errors/base.js'
-import { formatViemError } from '../src/errors/format.js'
+import { formatError } from '../src/errors/format.js'
 
-describe('formatViemError', () => {
+describe('formatError', () => {
   it('returns .message for an X402rError instance', () => {
     const err = new X402rError('capture failed', { details: 'ConditionNotMet' })
-    expect(formatViemError(err)).toBe(err.message)
+    expect(formatError(err)).toBe(err.message)
   })
 
   it('returns shortMessage for a viem-shaped object', () => {
     const viemLike = { shortMessage: 'The contract function reverted.' }
-    expect(formatViemError(viemLike)).toBe('The contract function reverted.')
+    expect(formatError(viemLike)).toBe('The contract function reverted.')
   })
 
   it('returns .message for a plain Error', () => {
     const err = new Error('something went wrong')
-    expect(formatViemError(err)).toBe('something went wrong')
+    expect(formatError(err)).toBe('something went wrong')
   })
 
   it('returns the string itself for a string value', () => {
-    expect(formatViemError('raw string error')).toBe('raw string error')
+    expect(formatError('raw string error')).toBe('raw string error')
   })
 
   it('falls through to String(err) for a plain object without shortMessage', () => {
     const obj = { code: 42 }
-    expect(formatViemError(obj)).toBe(String(obj))
+    expect(formatError(obj)).toBe(String(obj))
   })
 
   it('handles null', () => {
-    expect(formatViemError(null)).toBe('null')
+    expect(formatError(null)).toBe('null')
   })
 
   it('handles undefined', () => {
-    expect(formatViemError(undefined)).toBe('undefined')
+    expect(formatError(undefined)).toBe('undefined')
   })
 })

--- a/packages/core/tests/format-viem-error.test.ts
+++ b/packages/core/tests/format-viem-error.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { X402rError } from '../src/errors/base.js'
+import { formatViemError } from '../src/errors/format.js'
+
+describe('formatViemError', () => {
+  it('returns .message for an X402rError instance', () => {
+    const err = new X402rError('capture failed', { details: 'ConditionNotMet' })
+    expect(formatViemError(err)).toBe(err.message)
+  })
+
+  it('returns shortMessage for a viem-shaped object', () => {
+    const viemLike = { shortMessage: 'The contract function reverted.' }
+    expect(formatViemError(viemLike)).toBe('The contract function reverted.')
+  })
+
+  it('returns .message for a plain Error', () => {
+    const err = new Error('something went wrong')
+    expect(formatViemError(err)).toBe('something went wrong')
+  })
+
+  it('returns the string itself for a string value', () => {
+    expect(formatViemError('raw string error')).toBe('raw string error')
+  })
+
+  it('falls through to String(err) for a plain object without shortMessage', () => {
+    const obj = { code: 42 }
+    expect(formatViemError(obj)).toBe(String(obj))
+  })
+
+  it('handles null', () => {
+    expect(formatViemError(null)).toBe('null')
+  })
+
+  it('handles undefined', () => {
+    expect(formatViemError(undefined)).toBe('undefined')
+  })
+})

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -38,6 +38,7 @@ export {
   ContractCallError,
   computePaymentInfoHash,
   createPermit2ApprovalTx,
+  formatError,
   formatFeeBreakdown,
   getChainConfig,
   getPermit2AllowanceReadParams,


### PR DESCRIPTION
## What
Adds `formatError(err: unknown): string` to `@x402r/core`, exported from the package root and the `./errors` subpath. Flattens any thrown value to a human-readable string in priority order: `X402rError` → its structured `.message`; viem-shaped errors → `shortMessage`; `Error` → `.message`; otherwise `String(err)`.

Centralizes the `err.shortMessage ?? err.message ?? String(err)` one-liner that consumers (arbiters, merchant handlers, CLI) re-implement, and gives one place to enrich later (e.g. unwrapping `ContractFunctionExecutionError`, falling back to `details`).

> Note: issue #118 proposed the name `formatViemError`; this ships as `formatError` since it also handles `X402rError` / `Error` / string / `unknown` — viem's `shortMessage` is just one of four branches.

## Tests
7 vitest cases covering each branch plus edge inputs (`null` / `undefined` / plain object). The `X402rError`-before-`shortMessage` ordering is guarded with a fixture whose `.message` ≠ `.shortMessage`.

## Out of scope
Adopting this in the arbiter examples is a follow-up in that repo.

Closes #118