### PR TITLE
chore(helpers): drop unused @x402/evm + viem peer dependencies

### DIFF
--- a/.changeset/helpers-drop-unused-peers.md
+++ b/.changeset/helpers-drop-unused-peers.md
@@ -1,0 +1,5 @@
+---
+"@x402r/helpers": patch
+---
+
+Drop the unused `@x402/evm` and `viem` peer dependencies — `@x402r/helpers` only requires `@x402/core` and `@x402r/evm` (which pulls the rest transitively).

--- a/.changeset/helpers-drop-unused-peers.md
+++ b/.changeset/helpers-drop-unused-peers.md
@@ -2,4 +2,4 @@
 "@x402r/helpers": patch
 ---
 
-Drop the unused `@x402/evm` and `viem` peer dependencies — `@x402r/helpers` only requires `@x402/core` and `@x402r/evm` (which pulls the rest transitively).
+Drop the unused `@x402/evm` and `viem` peer dependencies — `@x402r/helpers` only requires `@x402/core` and `@x402r/evm`. Consumers still provide `viem` / `@x402/evm` via `@x402r/evm`'s own peer requirements.

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -35,15 +35,11 @@
   },
   "peerDependencies": {
     "@x402/core": "^2.14.0",
-    "@x402/evm": "^2.14.0",
-    "@x402r/evm": ">=0.2.0-alpha.1 <0.3.0",
-    "viem": "^2.48.11"
+    "@x402r/evm": ">=0.2.0-alpha.1 <0.3.0"
   },
   "devDependencies": {
     "@x402/core": "2.14.0",
-    "@x402/evm": "2.14.0",
-    "@x402r/evm": "0.2.0-alpha.1",
-    "viem": "^2.48.11"
+    "@x402r/evm": "0.2.0-alpha.1"
   },
   "size-limit": [
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,15 +140,9 @@ importers:
       '@x402/core':
         specifier: 2.14.0
         version: 2.14.0
-      '@x402/evm':
-        specifier: 2.14.0
-        version: 2.14.0(typescript@6.0.3)
       '@x402r/evm':
         specifier: 0.2.0-alpha.1
         version: 0.2.0-alpha.1(@x402/core@2.14.0)(@x402/evm@2.14.0(typescript@6.0.3))(viem@2.52.0(typescript@6.0.3)(zod@4.4.3))
-      viem:
-        specifier: ^2.48.11
-        version: 2.52.0(typescript@6.0.3)(zod@4.4.3)
 
   packages/sdk:
     dependencies:


### PR DESCRIPTION
## What

`@x402r/helpers` declared `@x402/evm` and `viem` as `peerDependencies`, but its source imports only `@x402r/evm` (the `r` one) and `@x402/core/server` — `viem`/`@x402/evm` were redundant. This drops them from both `peerDependencies` and `devDependencies`.

Consumers' required-peer surface is **unchanged**: `@x402r/helpers` takes `@x402r/evm` as a peer, and `@x402r/evm@0.2.0-alpha.1` already declares `@x402/evm` + `viem` as *its* peers — so a consumer still surfaces them, just via `@x402r/evm` rather than a redundant re-declaration here. No internal workspace package depends on `@x402r/helpers`.

Follow-up to the peer-hygiene note on #185.

## Validation (Node 22 / engine-strict)

- `pnpm --filter @x402r/helpers test` → 30/30 pass
- `typecheck` + `build` (publint + attw) clean — generated `dist/index.d.ts` carries no `viem` import, so nothing leaks into the published types
- `pnpm knip` → exit 0 (no unused/unlisted-dependency error)
- `pnpm install --frozen-lockfile` settled; lockfile diff is surgical (only the helpers importer's `@x402/evm` + `viem` entries removed)

`patch` changeset for `@x402r/helpers`.
