### PR TITLE
ci: bump codecov-action to v7.0.0 for codecovsecops gpg key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - run: pnpm build
       - run: pnpm --filter=@x402r/core test:cov
       - name: Upload core coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           files: packages/core/coverage/lcov.info
@@ -87,7 +87,7 @@ jobs:
           fail_ci_if_error: true
       - run: pnpm --filter=@x402r/helpers test:cov
       - name: Upload helpers coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           files: packages/helpers/coverage/lcov.info
@@ -95,7 +95,7 @@ jobs:
           fail_ci_if_error: true
       - run: pnpm --filter=@x402r/sdk test:cov
       - name: Upload SDK coverage
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           use_oidc: ${{ !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
           files: packages/sdk/coverage/lcov.info


### PR DESCRIPTION
## Problem

Every PR's `Test` job has been failing on the Codecov upload step (not on any test):

```
gpg: no valid OpenPGP data found.
gpg: Total number processed: 0
...
gpg: Can't check signature: No public key
==> Could not verify signature. Please contact Codecov if problem continues
Error: Process completed with exit code 1.
```

CI pins `codecov/codecov-action` to **v6.0.0**. That version's CLI installer verifies the Codecov CLI by importing Codecov's GPG public key from their `codecovsecurity` keybase account. On 2026-06-07 Codecov **deleted that account** and migrated to `codecovsecops` (see the v7.0.0 release notes). So v6.0.0 now fetches the key from a dead endpoint, imports 0 keys, and the signature check fails with `No public key`. Because the upload steps set `fail_ci_if_error: true`, that hard-fails the whole job — deterministically, on every PR. Re-running does not help.

## Fix

Bump all three `codecov/codecov-action` pins from v6.0.0 → **v7.0.0** (`fb8b3582c8e4def4969c97caa2f19720cb33a72f`), which carries the new `codecovsecops` key.

v7.0.0 is a drop-in: its only changes vs v6.0.0 are the GPG key migration and removal of an internal license-compliance workflow. The public `action.yml` inputs are byte-for-byte identical, so the `with:` blocks (`use_oidc`, `files`, `flags`, `fail_ci_if_error`) need no changes. SHA verified to dereference from `refs/tags/v7.0.0`. (v6/v6.0.2/v7 also point to this same commit; `# v7.0.0` is used as the canonical label.)

Once merged, every open PR goes green on the upload step once it picks up the updated workflow.