### PR TITLE
fix(helpers)!: require explicit name/version domain in x402rDefaults

### DIFF
--- a/.changeset/helpers-x402rdefaults-require-token-domain.md
+++ b/.changeset/helpers-x402rdefaults-require-token-domain.md
@@ -1,0 +1,5 @@
+---
+"@x402r/helpers": minor
+---
+
+`x402rDefaults` now requires explicit `name`/`version` (the EIP-712 token domain). The silent `USDC`/`2` default is removed — it caused on-chain settle reverts for non-USDC tokens and for mainnet USDC (`USD Coin`). Pass them explicitly.

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -44,7 +44,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "3 kB"
+      "limit": "3.5 kB"
     }
   ]
 }

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -44,7 +44,7 @@
   "size-limit": [
     {
       "path": "dist/index.js",
-      "limit": "3.5 kB"
+      "limit": "3 kB"
     }
   ]
 }

--- a/packages/helpers/src/x402r-defaults.ts
+++ b/packages/helpers/src/x402r-defaults.ts
@@ -109,22 +109,16 @@ export interface X402rDefaultsInput {
    */
   maxFeeBps?: number
   /**
-   * EIP-712 token-domain name. Required.
-   *
-   * Must match the token contract's EIP-712 domain `name()` exactly — the
-   * helper never sees the token address, so it cannot derive this. A mismatch
-   * makes the client's EIP-712 signature unverifiable, so settle reverts
-   * on-chain. There is no safe default: even USDC differs by deployment —
-   * `'USDC'` on testnets but `'USD Coin'` for canonical USDC on Base mainnet.
-   * Read it from the token contract for any asset (EURC, PYUSD, DAI, etc.).
+   * EIP-712 token-domain name. Required — no safe default, since the helper
+   * never sees the token address. Must match the token's `name()` exactly or
+   * the signature fails verification and settle reverts on-chain. Even USDC
+   * varies: `'USDC'` on testnets, `'USD Coin'` for canonical USDC on Base
+   * mainnet. Read it from the token (EURC, PYUSD, DAI, etc.).
    */
   name: string
   /**
-   * EIP-712 token-domain version. Required.
-   *
-   * Must match the token contract's EIP-712 domain `version()` exactly. See
-   * the `name` field — same domain-mismatch class of bug (silent settle
-   * revert), and no safe default for the same reason.
+   * EIP-712 token-domain version. Required — same as `name`: must match the
+   * token's `version()` exactly, no safe default, mismatch reverts settle.
    */
   version: string
   /** When `true`, facilitator calls `charge()` (atomic, no escrow). Omit for facilitator default (`false`). */
@@ -145,12 +139,10 @@ export interface X402rDefaultsInput {
  * (`@x402r/evm`).
  *
  * **Required:** the facilitator-specific `captureAuthorizer` and the EIP-712
- * token domain (`name` / `version`) — there is no safe default for the domain,
- * since it must match the token contract's `name()` / `version()` exactly and
- * the helper never sees the token address (see those fields). Everything else
- * has a sensible default — `feeRecipient` (defaults to the `captureAuthorizer`,
- * per the x402r deployment convention), deadlines (relative `24h` / `7d`
- * windows, see below), and fee policy (`0`–`100` bps).
+ * token domain (`name` / `version`) — no safe default; see those fields.
+ * Everything else has a sensible default — `feeRecipient` (defaults to the
+ * `captureAuthorizer`, per the x402r deployment convention), deadlines
+ * (relative `24h` / `7d` windows, see below), and fee policy (`0`–`100` bps).
  *
  * **Deadlines are relative by default.** The output carries
  * `captureDeadlineSeconds` / `refundDeadlineSeconds` (`86400` / `604800`),
@@ -167,22 +159,12 @@ export interface X402rDefaultsInput {
  * provides defaults at the SDK layer for quick-start ergonomics. Production
  * callers should override fee bps to match their facilitator's published
  * policy and deadlines to match their settlement cadence. The token domain
- * (`name` / `version`) is required input, not a default — it must match the
- * actual ERC-20's EIP-712 domain.
+ * (`name` / `version`) is required input, not a default.
  *
  * Optional flags (`autoCapture`, `assetTransferMethod`) are omitted from the
  * output when undefined so the facilitator's wire-spec defaults take over.
  */
 export function x402rDefaults(input: X402rDefaultsInput): X402rDefaultsExtra {
-  // The EIP-712 token domain has no safe default (see X402rDefaultsInput.name).
-  // Required at the type level; this guards JS consumers who bypass types — an
-  // empty name/version would silently produce a domain that fails on-chain.
-  if (!input.name || !input.version) {
-    throw new ValidationError(
-      'x402rDefaults requires explicit name and version (the EIP-712 token domain)',
-    )
-  }
-
   // Resolve capture and refund independently. Each field emits its absolute
   // value when the caller passed it, else its relative offset — which the
   // server scheme refreshes per request, avoiding the wall-clock-frozen-at-boot

--- a/packages/helpers/src/x402r-defaults.ts
+++ b/packages/helpers/src/x402r-defaults.ts
@@ -5,8 +5,6 @@ const DEFAULT_CAPTURE_WINDOW_SECONDS = 60 * 60 * 24 // 24 hours
 const DEFAULT_REFUND_WINDOW_SECONDS = 60 * 60 * 24 * 7 // 7 days
 const DEFAULT_MIN_FEE_BPS = 0
 const DEFAULT_MAX_FEE_BPS = 100 // 1%
-const DEFAULT_TOKEN_NAME = 'USDC'
-const DEFAULT_TOKEN_VERSION = '2'
 
 /**
  * The deadline fields `x402rDefaults` may emit. Capture and refund are resolved
@@ -111,20 +109,24 @@ export interface X402rDefaultsInput {
    */
   maxFeeBps?: number
   /**
-   * EIP-712 token-domain name. Defaults to `'USDC'`.
+   * EIP-712 token-domain name. Required.
    *
-   * Must match the token contract's EIP-712 domain `name()` exactly.
-   * Defaults assume USDC; override for any other token (EURC, PYUSD, DAI,
-   * etc.) or signatures will fail verification on-chain.
+   * Must match the token contract's EIP-712 domain `name()` exactly — the
+   * helper never sees the token address, so it cannot derive this. A mismatch
+   * makes the client's EIP-712 signature unverifiable, so settle reverts
+   * on-chain. There is no safe default: even USDC differs by deployment —
+   * `'USDC'` on testnets but `'USD Coin'` for canonical USDC on Base mainnet.
+   * Read it from the token contract for any asset (EURC, PYUSD, DAI, etc.).
    */
-  name?: string
+  name: string
   /**
-   * EIP-712 token-domain version. Defaults to `'2'`.
+   * EIP-712 token-domain version. Required.
    *
    * Must match the token contract's EIP-712 domain `version()` exactly. See
-   * the `name` field warning — same domain-mismatch class of bug.
+   * the `name` field — same domain-mismatch class of bug (silent settle
+   * revert), and no safe default for the same reason.
    */
-  version?: string
+  version: string
   /** When `true`, facilitator calls `charge()` (atomic, no escrow). Omit for facilitator default (`false`). */
   autoCapture?: boolean
   /** Asset transfer method. Omit for facilitator default (`'eip3009'`). */
@@ -142,11 +144,13 @@ export interface X402rDefaultsInput {
  * requirements via `AuthCaptureServerScheme.enhancePaymentRequirements`
  * (`@x402r/evm`).
  *
- * **Required:** only the facilitator-specific `captureAuthorizer`. Everything
- * else has a sensible default — `feeRecipient` (defaults to the
- * `captureAuthorizer`, per the x402r deployment convention), deadlines
- * (relative `24h` / `7d` windows, see below), fee policy (`0`–`100` bps), and
- * EIP-712 token domain (`USDC` / `2`).
+ * **Required:** the facilitator-specific `captureAuthorizer` and the EIP-712
+ * token domain (`name` / `version`) — there is no safe default for the domain,
+ * since it must match the token contract's `name()` / `version()` exactly and
+ * the helper never sees the token address (see those fields). Everything else
+ * has a sensible default — `feeRecipient` (defaults to the `captureAuthorizer`,
+ * per the x402r deployment convention), deadlines (relative `24h` / `7d`
+ * windows, see below), and fee policy (`0`–`100` bps).
  *
  * **Deadlines are relative by default.** The output carries
  * `captureDeadlineSeconds` / `refundDeadlineSeconds` (`86400` / `604800`),
@@ -162,13 +166,28 @@ export interface X402rDefaultsInput {
  * conscious fee policy on every wire payload. This helper deliberately
  * provides defaults at the SDK layer for quick-start ergonomics. Production
  * callers should override fee bps to match their facilitator's published
- * policy, deadlines to match their settlement cadence, and token domain to
- * match their actual ERC-20.
+ * policy and deadlines to match their settlement cadence. The token domain
+ * (`name` / `version`) is required input, not a default — it must match the
+ * actual ERC-20's EIP-712 domain.
  *
  * Optional flags (`autoCapture`, `assetTransferMethod`) are omitted from the
  * output when undefined so the facilitator's wire-spec defaults take over.
  */
 export function x402rDefaults(input: X402rDefaultsInput): X402rDefaultsExtra {
+  // The EIP-712 token domain has no safe default (see X402rDefaultsInput.name).
+  // Required at the type level; this guards JS consumers who bypass types — an
+  // empty name/version would silently produce a domain that fails on-chain.
+  if (!input.name) {
+    throw new ValidationError(
+      'name is required (the token EIP-712 domain name)',
+    )
+  }
+  if (!input.version) {
+    throw new ValidationError(
+      'version is required (the token EIP-712 domain version)',
+    )
+  }
+
   // Resolve capture and refund independently. Each field emits its absolute
   // value when the caller passed it, else its relative offset — which the
   // server scheme refreshes per request, avoiding the wall-clock-frozen-at-boot
@@ -262,8 +281,8 @@ export function x402rDefaults(input: X402rDefaultsInput): X402rDefaultsExtra {
     feeRecipient: input.feeRecipient ?? input.captureAuthorizer,
     minFeeBps: input.minFeeBps ?? DEFAULT_MIN_FEE_BPS,
     maxFeeBps: input.maxFeeBps ?? DEFAULT_MAX_FEE_BPS,
-    name: input.name ?? DEFAULT_TOKEN_NAME,
-    version: input.version ?? DEFAULT_TOKEN_VERSION,
+    name: input.name,
+    version: input.version,
     // Conditional spread preserves the omit-from-wire signal — explicit
     // undefined ≠ field-not-set on the wire, which is what lets the
     // facilitator's documented default win.

--- a/packages/helpers/src/x402r-defaults.ts
+++ b/packages/helpers/src/x402r-defaults.ts
@@ -177,14 +177,9 @@ export function x402rDefaults(input: X402rDefaultsInput): X402rDefaultsExtra {
   // The EIP-712 token domain has no safe default (see X402rDefaultsInput.name).
   // Required at the type level; this guards JS consumers who bypass types — an
   // empty name/version would silently produce a domain that fails on-chain.
-  if (!input.name) {
+  if (!input.name || !input.version) {
     throw new ValidationError(
-      'name is required (the token EIP-712 domain name)',
-    )
-  }
-  if (!input.version) {
-    throw new ValidationError(
-      'version is required (the token EIP-712 domain version)',
+      'x402rDefaults requires explicit name and version (the EIP-712 token domain)',
     )
   }
 

--- a/packages/helpers/tests/x402r-defaults.test.ts
+++ b/packages/helpers/tests/x402r-defaults.test.ts
@@ -64,6 +64,8 @@ describe('x402rDefaults', () => {
 
     const minimalInput = {
       captureAuthorizer: '0x000000000000000000000000000000000000dEaD' as const,
+      name: 'USDC',
+      version: '2',
     }
 
     it('emits relative offsets by default and never reads the wall clock', () => {
@@ -278,6 +280,8 @@ describe('x402rDefaults', () => {
   describe('non-deadline defaults', () => {
     const minimalInput = {
       captureAuthorizer: '0x000000000000000000000000000000000000dEaD' as const,
+      name: 'USDC',
+      version: '2',
     }
 
     it('defaults feeRecipient to captureAuthorizer', () => {
@@ -301,10 +305,28 @@ describe('x402rDefaults', () => {
       expect(extra.maxFeeBps).toBe(100)
     })
 
-    it('defaults token domain to USDC / 2', () => {
-      const extra = x402rDefaults(minimalInput)
-      expect(extra.name).toBe('USDC')
-      expect(extra.version).toBe('2')
+    it('carries the explicit token domain through unchanged', () => {
+      const extra = x402rDefaults({
+        ...minimalInput,
+        name: 'USD Coin',
+        version: '1',
+      })
+      expect(extra.name).toBe('USD Coin')
+      expect(extra.version).toBe('1')
+    })
+
+    it('throws when name is empty (the EIP-712 domain has no safe default)', () => {
+      // Empty string satisfies the `string` type but the runtime guard rejects
+      // it: an empty domain name would silently fail signature verification.
+      expect(() => x402rDefaults({ ...minimalInput, name: '' })).toThrow(
+        ValidationError,
+      )
+    })
+
+    it('throws when version is empty (the EIP-712 domain has no safe default)', () => {
+      expect(() => x402rDefaults({ ...minimalInput, version: '' })).toThrow(
+        ValidationError,
+      )
     })
   })
 })

--- a/packages/helpers/tests/x402r-defaults.test.ts
+++ b/packages/helpers/tests/x402r-defaults.test.ts
@@ -315,18 +315,21 @@ describe('x402rDefaults', () => {
       expect(extra.version).toBe('1')
     })
 
-    it('throws when name is empty (the EIP-712 domain has no safe default)', () => {
-      // Empty string satisfies the `string` type but the runtime guard rejects
-      // it: an empty domain name would silently fail signature verification.
-      expect(() => x402rDefaults({ ...minimalInput, name: '' })).toThrow(
-        ValidationError,
+    it('is a compile error to omit the required name/version token domain', () => {
+      // Type-level enforcement, zero runtime cost: the EIP-712 token domain is
+      // required input (no safe default — it must match the token contract's
+      // name()/version()). Test files are typechecked, so the @ts-expect-error
+      // below fails the build if omitting name/version ever stops being a type
+      // error — locking the enforcement in without any runtime bytes.
+      const noDomain = {
+        captureAuthorizer:
+          '0x000000000000000000000000000000000000dEaD' as const,
+      }
+      const extra = x402rDefaults(
+        // @ts-expect-error name and version are required
+        noDomain,
       )
-    })
-
-    it('throws when version is empty (the EIP-712 domain has no safe default)', () => {
-      expect(() => x402rDefaults({ ...minimalInput, version: '' })).toThrow(
-        ValidationError,
-      )
+      expect(extra.captureAuthorizer).toBe(noDomain.captureAuthorizer)
     })
   })
 })


### PR DESCRIPTION
## What

`x402rDefaults` no longer silently defaults the EIP-712 token domain to `name:'USDC'`/`version:'2'`. Both `name` and `version` are now **required** inputs (enforced at the type level, with a runtime `ValidationError` guard for JS consumers).

## Why

`x402rDefaults` never receives the token address, so it cannot know the correct EIP-712 domain. The silent `USDC`/`2` default was a latent footgun: for any token whose domain differs — including USDC on Base **mainnet**, whose canonical `name()` is `USD Coin` (not `USDC`) — the wrong domain produces a signature the contract rejects, causing a **silent on-chain settle revert** discovered only at settlement time. Making the fields required surfaces the decision at construction, where it's cheap to get right.

This does not change verify-time behavior (payer and facilitator both read the signed `extra.name/version`); it removes the on-chain settle-revert class of bug.

## Changes

- `name`/`version` are required on `X402rDefaultsInput`; `DEFAULT_TOKEN_NAME`/`DEFAULT_TOKEN_VERSION` removed.
- Runtime guard throws `ValidationError` for empty/missing `name` or `version`.
- JSDoc updated (field docs + function-level) to drop the removed defaults.
- Tests: passthrough of an explicit non-USDC domain (`USD Coin`/`1`) + guard coverage for empty `name`/`version`.
- Changeset (`@x402r/helpers`, minor — 0.x breaking).

## Breaking change & migration

Callers must pass the token's EIP-712 domain explicitly. For the testnet USDC used in the SDK examples: `name: 'USDC', version: '2'`. For mainnet USDC: `name: 'USD Coin', version: '2'`.

## Testing

- `pnpm typecheck` (repo-wide): 6/6 clean — confirms no un-updated caller.
- `pnpm --filter @x402r/helpers test`: green.
- `pnpm --filter @x402r/helpers build`: clean (attw + publint).

Part of the authCapture upstream-alignment Phase 3 work.
