### PR TITLE
refactor(examples): build the http-wire-capture extra with x402rDefaults

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@x402r/core": "workspace:*",
+    "@x402r/helpers": "workspace:*",
     "@x402r/sdk": "workspace:*",
     "prool": "^0.2.4",
     "tsx": "^4.22.4",

--- a/examples/scenarios/http-wire-capture.ts
+++ b/examples/scenarios/http-wire-capture.ts
@@ -11,6 +11,7 @@ import { authCaptureEscrowAbi, getChainConfig } from '@x402r/core'
 import { AUTH_CAPTURE_SCHEME } from '@x402r/evm'
 import { AuthCaptureEvmScheme as AuthCaptureFacilitatorScheme } from '@x402r/evm/auth-capture/facilitator'
 import { AuthCaptureEvmScheme as AuthCaptureServerScheme } from '@x402r/evm/auth-capture/server'
+import { x402rDefaults } from '@x402r/helpers'
 import express from 'express'
 import {
   type Address,
@@ -316,7 +317,10 @@ async function startResourceServer(
             // derive preApprovalExpiry). Upstream example omits this because
             // it has a default; we set it explicitly for clarity.
             maxTimeoutSeconds: 600,
-            extra: {
+            // x402rDefaults supplies the fee policy (0-100 bps) and the USDC
+            // EIP-712 domain (name 'USDC', version '2'); only the
+            // scenario-specific values are passed explicitly.
+            extra: x402rDefaults({
               captureAuthorizer,
               // Absolute deadlines instead of *Seconds offsets — easier to
               // reason about in a one-off scenario.
@@ -327,11 +331,7 @@ async function startResourceServer(
               // time). Since the scenario only authorizes (autoCapture left
               // unset), no fee is actually paid out in this run.
               feeRecipient: zeroAddress,
-              minFeeBps: 0,
-              maxFeeBps: 100,
-              name: 'USDC',
-              version: '2',
-            },
+            }),
           },
           description: 'A widget',
           mimeType: 'application/json',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,6 +67,9 @@ importers:
       '@x402r/core':
         specifier: workspace:*
         version: link:../packages/core
+      '@x402r/helpers':
+        specifier: workspace:*
+        version: link:../packages/helpers
       '@x402r/sdk':
         specifier: workspace:*
         version: link:../packages/sdk


### PR DESCRIPTION
## Summary

The http-wire-capture scenario was the only place in the repo that builds an auth-capture `extra` by hand, and four of its eight literals (`minFeeBps: 0`, `maxFeeBps: 100`, `name: 'USDC'`, `version: '2'`) are exactly the defaults `x402rDefaults` ships. The SDK was not dogfooding its own helper.

This routes the scenario through `x402rDefaults`, keeping the scenario-specific values explicit:

- `captureAuthorizer` (required input)
- absolute `captureDeadline` / `refundDeadline` derived from the Anvil block timestamp (the helper's opt-in absolute escape hatch)
- `feeRecipient: zeroAddress` (deferred fee-recipient selection; the helper would otherwise default it to the captureAuthorizer)

Also adds `@x402r/helpers` as a workspace dep of `examples`.

No changeset: only the private `examples` package changes.

## Test plan

- [x] `pnpm typecheck` clean (7/7 tasks)
- [x] `pnpm check` (biome) clean
- [x] `pnpm --filter examples run scenario:http-wire-capture` passes end-to-end against an Anvil fork of Base Sepolia (6 steps, all post-conditions green, including the PaymentAuthorized event and escrow-state assertions that would catch any drift in the produced `extra`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)